### PR TITLE
Introduce kernel and MDBC mode types for SimulationMetaData

### DIFF
--- a/example/Dambreak2dMDBC.jl
+++ b/example/Dambreak2dMDBC.jl
@@ -27,8 +27,8 @@ let
     # Load in particles
     SimParticles = AllocateDataStructures(SimulationGeometry)
 
-    SimMetaDataDambreak  = SimulationMetaData{Dimensions,FloatType}(
-        SimulationName="DamBreak2D", 
+    SimMetaDataDambreak  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC}(
+        SimulationName="DamBreak2D",
         SaveLocation="E:/SecondApproach/DamBreak2D_MDBC/",
         SimulationTime=2,
         OutputTimes=collect(0.01:0.01:2),
@@ -36,8 +36,6 @@ let
         ExportSingleVTKHDF=true,
         ExportGridCells=true,
         OpenLogFile=true,
-        FlagOutputKernelValues=false,
-        FlagMDBCSimple=true,
         FlagLog=true
     )
 

--- a/example/Dambreak3d.jl
+++ b/example/Dambreak3d.jl
@@ -42,7 +42,6 @@ let
         ExportSingleVTKHDF     = true,
         ExportGridCells        = true,
         OpenLogFile            = true,
-        FlagOutputKernelValues = false,
         FlagLog                = true
     )
 

--- a/example/DucklingMDBC.jl
+++ b/example/DucklingMDBC.jl
@@ -26,8 +26,8 @@ let
     # Load in particles
     SimParticles = AllocateDataStructures(SimulationGeometry)
 
-    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType}(
-        SimulationName="CaseDuckling", 
+    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC}(
+        SimulationName="CaseDuckling",
         SaveLocation="E:/SecondApproach/TESTING_CPU_Duckling",
         SimulationTime=1,
         OutputTimes=0.02,
@@ -35,10 +35,7 @@ let
         ExportSingleVTKHDF=true,
         ExportGridCells= true,
         OpenLogFile=true,
-        FlagOutputKernelValues=false,
-        FlagLog=true,
-        FlagShifting=false,
-        FlagMDBCSimple=true,
+        FlagLog=true
     )
 
     SimKernel           = SPHKernelInstance{Dimensions, FloatType}(WendlandC2(); dx = SimConstantsWedge.dx, k = 1.5)

--- a/example/MovingSquare2d.jl
+++ b/example/MovingSquare2d.jl
@@ -15,17 +15,15 @@ let
         CFL=0.2
     )
 
