### PR TITLE
Add pairwise neighbor conversion utility

### DIFF
--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -17,7 +17,7 @@ module SPHExample
 
     # Re-export desired functions from each submodule
     using .AuxiliaryFunctions
-    export ResetArrays!, to_3d, CloseHDFVTKManually, CleanUpSimulationFolder
+    export ResetArrays!, to_3d, CloseHDFVTKManually, CleanUpSimulationFolder, pairs_to_per_particle
 
     using .SPHKernels
     export SPHKernel, SPHKernelInstance, WendlandC2, CubicSpline, Wᵢⱼ, ∇Wᵢⱼ, tensile_correction


### PR DESCRIPTION
## Summary
- expose new `pairs_to_per_particle` helper
- re-export from `SPHExample` for user access

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: Package SPHExample did not provide a `test/runtests.jl` file)*

------
https://chatgpt.com/codex/tasks/task_e_685b0484b5e883238932c4ef121bcee9