### PR TITLE
Switch dρdt rate array to Atomic

### DIFF
--- a/src/AuxiliaryFunctions.jl
+++ b/src/AuxiliaryFunctions.jl
@@ -10,7 +10,18 @@ export ResetArrays!, to_3d, CloseHDFVTKManually, CleanUpSimulationFolder
 
 Fill each array in `arrays` with zeros in place.
 """
-@inline ResetArrays!(arrays...) = foreach(a -> fill!(a, zero(eltype(a))), arrays)
+function _reset_array!(a)
+    if eltype(a) <: Atomic
+        T = eltype(a).parameters[1]
+        for x in a
+            atomic_xchg!(x, zero(T))
+        end
+    else
+        fill!(a, zero(eltype(a)))
+    end
+end
+
+@inline ResetArrays!(arrays...) = foreach(_reset_array!, arrays)
 
 """
     to_3d(vec_2d)

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -141,11 +141,11 @@ end
 function AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ   ; n_copy = Base.Threads.nthreads())
     
         
-    dρdtIThreaded        = [dρdtI for _ in 1:n_copy]
+    # dρdtIThreaded        = [dρdtI for _ in 1:n_copy]
     AccelerationThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
 
     nt = (
-        dρdtIThreaded = dρdtIThreaded,
+        # dρdtIThreaded = dρdtIThreaded,
         AccelerationThreaded = AccelerationThreaded,
     )
 

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -6,6 +6,7 @@ using CSV
 using DataFrames
 using StaticArrays
 using StructArrays
+using Base.Threads
 
 using ..SimulationGeometry
 
@@ -126,7 +127,7 @@ function AllocateSupportDataStructures(Position)
     PositionType             = eltype(Position)
     PositionUnderlyingType   = eltype(PositionType)
 
-    dρdtI           = zeros(PositionUnderlyingType, NumberOfPoints)
+    dρdtI           = [Atomic{PositionUnderlyingType}(zero(PositionUnderlyingType)) for _ in 1:NumberOfPoints]
     Velocityₙ⁺      = zeros(PositionType, NumberOfPoints)
     Positionₙ⁺      = zeros(PositionType, NumberOfPoints)
     ρₙ⁺             = zeros(PositionUnderlyingType, NumberOfPoints)
@@ -140,7 +141,7 @@ end
 function AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ   ; n_copy = Base.Threads.nthreads())
     
         
-    dρdtIThreaded        = [copy(dρdtI) for _ in 1:n_copy]
+    dρdtIThreaded        = [dρdtI for _ in 1:n_copy]
     AccelerationThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
 
     nt = (

--- a/src/SimulationEquations.jl
+++ b/src/SimulationEquations.jl
@@ -27,7 +27,7 @@ end
 # using symplectic time stepping
 @inline function DensityEpsi!(Density, dρdtIₙ⁺,ρₙ⁺,Δt)
     @inbounds for i in eachindex(Density)
-        epsi = - (dρdtIₙ⁺[i] / ρₙ⁺[i]) * Δt
+        epsi = - (dρdtIₙ⁺[i][] / ρₙ⁺[i]) * Δt
         Density[i] *= (2 - epsi) / (2 + epsi)
     end
 end


### PR DESCRIPTION
## Summary
- store `dρdtI` as atomic values
- share the atomic array across thread workers
- adjust reset logic for atomic arrays
- update density-related routines to read atomic values
- use `atomic_add!` when accumulating `dρdtI`

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: Package SPHExample did not provide a `test/runtests.jl` file)*

------
https://chatgpt.com/codex/tasks/task_e_685c6f67451c8323b91bcd8e9bc3d280