-    SimMetaDataMovingSquare  = SimulationMetaData{Dimensions,FloatType}(
-        SimulationName="MovingSquare2D", 
+    SimMetaDataMovingSquare  = SimulationMetaData{Dimensions,FloatType,PlanarShifting}(
+        SimulationName="MovingSquare2D",
         SaveLocation="E:/SecondApproach/MovingSquare2D",
         SimulationTime=2.5,
         OutputTimes=0.01,
         VisualizeInParaview=true,
         ExportSingleVTKHDF=true,
         OpenLogFile=true,
-        FlagOutputKernelValues=false,
-        FlagLog=true,
-        FlagShifting=true
+        FlagLog=true
     )
     FixedBoundary = Geometry{Dimensions, FloatType}(
         CSVFile     = "./input/moving_square_2d/MovingSquare_Dp$(SimConstantsMovingSquare.dx)_Fixed.csv",

--- a/example/StillWedgeMDBC.jl
+++ b/example/StillWedgeMDBC.jl
@@ -27,7 +27,7 @@ let
     # Load in particles
     SimParticles = AllocateDataStructures(SimulationGeometry)
 
-    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType}(
+    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC}(
         SimulationName="StillWedge", 
         SaveLocation="E:/SecondApproach/StillWedge2D_MDBC",
         SimulationTime=4.0,
@@ -36,9 +36,7 @@ let
         ExportSingleVTKHDF=true,
         ExportGridCells=true,
         OpenLogFile=true,
-        FlagOutputKernelValues=false,
         FlagLog=true,
-        FlagMDBCSimple=true,
         # OutputVariables = [
         #     # "ChunkID",
         #     # "Kernel",

--- a/example/StillWedgeMiddleSquareMDBC.jl
+++ b/example/StillWedgeMiddleSquareMDBC.jl
@@ -27,7 +27,7 @@ let
     # Load in particles
     SimParticles = AllocateDataStructures(SimulationGeometry)
 
-    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType}(
+    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC}(
         SimulationName="StillWedge", 
         SaveLocation="E:/SecondApproach/StillWedgeMiddleSquare2D_MDBC",
         SimulationTime=4,
@@ -36,9 +36,7 @@ let
         ExportSingleVTKHDF=true,
         ExportGridCells=true,
         OpenLogFile=true,
-        FlagOutputKernelValues=false,
-        FlagLog=true,
-        FlagMDBCSimple=true
+        FlagLog=true
     )
 
     # If save directory is not already made, make it

--- a/src/OpenExternalPrograms.jl
+++ b/src/OpenExternalPrograms.jl
@@ -76,7 +76,7 @@ function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames;
         py_regex = "^$(SimMetaData.SimulationName)_(\\d+).vtk" #^ means to anchor the regex to the start of the string
     end
 
-    ExtractDimensionalityMetaData(::SimulationMetaData{N, FloatType}) where {N, FloatType} = N
+    ExtractDimensionalityMetaData(::SimulationMetaData{N, FloatType, SMode, KMode, BMode}) where {N, FloatType, SMode, KMode, BMode} = N
     ViewDimension = ExtractDimensionalityMetaData(SimMetaData) == 2 ? "2D" : "3D"
 
     ParaViewStateFile     = open(ParaViewStateFileName, "w")

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -32,7 +32,7 @@ using HDF5
 using Base.Threads
 using UnicodePlots
 using LinearAlgebra
-using Bumper
+    using Bumper
 
     function ConstructStencil(v::Val{d}) where d
         n_ = CartesianIndices(ntuple(_->-1:1,v))
@@ -58,6 +58,50 @@ using Bumper
         # Consider -1.7 + 0.5, this would give -1.2 and then trunced 1, but we want -2, therefore absolute addition before hand
         # We add 0.5 instead of 1, to ensure proper rounding behavior when restoring the sign for negative numbers.
         Int(sign(x)) * unsafe_trunc(Int, muladd(abs(x),InverseCutOff,0.5))
+    end
+
+    # Add contributions related to particle shifting. Dispatch on `SimulationMetaData`
+    # so that no runtime checks are required.
+    function add_shifting_terms!(::SimulationMetaData{D,T,NoShifting,K,B}, SimThreadedArrays,
+                                MotionLimiter, xᵢⱼ, ∇ᵢWᵢⱼ, m₀, ρᵢ, ρⱼ, i, j, ichunk) where {D,T,
+                                                                                                K<:KernelOutputMode,
+                                                                                                B<:MDBCMode}
+        return nothing
+    end
+
+    function add_shifting_terms!(::SimulationMetaData{D,T,S,K,B}, SimThreadedArrays,
+                                MotionLimiter, xᵢⱼ, ∇ᵢWᵢⱼ, m₀, ρᵢ, ρⱼ, i, j, ichunk) where {D,T,S<:ShiftingMode,
+                                                                                                   K<:KernelOutputMode,
+                                                                                                   B<:MDBCMode}
+        MLcond = MotionLimiter[i] * MotionLimiter[j]
+
+        SimThreadedArrays.∇CᵢThreaded[ichunk][i]   += (m₀/ρᵢ) *  ∇ᵢWᵢⱼ
+        SimThreadedArrays.∇CᵢThreaded[ichunk][j]   += (m₀/ρⱼ) * -∇ᵢWᵢⱼ
+
+        # Switch signs compared to DSPH, else free surface detection does not make sense
+        # Agrees, https://arxiv.org/abs/2110.10076, it should have been r_ji
+        SimThreadedArrays.∇◌rᵢThreaded[ichunk][i]  += (m₀/ρⱼ) * dot(-xᵢⱼ , ∇ᵢWᵢⱼ) * MLcond
+        SimThreadedArrays.∇◌rᵢThreaded[ichunk][j]  += (m₀/ρᵢ) * dot( xᵢⱼ ,-∇ᵢWᵢⱼ) * MLcond
+        return nothing
+    end
+
+    # Optionally record kernel values and gradients based on `SimulationMetaData`
+    function kernel_output!(::SimulationMetaData{D,T,S,NoKernelOutput,B}, SimKernel,
+                            SimThreadedArrays, q, ∇ᵢWᵢⱼ, i, j, ichunk) where {D,T,S<:ShiftingMode,
+                                                                               B<:MDBCMode}
+        return nothing
+    end
+
+    function kernel_output!(::SimulationMetaData{D,T,S,K,B}, SimKernel,
+                            SimThreadedArrays, q, ∇ᵢWᵢⱼ, i, j, ichunk) where {D,T,S<:ShiftingMode,
+                                                                            K<:KernelOutputMode,
+                                                                            B<:MDBCMode}
+        Wᵢⱼ  = @fastpow SPHKernels.Wᵢⱼ(SimKernel, q)
+        SimThreadedArrays.KernelThreaded[ichunk][i]         += Wᵢⱼ
+        SimThreadedArrays.KernelThreaded[ichunk][j]         += Wᵢⱼ
+        SimThreadedArrays.KernelGradientThreaded[ichunk][i] +=  ∇ᵢWᵢⱼ
+        SimThreadedArrays.KernelGradientThreaded[ichunk][j] += -∇ᵢWᵢⱼ
+        return nothing
     end
    
     @inline function ExtractCells!(Particles, InverseCutOff)
@@ -163,10 +207,10 @@ using Bumper
 
     f(SimKernel, GhostPoint) = CartesianIndex(map(x->map_floor(x,SimKernel.H⁻¹), Tuple(GhostPoint)))
     function NeighborLoopMDBC!(SimKernel,
-                               SimMetaData::SimulationMetaData{Dimensions, _},
+                               SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode},
                                SimConstants, ParticleRanges, CellDict, Position,
                                Density, GhostPoints, GhostNormals, ParticleType,
-                               bᵧ, Aᵧ) where {Dimensions, _}
+                               bᵧ, Aᵧ) where {Dimensions, FloatType, SMode, KMode, BMode}
         
         FullStencil = CartesianIndices(ntuple(_->-1:1, Dimensions))
 
