### PR TITLE
Improve thread scheduling and pad thread arrays

### DIFF
--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -9,6 +9,15 @@ using StructArrays
 using ..SimulationGeometry
 using ..SimulationMetaDataConfiguration
 
+const CACHE_LINE_BYTES = 64
+
+function cacheline_padded_copy(v::AbstractVector)
+    pad = Int(CACHE_LINE_BYTES ÷ sizeof(eltype(v)))
+    padded = similar(v, length(v) + pad)
+    @inbounds padded[1:length(v)] = v
+    return padded
+end
+
 function LoadSpecificCSV(::Val{D}, ::Type{T}, particle_type::ParticleType, particle_group_marker::Int, specific_csv::String) where {D, T}
     csv_file = CSV.File(specific_csv)
 
@@ -168,8 +177,8 @@ function allocate_kernel_arrays(::SimulationMetaData{D,T,S,K,B,L},
                                                              K<:KernelOutputMode,
                                                              B<:MDBCMode,
                                                              L<:LogMode}
-    KernelThreaded         = [copy(SimParticles.Kernel) for _ in 1:n_copy]
-    KernelGradientThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
+    KernelThreaded = [cacheline_padded_copy(SimParticles.Kernel) for _ in 1:n_copy]
+    KernelGradientThreaded = [cacheline_padded_copy(SimParticles.KernelGradient) for _ in 1:n_copy]
     return (
         KernelThreaded = KernelThreaded,
         KernelGradientThreaded = KernelGradientThreaded,
@@ -187,8 +196,8 @@ function allocate_shifting_arrays(::SimulationMetaData{D,T,S,K,B,L},
                                                             K<:KernelOutputMode,
                                                             B<:MDBCMode,
                                                             L<:LogMode}
-    ∇CᵢThreaded  = [copy(∇Cᵢ) for _ in 1:n_copy]
-    ∇◌rᵢThreaded = [copy(∇◌rᵢ) for _ in 1:n_copy]
+    ∇CᵢThreaded  = [cacheline_padded_copy(∇Cᵢ) for _ in 1:n_copy]
+    ∇◌rᵢThreaded = [cacheline_padded_copy(∇◌rᵢ) for _ in 1:n_copy]
     return (
         ∇CᵢThreaded  = ∇CᵢThreaded,
         ∇◌rᵢThreaded = ∇◌rᵢThreaded,
@@ -201,8 +210,8 @@ function AllocateThreadedArrays(SimMetaData::SimulationMetaData{D,T,S,K,B,L},
                                                                            K<:KernelOutputMode,
                                                                            B<:MDBCMode,
                                                                            L<:LogMode}
-    dρdtIThreaded        = [copy(dρdtI) for _ in 1:n_copy]
-    AccelerationThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
+    dρdtIThreaded = [cacheline_padded_copy(dρdtI) for _ in 1:n_copy]
+    AccelerationThreaded = [cacheline_padded_copy(SimParticles.KernelGradient) for _ in 1:n_copy]
     nt = (
         dρdtIThreaded = dρdtIThreaded,
         AccelerationThreaded = AccelerationThreaded,

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -179,31 +179,41 @@ using LinearAlgebra
         end
         ordered = sortperm(weights, rev = true)
 
-        Threads.@threads :dynamic for idx in 1:n_cells
-            iter = ordered[idx]
-            tid = Threads.threadid()
-            CellIndex = UniqueCellsView[iter]
-            SimParticles.ChunkID[iter] = tid
-            StartIndex = ParticleRanges[iter]
-            EndIndex   = ParticleRanges[iter + 1] - 1
+        next_cell = Threads.Atomic{Int}(0)
+        Threads.@sync begin
+            for _ in 1:Threads.nthreads()
+                Threads.@spawn begin
+                    tid = Threads.threadid()
+                    idx = Threads.atomic_add!(next_cell, 1)
+                    while idx <= n_cells
+                        iter = ordered[idx]
+                        CellIndex = UniqueCellsView[iter]
+                        SimParticles.ChunkID[iter] = tid
+                        StartIndex = ParticleRanges[iter]
+                        EndIndex   = ParticleRanges[iter + 1] - 1
 
-            @inbounds for i = StartIndex:EndIndex, j = (i + 1):EndIndex
-                ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                                    SimConstants, SimParticles, SimThreadedArrays,
-                                    Position, Density, Pressure, Velocity,
-                                    i, j, MotionLimiter, tid)
-            end
+                        @inbounds for i = StartIndex:EndIndex, j = (i + 1):EndIndex
+                            ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                                SimConstants, SimParticles, SimThreadedArrays,
+                                                Position, Density, Pressure, Velocity,
+                                                i, j, MotionLimiter, tid)
+                        end
 
-            @inbounds for S in Stencil
-                SCellIndex = CellIndex + S
-                NeighborIdx = get(CellDict, SCellIndex, 1)
-                StartIndex_ = ParticleRanges[NeighborIdx]
-                EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
-                for i = StartIndex:EndIndex, j = StartIndex_:EndIndex_
-                    ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                                        SimConstants, SimParticles, SimThreadedArrays,
-                                        Position, Density, Pressure, Velocity,
-                                        i, j, MotionLimiter, tid)
+                        @inbounds for S in Stencil
+                            SCellIndex = CellIndex + S
+                            NeighborIdx = get(CellDict, SCellIndex, 1)
+                            StartIndex_ = ParticleRanges[NeighborIdx]
+                            EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
+                            for i = StartIndex:EndIndex, j = StartIndex_:EndIndex_
+                                ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                                    SimConstants, SimParticles, SimThreadedArrays,
+                                                    Position, Density, Pressure, Velocity,
+                                                    i, j, MotionLimiter, tid)
+                            end
+                        end
+
+                        idx = Threads.atomic_add!(next_cell, 1)
+                    end
                 end
             end
         end

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -171,48 +171,43 @@ using LinearAlgebra
                            Position, Density, Pressure, Velocity, MotionLimiter,
                            UniqueCellsView) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
 
