### PR TITLE
Improve data allocation

### DIFF
--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -56,12 +56,12 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
         # Assuming LoadSpecificCSV is already defined and works with these arguments
         points, density, types, group_marker, idp = LoadSpecificCSV(Val(Dimensions), FloatType, particle_type, particle_group_marker, specific_csv)
     
-        # Concatenate the results to the respective arrays
-        Position    = vcat(Position    , points)
-        Density     = vcat(Density     , density)
-        Types       = vcat(Types       , types)
-        GroupMarker = vcat(GroupMarker , group_marker)
-        Idp         = vcat(Idp         , idp)
+        # Append the results to the respective arrays without reallocating on every iteration
+        append!(Position,    points)
+        append!(Density,     density)
+        append!(Types,       types)
+        append!(GroupMarker, group_marker)
+        append!(Idp,         idp)
     end
 
     NumberOfPoints           = length(Position)


### PR DESCRIPTION
## Summary
- speed up particle allocation by avoiding repeated `vcat` reallocation

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: Package SPHExample did not provide a `test/runtests.jl` file)*

------
https://chatgpt.com/codex/tasks/task_e_685465c838888323a7fd41229d410705