@@ -211,7 +255,6 @@ using Bumper
     end
 
     Base.@propagate_inbounds function ComputeInteractions!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, Position, Density, Pressure, Velocity, i, j, MotionLimiter, ichunk) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
-        @unpack FlagOutputKernelValues = SimMetaData
         @unpack ρ₀, m₀, α, γ, g, c₀, δᵩ, Cb, Cb⁻¹, ν₀, dx, SmagorinskyConstant, BlinConstant = SimConstants
 
         @unpack h⁻¹, h, η², H², αD = SimKernel 
@@ -255,32 +298,16 @@ using Bumper
             SimThreadedArrays.AccelerationThreaded[ichunk][j] -= uₘ 
 
             
-            if FlagOutputKernelValues
-                Wᵢⱼ  = @fastpow SPHKernels.Wᵢⱼ(SimKernel, q)
-                SimThreadedArrays.KernelThreaded[ichunk][i]         += Wᵢⱼ
-                SimThreadedArrays.KernelThreaded[ichunk][j]         += Wᵢⱼ
-                SimThreadedArrays.KernelGradientThreaded[ichunk][i] +=  ∇ᵢWᵢⱼ
-                SimThreadedArrays.KernelGradientThreaded[ichunk][j] += -∇ᵢWᵢⱼ
-            end
+            kernel_output!(SimMetaData, SimKernel, SimThreadedArrays, q, ∇ᵢWᵢⱼ, i, j, ichunk)
 
-            if SimMetaData.FlagShifting
-                
-                MLcond = MotionLimiter[i] * MotionLimiter[j]
-
-                SimThreadedArrays.∇CᵢThreaded[ichunk][i]   += (m₀/ρᵢ) *  ∇ᵢWᵢⱼ
-                SimThreadedArrays.∇CᵢThreaded[ichunk][j]   += (m₀/ρⱼ) * -∇ᵢWᵢⱼ
-        
-                # Switch signs compared to DSPH, else free surface detection does not make sense
-                # Agrees, https://arxiv.org/abs/2110.10076, it should have been r_ji
-                SimThreadedArrays.∇◌rᵢThreaded[ichunk][i]  += (m₀/ρⱼ) * dot(-xᵢⱼ , ∇ᵢWᵢⱼ)  * MLcond
-                SimThreadedArrays.∇◌rᵢThreaded[ichunk][j]  += (m₀/ρᵢ) * dot( xᵢⱼ ,-∇ᵢWᵢⱼ)  * MLcond
-            end
+            add_shifting_terms!(SimMetaData, SimThreadedArrays, MotionLimiter,
+                                 xᵢⱼ, ∇ᵢWᵢⱼ, m₀, ρᵢ, ρⱼ, i, j, ichunk)
         end
 
         return nothing
     end
 
