### PR TITLE
Add configurable output times

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SPHExample"
 uuid = "49649ea8-6f54-4931-9342-0ba915f114f7"
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Written by Ahmed Salih ([AhmedSalih3d](https://github.com/AhmedSalih3d)).
 
 | Version | Description |
 |---------|-------------|
+| 0.6.9 | Specify output times via `OutputTimes` (float or vector). |
 | 0.6.8 | Select which variables are written to `vtkhdf` files. |
 | 0.6.7 | Introduced mDBC boundary conditions and other improvements allowing particles to interact with boundaries. |
 | 0.6.6 | Added neighbour grid visualisation in ParaView for debugging. |

--- a/example/Dambreak2dMDBC.jl
+++ b/example/Dambreak2dMDBC.jl
@@ -31,7 +31,7 @@ let
         SimulationName="DamBreak2D", 
         SaveLocation="E:/SecondApproach/DamBreak2D_MDBC/",
         SimulationTime=2,
-        OutputEach=0.01,
+        OutputTimes=collect(0.01:0.01:2),
         VisualizeInParaview=true,
         ExportSingleVTKHDF=true,
         ExportGridCells=true,

--- a/example/Dambreak3d.jl
+++ b/example/Dambreak3d.jl
@@ -37,7 +37,7 @@ let
         SimulationName         = "DamBreak3D_Test",
         SaveLocation           = "E:/SecondApproach/TESTING_CPU_3DDambreak",
         SimulationTime         = 1.6,
-        OutputEach             = 0.01,
+        OutputTimes            = 0.01,
         VisualizeInParaview    = true,
         ExportSingleVTKHDF     = true,
         ExportGridCells        = true,

--- a/example/DucklingMDBC.jl
+++ b/example/DucklingMDBC.jl
@@ -30,7 +30,7 @@ let
         SimulationName="CaseDuckling", 
         SaveLocation="E:/SecondApproach/TESTING_CPU_Duckling",
         SimulationTime=1,
-        OutputEach=0.02,
+        OutputTimes=0.02,
         VisualizeInParaview=true,
         ExportSingleVTKHDF=true,
         ExportGridCells= true,

--- a/example/MovingSquare2d.jl
+++ b/example/MovingSquare2d.jl
@@ -19,7 +19,7 @@ let
         SimulationName="MovingSquare2D", 
         SaveLocation="E:/SecondApproach/MovingSquare2D",
         SimulationTime=2.5,
-        OutputEach=0.01,
+        OutputTimes=[0.035, 0.07, 0.105, 0.14, 0.175, 0.21, 0.245, 0.28, 0.315, 0.35, 0.385, 0.42, 0.455, 0.49, 0.525, 0.56, 0.595, 0.63, 0.665, 0.7, 1.0, 1.5, 2.0, 2.5],
         VisualizeInParaview=true,
         ExportSingleVTKHDF=true,
         OpenLogFile=true,

--- a/example/StillWedgeMDBC.jl
+++ b/example/StillWedgeMDBC.jl
@@ -31,7 +31,7 @@ let
         SimulationName="StillWedge", 
         SaveLocation="E:/SecondApproach/StillWedge2D_MDBC",
         SimulationTime=4,
-        OutputEach=0.01,
+        OutputTimes=0.01,
         VisualizeInParaview=true,
         ExportSingleVTKHDF=true,
         ExportGridCells=true,

--- a/example/StillWedgeMDBC.jl
+++ b/example/StillWedgeMDBC.jl
@@ -30,7 +30,7 @@ let
     SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType}(
         SimulationName="StillWedge", 
         SaveLocation="E:/SecondApproach/StillWedge2D_MDBC",
-        SimulationTime=4,
+        SimulationTime=4.0,
         OutputTimes=0.01,
         VisualizeInParaview=true,
         ExportSingleVTKHDF=true,

--- a/example/StillWedgeMiddleSquareMDBC.jl
+++ b/example/StillWedgeMiddleSquareMDBC.jl
@@ -31,7 +31,7 @@ let
         SimulationName="StillWedge", 
         SaveLocation="E:/SecondApproach/StillWedgeMiddleSquare2D_MDBC",
         SimulationTime=4,
-        OutputEach=0.01,
+        OutputTimes=0.01,
         VisualizeInParaview=true,
         ExportSingleVTKHDF=true,
         ExportGridCells=true,

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -472,8 +472,13 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         # Initialize storage for file handles
         file_handles = if !SimMetaData.ExportSingleVTKHDF
             # Multi-file mode: vector for particle files
+            n_outputs = if SimMetaData.OutputTimes isa AbstractVector
+                length(SimMetaData.OutputTimes) + 1
+            else
+                Int(SimMetaData.SimulationTime/SimMetaData.OutputTimes + 1)
+            end
             (
-                particle_files = Vector{HDF5.File}(undef, Int(SimMetaData.SimulationTime/SimMetaData.OutputEach + 1)),
+                particle_files = Vector{HDF5.File}(undef, n_outputs),
                 grid_files = nothing,
             )
         else

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -486,6 +486,21 @@ using Bumper
         return nothing
     end
 
+    @inline next_output_time(SimMetaData) =
+        next_output_time(SimMetaData.OutputTimes, SimMetaData)
+
+    @inline next_output_time(interval::Real, SimMetaData) =
+        interval * SimMetaData.OutputIterationCounter
+
+    @inline function next_output_time(times::AbstractVector, SimMetaData)
+        idx = SimMetaData.OutputIterationCounter
+        if idx <= length(times)
+            return times[idx]
+        else
+            return SimMetaData.SimulationTime
+        end
+    end
+
     """
         update_delta_x!(Δx, posₙ⁺, pos)
 
@@ -539,7 +554,7 @@ using Bumper
         UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
         EnumeratedIndices = enumerate(index_chunks(UniqueCellsView; n=nthreads()))
         @no_escape begin
-            while SimMetaData.TotalTime <= SimMetaData.OutputEach * SimMetaData.OutputIterationCounter
+            while SimMetaData.TotalTime <= next_output_time(SimMetaData)
 
                 Δx = update_delta_x!(Δx, Positionₙ⁺, SimParticles.Position)
 

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -494,7 +494,7 @@ using Bumper
 
     @inline function next_output_time(times::AbstractVector, SimMetaData)
         idx = SimMetaData.OutputIterationCounter
-        if idx <= length(times)
+        if idx < length(times)
             return times[idx]
         else
             return SimMetaData.SimulationTime

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -13,6 +13,7 @@ export SimulationMetaData
     HourGlass::TimerOutput                  = TimerOutput()
     Iteration::Int                          = 0
     OutputEach::FloatType                   = 0.02 #seconds
+    OutputTimes::Union{FloatType,Vector{FloatType}} = OutputEach
     OutputIterationCounter::Int             = 0
     StepsTakenForLastOutput::Int            = 0
     CurrentTimeStep::FloatType              = 0


### PR DESCRIPTION
## Summary
- allow specifying exact output times via `OutputTimes` with dispatch on `Float` or `Vector`
- allocate VTK output files based on `OutputTimes`
- use dispatched `next_output_time` helper in simulation loop
- demonstrate feature in 2D dambreak example (already updated)
- bump version to 0.6.9 in docs

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: Package did not provide a `test/runtests.jl` file)*

------
https://chatgpt.com/codex/tasks/task_e_685f0a2875c08323bf1d94ef8cd62bb3