### PR TITLE
Improve external program helpers

### DIFF
--- a/src/OpenExternalPrograms.jl
+++ b/src/OpenExternalPrograms.jl
@@ -57,7 +57,7 @@ end
                      representation="Point Gaussian",
                      color_variable="Density")
 
-Create a temporary ParaView state file for the given simulation and optionally
+Write a ParaView state file for the given simulation and optionally
 launch ParaView to visualise the results. `variable_names` should contain the
 point arrays stored in the output files. Pass `paraview_cmd = nothing` to skip
 launching ParaView automatically.

--- a/src/OpenExternalPrograms.jl
+++ b/src/OpenExternalPrograms.jl
@@ -1,3 +1,8 @@
+"""
+Utility wrappers for launching external programs such as a text editor or
+ParaView. These helpers are optional conveniences used at the end of a
+simulation run to quickly inspect the produced output.
+"""
 module OpenExternalPrograms
 
 export AutoOpenLogFile, AutoOpenParaview
@@ -5,22 +10,62 @@ export AutoOpenLogFile, AutoOpenParaview
 using ..SimulationLoggerConfiguration
 using ..SimulationMetaDataConfiguration
 
+"""
+    _default_open_command(path)
 
-function AutoOpenLogFile(SimLogger::SimulationLogger, SimMetaData::SimulationMetaData)
-    LogFileName = replace(strip(SimLogger.LoggerIo.name,['<', '>']), "file " => "")
-    if SimMetaData.OpenLogFile
+Return a platform specific [`Cmd`] used to open `path` with the default
+application.
+"""
+function _default_open_command(path::AbstractString)
+    if Sys.iswindows()
+        return `notepad $(path)`
+    elseif Sys.isapple()
+        return `open $(path)`
+    else
+        return `xdg-open $(path)`
+    end
+end
+
+
+"""
+    AutoOpenLogFile(logger, metadata; editor_cmd=nothing)
+
+Open the simulation log file using an external editor. If `editor_cmd` is not
+provided, a platform specific default is used. Setting `editor_cmd = nothing`
+disables the automatic opening entirely.
+"""
+function AutoOpenLogFile(SimLogger::SimulationLogger,
+                         SimMetaData::SimulationMetaData;
+                         editor_cmd::Union{String,Nothing}=nothing)
+    log_file = replace(strip(SimLogger.LoggerIo.name, ['<', '>']), "file " => "")
+    if SimMetaData.OpenLogFile && !isempty(log_file)
+        cmd = editor_cmd === nothing ? _default_open_command(log_file) :
+              `$(editor_cmd) $(log_file)`
         try
-            OpenLogFileCommand = `notepad "$(LogFileName)"`
-            run(OpenLogFileCommand; wait = false)
+            run(cmd; wait=false)
         catch e
-            @warn("Unable to open log file automatically. It uses notepad for Windows by default.", e)
+            @warn("Unable to open log file automatically", e)
         end
     end
 
     return nothing
 end
 
-function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames)
+"""
+    AutoOpenParaview(metadata, variable_names;
+                     paraview_cmd="paraview",
+                     representation="Point Gaussian",
+                     color_variable="Density")
+
+Create a temporary ParaView state file for the given simulation and optionally
+launch ParaView to visualise the results. `variable_names` should contain the
+point arrays stored in the output files. Pass `paraview_cmd = nothing` to skip
+launching ParaView automatically.
+"""
+function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames;
+                          paraview_cmd::Union{String,Nothing}="paraview",
+                          representation::String="Point Gaussian",
+                          color_variable::String="Density")
     ## Generate auto paraview py
 
     if SimMetaData.ExportSingleVTKHDF
@@ -104,13 +149,13 @@ function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames)
                             # show data from Simulation_vtkhdf
                             Simulation_vtkhdfDisplay = Show(Simulation_vtkhdf, renderView1, 'GeometryRepresentation')
 
-                            Simulation_vtkhdfDisplay.SetRepresentationType('Point Gaussian')
+                            Simulation_vtkhdfDisplay.SetRepresentationType('$(representation)')
 
                             # To always load in at correct position
                             Simulation_vtkhdfDisplay.Position = [0.0, 0.0, 0.0]
 
                             # set scalar coloring
-                            ColorBy(Simulation_vtkhdfDisplay, ('POINTS', 'Density'))
+                            ColorBy(Simulation_vtkhdfDisplay, ('POINTS', '$(color_variable)'))
 
                             # rescale color and/or opacity maps used to include current data range
                             Simulation_vtkhdfDisplay.RescaleTransferFunctionToDataRange(True, False)
@@ -128,12 +173,12 @@ function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames)
 
     close(ParaViewStateFile)
 
-    if SimMetaData.VisualizeInParaview
+    if SimMetaData.VisualizeInParaview && paraview_cmd !== nothing
         try
-            OpenInParaview = `paraview --state="$(ParaViewStateFileName)"`
-            run(OpenInParaview; wait = false)
-        catch
-            @error("You must add Paraview to path as `paraview` and use at minimum version 5.12")
+            OpenInParaview = `$(paraview_cmd) --state="$(ParaViewStateFileName)"`
+            run(OpenInParaview; wait=false)
+        catch e
+            @error("You must add Paraview to path as $(paraview_cmd) and use at minimum version 5.12", e)
         end
     end
 


### PR DESCRIPTION
## Summary
- document `OpenExternalPrograms` module and provide OS specific helper
- allow custom commands for log files and ParaView
- include options for representation and color variable

## Testing
- `julia --project -e 'using SPHExample; println("Loaded")'`

------
https://chatgpt.com/codex/tasks/task_e_68547c6ad138832389fddc444b037ef8