-    Base.@propagate_inbounds function ComputeInteractionsMDBC!(SimKernel, SimMetaData::SimulationMetaData{Dimensions, FloatType}, SimConstants, Position, Density, ParticleType, GhostPoints, i, j) where {Dimensions, FloatType}
+    Base.@propagate_inbounds function ComputeInteractionsMDBC!(SimKernel, SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode}, SimConstants, Position, Density, ParticleType, GhostPoints, i, j) where {Dimensions, FloatType, SMode, KMode, BMode}
         @unpack ρ₀, m₀, α, γ, g, c₀, δᵩ, Cb, Cb⁻¹, ν₀, dx, SmagorinskyConstant, BlinConstant = SimConstants
         
         @unpack h⁻¹, h, η², H², αD = SimKernel 
@@ -344,23 +371,42 @@ using Bumper
         end
     end
 
+    # Zero arrays related to shifting depending on the selected mode.
+    function zero_shifting_arrays!(::SimulationMetaData{D,T,NoShifting,K,B}, _...) where {D,T,
+                                                                                     K<:KernelOutputMode,
+                                                                                     B<:MDBCMode}
+        return nothing
+    end
+    function zero_shifting_arrays!(::SimulationMetaData{D,T,S,K,B}, arrays...) where {D,T,S<:ShiftingMode,
+                                                                                     K<:KernelOutputMode,
+                                                                                     B<:MDBCMode}
+        @threads for arr in arrays
+            fill!(arr, zero(eltype(arr)))
+        end
+        return nothing
+    end
+
+    # Zero arrays related to kernel output depending on the selected mode.
+    function zero_kernel_arrays!(::SimulationMetaData{D,T,S,NoKernelOutput,B}, _...) where {D,T,S<:ShiftingMode,
+                                                                                           B<:MDBCMode}
+        return nothing
+    end
+    function zero_kernel_arrays!(::SimulationMetaData{D,T,S,K,B}, arrays...) where {D,T,S<:ShiftingMode,
+                                                                                    K<:KernelOutputMode,
+                                                                                    B<:MDBCMode}
+        @threads for arr in arrays
+            fill!(arr, zero(eltype(arr)))
+        end
+        return nothing
+    end
+
     function ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
         # Threaded zeroing for main arrays
         @threads for arr in (dρdtI, Acceleration)
             fill!(arr, zero(eltype(arr)))
         end
