### PR TITLE
Optimize neighbor chunk computation

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -517,6 +517,8 @@ using Bumper
         ###
         DimensionsPlus = Dimensions + 1
         Δx = one(eltype(Density)) + SimKernel.h
+        UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
+        EnumeratedIndices = enumerate(index_chunks(UniqueCellsView; n=nthreads()))
         @no_escape begin
             while SimMetaData.TotalTime <= SimMetaData.OutputEach * SimMetaData.OutputIterationCounter
 
@@ -537,10 +539,9 @@ using Bumper
                     # if 1.25 * Δx >= SimKernel.h
                         @timeit SimMetaData.HourGlass "02a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells)
                         Δx = zero(eltype(Density))
+                        UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
+                        EnumeratedIndices = enumerate(index_chunks(UniqueCellsView; n=nthreads()))
                     end
-
-                    UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
-                    EnumeratedIndices = enumerate(index_chunks(UniqueCellsView; n=nthreads()))
                 end
 
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(Position, Velocity, ParticleType, ParticleMarker, dt₂, MotionDefinition, SimMetaData)


### PR DESCRIPTION
## Summary
- update neighbor chunk creation only when the neighbor list is refreshed

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: `Package SPHExample did not provide a test/runtests.jl file`)*

------
https://chatgpt.com/codex/tasks/task_e_6855cd1102108323a93077a973d296ac