-        # ceil(length(CellDict)/nthreads()) then bump to even:
-        base = (length(CellDict) + nthreads() - 1) ÷ nthreads()
-        chunk_size = base + (base & 1)    # add 1 if base is odd
-        Threads.@sync begin
-            # Iterate over UniqueCells in increments of `chunk_size`
-            for chunk_start in 1:chunk_size:length(UniqueCellsView)
-                # Define the range of cell indices for this chunk
-                chunk_end = min(chunk_start + chunk_size - 1, length(UniqueCellsView))
-                Threads.@spawn begin
-                    # Process each cell in this chunk
-                    for iter in chunk_start:chunk_end
-                        CellIndex = UniqueCellsView[iter]
-                        SimParticles.ChunkID[iter] = Threads.threadid()   # mark which thread handles this cell
-                        StartIndex = ParticleRanges[iter]
-                        EndIndex   = ParticleRanges[iter+1] - 1
+        n_cells = length(UniqueCellsView)
+        weights = Vector{Int}(undef, n_cells)
+        @inbounds for i in 1:n_cells
+            n = ParticleRanges[i + 1] - ParticleRanges[i]
+            weights[i] = n * n
+        end
+        ordered = sortperm(weights, rev = true)
 
-                        # (1) Interactions among particles within the same cell `iter`
-                        @inbounds for i = StartIndex:EndIndex, j = (i+1):EndIndex
-                            ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                                                SimConstants, SimParticles, SimThreadedArrays,
-                                                Position, Density, Pressure, Velocity,
-                                                i, j, MotionLimiter, Threads.threadid())
-                        end
+        Threads.@threads :dynamic for idx in 1:n_cells
+            iter = ordered[idx]
+            tid = Threads.threadid()
+            CellIndex = UniqueCellsView[iter]
+            SimParticles.ChunkID[iter] = tid
+            StartIndex = ParticleRanges[iter]
+            EndIndex   = ParticleRanges[iter + 1] - 1
 
-                        # (2) Interactions between this cell and each neighboring cell in the stencil
-                        @inbounds for S in Stencil
-                            SCellIndex   = CellIndex + S
-                            NeighborIdx  = get(CellDict, SCellIndex, 1)            # lookup neighbor cell index (or 1 if not present)
-                            StartIndex_  = ParticleRanges[NeighborIdx]
-                            EndIndex_    = ParticleRanges[NeighborIdx + 1] - 1
-                            for i = StartIndex:EndIndex, j = StartIndex_:EndIndex_
-                                ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                                                    SimConstants, SimParticles, SimThreadedArrays,
-                                                    Position, Density, Pressure, Velocity,
-                                                    i, j, MotionLimiter, Threads.threadid())
-                            end
-                        end
-                    end
-                end  # end @spawn
+            @inbounds for i = StartIndex:EndIndex, j = (i + 1):EndIndex
+                ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                    SimConstants, SimParticles, SimThreadedArrays,
+                                    Position, Density, Pressure, Velocity,
+                                    i, j, MotionLimiter, tid)
             end
-        end  # end @sync
-                
+
+            @inbounds for S in Stencil
+                SCellIndex = CellIndex + S
+                NeighborIdx = get(CellDict, SCellIndex, 1)
+                StartIndex_ = ParticleRanges[NeighborIdx]
+                EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
+                for i = StartIndex:EndIndex, j = StartIndex_:EndIndex_
+                    ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                        SimConstants, SimParticles, SimThreadedArrays,
+                                        Position, Density, Pressure, Velocity,
+                                        i, j, MotionLimiter, tid)
+                end
+            end
+        end
+
         return nothing
     end
 


### PR DESCRIPTION
## Summary
- Use dynamic thread scheduling with cell ordering to balance workload
- Pad per-thread accumulator arrays to avoid false sharing

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'`


------
https://chatgpt.com/codex/tasks/task_e_68c574a1557c8323bc434b9ea506a317