-
-        if SimMetaData.FlagOutputKernelValues
-            @threads for arr in (Kernel, KernelGradient)
-                fill!(arr, zero(eltype(arr)))
-            end
-        end
-
-        if SimMetaData.FlagShifting
-            @threads for arr in (∇Cᵢ, ∇◌rᵢ)
-                fill!(arr, zero(eltype(arr)))
-            end
-        end
+        zero_kernel_arrays!(SimMetaData, Kernel, KernelGradient)
+        zero_shifting_arrays!(SimMetaData, ∇Cᵢ, ∇◌rᵢ)
 
         # Threaded zeroing for fields in SimThreadedArrays
         foreachfield(f -> begin
@@ -372,23 +418,90 @@ using Bumper
         return nothing
     end
 
+    function reduce_shifting_arrays!(::SimulationMetaData{D,T,NoShifting,K,B}, _...) where {D,T,
+                                                                                           K<:KernelOutputMode,
+                                                                                           B<:MDBCMode}
+        return nothing
+    end
+    function reduce_shifting_arrays!(::SimulationMetaData{D,T,S,K,B}, ∇Cᵢ, ∇◌rᵢ, SimThreadedArrays) where {D,T,S<:ShiftingMode,
+                                                                                                           K<:KernelOutputMode,
+                                                                                                           B<:MDBCMode}
+        reduce_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded)
+        reduce_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded)
+        return nothing
+    end
+
+    function prepare_shifting_arrays!(::SimulationMetaData{D,T,NoShifting,K,B}, ∇Cᵢ, ∇◌rᵢ) where {D,T,
+                                                                                                K<:KernelOutputMode,
+                                                                                                B<:MDBCMode}
+        resize!(∇Cᵢ, 0)
+        resize!(∇◌rᵢ, 0)
+        return nothing
+    end
+    prepare_shifting_arrays!(::SimulationMetaData{D,T,S,K,B}, ∇Cᵢ, ∇◌rᵢ) where {D,T,S<:ShiftingMode,
+                                                                               K<:KernelOutputMode,
+                                                                               B<:MDBCMode} = nothing
+
+    function reduce_kernel_arrays!(::SimulationMetaData{D,T,S,NoKernelOutput,B}, _...) where {D,T,S<:ShiftingMode,
+                                                                                             B<:MDBCMode}
+        return nothing
+    end
+    function reduce_kernel_arrays!(::SimulationMetaData{D,T,S,K,B}, Kernel, KernelGradient, SimThreadedArrays) where {D,T,S<:ShiftingMode,
+                                                                                                                     K<:KernelOutputMode,
+                                                                                                                     B<:MDBCMode}
+        reduce_sum!(Kernel, SimThreadedArrays.KernelThreaded)
+        reduce_sum!(KernelGradient, SimThreadedArrays.KernelGradientThreaded)
+        return nothing
+    end
+
     function ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
         reduce_sum!(dρdtI, SimThreadedArrays.dρdtIThreaded)
         reduce_sum!(Acceleration, SimThreadedArrays.AccelerationThreaded)
-  
-        if SimMetaData.FlagOutputKernelValues
-            reduce_sum!(Kernel, SimThreadedArrays.KernelThreaded)
-            reduce_sum!(KernelGradient, SimThreadedArrays.KernelGradientThreaded)
-        end
 
-        if SimMetaData.FlagShifting
-            reduce_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded)
-            reduce_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded)
-        end
-    
+        reduce_kernel_arrays!(SimMetaData, Kernel, KernelGradient, SimThreadedArrays)
+        reduce_shifting_arrays!(SimMetaData, ∇Cᵢ, ∇◌rᵢ, SimThreadedArrays)
+
         return nothing
     end
-    
+
+    function apply_mdbc_before_half!(::SimulationMetaData{D,T,S,K,NoMDBC}, _args...) where {D,T,S<:ShiftingMode,
+                                                                                             K<:KernelOutputMode}
+        return nothing
+    end
+    function apply_mdbc_before_half!(SimMetaData::SimulationMetaData{D,T,S,K,SimpleMDBC},
+                                     SimKernel, SimConstants, SimParticles,
+                                     ParticleRanges, CellDict, Position, Density,
+                                     GhostPoints, GhostNormals, ParticleType) where {D,T,S<:ShiftingMode,
+                                                                                      K<:KernelOutputMode}
+        DimensionsPlus = D + 1
+        bᵧ = Vector{SVector{DimensionsPlus, T}}(undef, length(Position))
+        Aᵧ = Vector{SMatrix{DimensionsPlus, DimensionsPlus, T,
+                            DimensionsPlus * DimensionsPlus}}(undef, length(Position))
+        @timeit SimMetaData.HourGlass "04a First NeighborLoopMDBC" NeighborLoopMDBC!(SimKernel, SimMetaData,
+                                                                                       SimConstants, ParticleRanges, CellDict,
+                                                                                       Position, Density, GhostPoints,
+                                                                                       GhostNormals, ParticleType, bᵧ, Aᵧ)
+        @timeit SimMetaData.HourGlass "04b Apply MDBC before Half TimeStep" ApplyMDBCCorrection(SimConstants, SimParticles, bᵧ, Aᵧ)
+        return nothing
+    end
+
+    function load_mdbc_normals!(::SimulationMetaData{D,T,S,K,NoMDBC}, SimParticles, path) where {D,T,S<:ShiftingMode,
+                                                                                                 K<:KernelOutputMode}
+        return nothing
+    end
+    function load_mdbc_normals!(::SimulationMetaData{D,T,S,K,SimpleMDBC}, SimParticles, path) where {D,T,S<:ShiftingMode,
+                                                                                                    K<:KernelOutputMode}
+        if isnothing(path)
+            return nothing
+        end
+        _, GhostPoints, GhostNormals = LoadBoundaryNormals(Val(D), T, path)
+        for gi ∈ eachindex(GhostPoints)
+            SimParticles.GhostPoints[gi]  = GhostPoints[gi]
+            SimParticles.GhostNormals[gi] = GhostNormals[gi]
+        end
+        return nothing
+    end
+
     ### Some functions to simplify code inside of this function
     function ProgressMotion(Position, Velocity, ParticleType, ParticleMarker, dt₂, MotionsDefinition, SimMetaData)
         @inbounds @simd ivdep for i in eachindex(Position)
@@ -439,7 +552,9 @@ using Bumper
         end
     end
     
-    function HalfTimeStep(::SimulationMetaData{Dimensions, FloatType}, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂) where {Dimensions, FloatType}
+    function HalfTimeStep(::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode},
+                          SimConstants, SimParticles, Positionₙ⁺,
+                          Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂) where {Dimensions, FloatType, SMode, KMode, BMode}
         @unpack Position, Density, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
 
         @inbounds @simd ivdep for i in eachindex(Position)
@@ -453,34 +568,40 @@ using Bumper
         return nothing
     end
 
-    function FullTimeStep(SimMetaData, SimKernel, SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt)
+    function FullTimeStep(::SimulationMetaData{D,T,NoShifting,K,B}, SimKernel,
+                          SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt) where {D,T,
+                                                                             K<:KernelOutputMode,
+                                                                             B<:MDBCMode}
         @unpack Position, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
-  
-        if !SimMetaData.FlagShifting
-            @inbounds @simd ivdep for i in eachindex(Position)
-                Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
-                Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
-                Position[i]       +=  (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt) * MotionLimiter[i]
-            end
-        else
-            A     = 2# Value between 1 to 6 advised
-            A_FST = 0; # zero for internal flows
-            A_FSM = length(first(Position)); #2d, 3d val different
-            @inbounds @simd ivdep for i in eachindex(Position)
-                Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
-                Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
-        
-                A_FSC                  = (∇◌rᵢ[i] - A_FST)/(A_FSM - A_FST)
-                if A_FSC < 0
-                    δxᵢ = zero(eltype(Position))
-                else
-                    δxᵢ = -A_FSC * A * SimKernel.h * norm(Velocity[i]) * dt * ∇Cᵢ[i]
-                end
-        
-                Position[i]           += (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt + δxᵢ) * MotionLimiter[i]
-            end
+        @inbounds @simd ivdep for i in eachindex(Position)
+            Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
+            Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
+            Position[i]       +=  (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt) * MotionLimiter[i]
         end
+        return nothing
+    end
 
+    function FullTimeStep(::SimulationMetaData{D,T,S,K,B}, SimKernel, SimConstants,
+                          SimParticles, ∇Cᵢ, ∇◌rᵢ, dt) where {D,T,S<:ShiftingMode,
+                                                             K<:KernelOutputMode,
+                                                             B<:MDBCMode}
+        @unpack Position, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
+        A     = 2# Value between 1 to 6 advised
+        A_FST = 0; # zero for internal flows
+        A_FSM = length(first(Position)); #2d, 3d val different
+        @inbounds @simd ivdep for i in eachindex(Position)
+            Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
+            Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
+
+            A_FSC                  = (∇◌rᵢ[i] - A_FST)/(A_FSM - A_FST)
+            if A_FSC < 0
+                δxᵢ = zero(eltype(Position))
+            else
+                δxᵢ = -A_FSC * A * SimKernel.h * norm(Velocity[i]) * dt * ∇Cᵢ[i]
+            end
+
+            Position[i]           += (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt + δxᵢ) * MotionLimiter[i]
+        end
         return nothing
     end
 
@@ -533,12 +654,12 @@ using Bumper
 
     
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
-                                      SimMetaData::SimulationMetaData{Dimensions, FloatType},
+                                      SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode},
                                       SimConstants, SimParticles, Stencil,
                                       ParticleRanges, UniqueCells, CellDict,
                                       SortingScratchSpace, SimThreadedArrays,
                                       dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
-                                      ∇Cᵢ, ∇◌rᵢ, MotionDefinition) where {Dimensions, FloatType, SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
+                                      ∇Cᵢ, ∇◌rᵢ, MotionDefinition) where {Dimensions, FloatType, SMode, KMode, BMode, SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
         Position       = SimParticles.Position
         Density        = SimParticles.Density
         Pressure       = SimParticles.Pressure
@@ -553,7 +674,6 @@ using Bumper
         GhostNormals   = SimParticles.GhostNormals
 
         ###
-        DimensionsPlus = Dimensions + 1
         Δx = one(eltype(Density)) + SimKernel.h
         UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
 
@@ -589,12 +709,9 @@ using Bumper
                     ###===
                 
                     @timeit SimMetaData.HourGlass "03 Pressure"                          Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
-                    if SimMetaData.FlagMDBCSimple
-                        bᵧ = @alloc(SVector{DimensionsPlus, FloatType}, length(Position))
-                        Aᵧ = @alloc(SMatrix{DimensionsPlus, DimensionsPlus, FloatType, DimensionsPlus * DimensionsPlus}, length(Position))
-                        @timeit SimMetaData.HourGlass "04a First NeighborLoopMDBC"           NeighborLoopMDBC!(SimKernel, SimMetaData, SimConstants, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType, bᵧ, Aᵧ)
-                        @timeit SimMetaData.HourGlass "04b Apply MDBC before Half TimeStep"  ApplyMDBCCorrection(SimConstants, SimParticles, bᵧ, Aᵧ)
-                    end
+                    apply_mdbc_before_half!(SimMetaData, SimKernel, SimConstants, SimParticles,
+                                             ParticleRanges, CellDict, Position, Density,
+                                             GhostPoints, GhostNormals, ParticleType)
 
                     @timeit SimMetaData.HourGlass "04 First NeighborLoop"                NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Position, Density, Pressure, Velocity, MotionLimiter, UniqueCellsView)
                     @timeit SimMetaData.HourGlass "Reduction"                            ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
@@ -633,7 +750,7 @@ using Bumper
     
     ###===
     function RunSimulation(;SimGeometry::Vector{Geometry{Dimensions, FloatType}}, #Don't further specify type for now
-        SimMetaData::SimulationMetaData{Dimensions, FloatType},
+        SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode},
         SimConstants::SimulationConstants,
         SimKernel::SPHKernelInstance,
         SimLogger::SimulationLogger,
@@ -641,7 +758,7 @@ using Bumper
         SimViscosity::SV,
         SimDensityDiffusion::SDD,
         ParticleNormalsPath::Union{Nothing,String} = nothing
-        ) where {Dimensions,FloatType,SV<:SPHViscosity,SDD<:SPHDensityDiffusion}
+        ) where {Dimensions,FloatType,SMode,KMode,BMode,SV<:SPHViscosity,SDD<:SPHDensityDiffusion}
 
         # Unpack the relevant simulation meta data
         @unpack HourGlass = SimMetaData;
@@ -651,24 +768,9 @@ using Bumper
         
         dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ = AllocateSupportDataStructures(SimParticles.Position)
 
-        # Implement this properly later in shaa Allah
-        # if !isnothing(ParticleNormalsPath)
-            if SimMetaData.FlagMDBCSimple
-                _, GhostPoints, GhostNormals = LoadBoundaryNormals(Val(Dimensions), FloatType, ParticleNormalsPath)
-            
+        load_mdbc_normals!(SimMetaData, SimParticles, ParticleNormalsPath)
 
-                #TODO: In the future decide on one of the two in shaa Allah
-                for gi ∈ eachindex(GhostPoints)
-                    SimParticles.GhostPoints[gi]  = GhostPoints[gi]
-                    SimParticles.GhostNormals[gi] = GhostNormals[gi]
-                end
-            end
-        # end
-
-        if !SimMetaData.FlagShifting
-            resize!(∇Cᵢ , 0)
-            resize!(∇◌rᵢ, 0)
-        end
+        prepare_shifting_arrays!(SimMetaData, ∇Cᵢ, ∇◌rᵢ)
 
         if SimMetaData.FlagLog
             InitializeLogger(SimLogger, SimConstants, SimMetaData, SimKernel, SimViscosity, SimDensityDiffusion, SimGeometry, SimParticles)

--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -47,7 +47,9 @@ module SPHExample
     export SimulationLogger, generate_format_string, InitializeLogger, LogSimulationDetails, LogStep, LogFinal
 
     using .SimulationMetaDataConfiguration
-    export SimulationMetaData
+    export SimulationMetaData, ShiftingMode, NoShifting, PlanarShifting,
+           KernelOutputMode, NoKernelOutput, StoreKernelOutput,
+           MDBCMode, NoMDBC, SimpleMDBC
 
     using .SimulationConstantsConfiguration
     export SimulationConstants

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -4,10 +4,27 @@ using Parameters
 using TimerOutputs
 using ProgressMeter
 
-export SimulationMetaData
+export SimulationMetaData, ShiftingMode, NoShifting, PlanarShifting,
+       KernelOutputMode, NoKernelOutput, StoreKernelOutput,
+       MDBCMode, NoMDBC, SimpleMDBC
 
+abstract type ShiftingMode end
+struct NoShifting    <: ShiftingMode end
+struct PlanarShifting <: ShiftingMode end
 
-@with_kw mutable struct SimulationMetaData{Dimensions, FloatType <: AbstractFloat}
+abstract type KernelOutputMode end
+struct NoKernelOutput    <: KernelOutputMode end
+struct StoreKernelOutput <: KernelOutputMode end
+
+abstract type MDBCMode end
+struct NoMDBC    <: MDBCMode end
+struct SimpleMDBC <: MDBCMode end
+
+@with_kw mutable struct SimulationMetaData{Dimensions,
+                                           FloatType <: AbstractFloat,
+                                           SMode <: ShiftingMode,
+                                           KMode <: KernelOutputMode,
+                                           BMode <: MDBCMode}
     SimulationName::String
     SaveLocation::String
     HourGlass::TimerOutput                  = TimerOutput()
@@ -20,7 +37,7 @@ export SimulationMetaData
     TotalTime::FloatType                    = 0
     SimulationTime::FloatType               = 0
     IndexCounter::Int                       = 0
-    ProgressSpecification::ProgressUnknown  =  ProgressUnknown(desc="Simulation time per output each:", spinner=true, showspeed=true) 
+    ProgressSpecification::ProgressUnknown  = ProgressUnknown(desc="Simulation time per output each:", spinner=true, showspeed=true)
     VisualizeInParaview::Bool               = true
     ExportSingleVTKHDF::Bool                = true
     ExportGridCells::Bool                   = false
@@ -40,12 +57,16 @@ export SimulationMetaData
         "GhostNormals",
     ]
     OpenLogFile::Bool                       = true
-    FlagOutputKernelValues::Bool            = false
     FlagLog::Bool                           = false
-    FlagShifting::Bool                      = false
     FlagSingleStepTimeStepping::Bool        = false
     ChunkMultiplier::Int                    = 1
-    FlagMDBCSimple::Bool                    = false
 end
+SimulationMetaData{D,T,S,K}(; kwargs...) where {D,T,S<:ShiftingMode,K<:KernelOutputMode} =
+    SimulationMetaData{D,T,S,K,NoMDBC}(; kwargs...)
+SimulationMetaData{D,T,S}(; kwargs...) where {D,T,S<:ShiftingMode} =
+    SimulationMetaData{D,T,S,NoKernelOutput,NoMDBC}(; kwargs...)
+SimulationMetaData{D,T}(; kwargs...) where {D,T} =
+    SimulationMetaData{D,T,NoShifting,NoKernelOutput,NoMDBC}(; kwargs...)
 
 end
+


### PR DESCRIPTION
## Summary
- add `KernelOutputMode` and `MDBCMode` hierarchies and parameterize `SimulationMetaData`
- use dispatch helpers to apply MDBC corrections and load boundary normals
- remove `FlagMDBCSimple` from examples and specify `SimpleMDBC` mode explicitly

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(hangs after precompilation; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0991cd588323b5bc47ae79ce6724