### PR TITLE
Add asynchronous particle output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The project demonstrates how to assemble a small SPH solver with Julia. It focus
 - **Weakly compressible formulation** – density varies ~1 % and pressure is a function of density.
 - **Multi-threaded execution** – achieved by spawning the neighbour loop.
 - **Configurable task granularity** – `ChunkMultiplier` controls load balancing across threads.
+- **Optional asynchronous output** – set `async_output=true` to save on a
+  background thread.
 - **Dynamic boundary condition** – inspired by DualSPHysics.
 - **Density diffusion** – based on Fourtakas et al. 2019 to reduce pressure noise.
 - **Wendland quintic kernel** – simple and stable without tensile corrections.
@@ -79,6 +81,8 @@ Pkg.add(url="https://github.com/AhmedSalih3d/SPHExample")
 ### Running an Example
 
 Open one of the files in `example/`, for instance `example/StillWedgeMDBC.jl`, and adjust the simulation parameters or the `ComputerInteractions!` function. Run the script to start the simulation. Results are written in `hdfvtk` format which can be loaded with ParaView 5.12 or newer.
+To reduce the impact of frequent saves on simulation time, enable background
+writing by setting `async_output=true` in `SimulationMetaData`.
 
 ## Help
 

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -20,6 +20,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
 
     using HDF5
     using StaticArrays
+    using Base.Threads
 
     using ..AuxiliaryFunctions: to_3d, to_3d!
 
@@ -458,7 +459,8 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     `save_grid` and `close_files` functions. Uses single or multi-file mode
     depending on `SimMetaData.ExportSingleVTKHDF`.
     """
-    function SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)
+    function SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions;
+                            async_output=false)
         # Generate save locations
         particle_savepath = joinpath(SimMetaData.SaveLocation, SimMetaData.SimulationName)
         grid_savepath = joinpath(SimMetaData.SaveLocation, "CellGrid_$(SimMetaData.SimulationName)")
@@ -540,6 +542,9 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             end
         end
 
+        # Task handle for asynchronous saving
+        last_task_ref = Ref{Task}(nothing)
+
         # Main saving functions
         function save_particle_data(iteration)
             if Dimensions == 2
@@ -576,12 +581,33 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             )
             output_data = [available[name] for name in output_vars]
 
-            if !SimMetaData.ExportSingleVTKHDF
-                SaveVTKHDF(file_handles.particle_files, iteration, particle_filename(iteration),
-                          pos, output_vars, output_data...)
+            t = SimMetaData.TotalTime
+            if async_output
+                pos_copy = copy(pos)
+                data_copies = [copy(d) for d in output_data]
+                last = last_task_ref[]
+                last_task_ref[] = Threads.@spawn begin
+                    if last !== nothing
+                        wait(last)
+                    end
+                    if !SimMetaData.ExportSingleVTKHDF
+                        SaveVTKHDF(file_handles.particle_files, iteration,
+                                   particle_filename(iteration), pos_copy,
+                                   output_vars, data_copies...)
+                    else
+                        AppendVTKHDFData(root, t, pos_copy, output_vars,
+                                         data_copies...)
+                    end
+                end
             else
-                AppendVTKHDFData(root, SimMetaData.TotalTime, pos, output_vars,
-                                output_data...)
+                if !SimMetaData.ExportSingleVTKHDF
+                    SaveVTKHDF(file_handles.particle_files, iteration,
+                               particle_filename(iteration), pos,
+                               output_vars, output_data...)
+                else
+                    AppendVTKHDFData(root, t, pos, output_vars,
+                                     output_data...)
+                end
             end
         end
     
@@ -596,6 +622,12 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         end
     
         function close_files()
+            if async_output
+                last = last_task_ref[]
+                if last !== nothing
+                    wait(last)
+                end
+            end
             if !SimMetaData.ExportSingleVTKHDF
                 # Close all particle files in multi-file mode
                 for f in file_handles.particle_files

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -843,7 +843,13 @@ using LinearAlgebra
         Stencil                = ConstructStencil(Val(Dimensions))
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
 
-        output = SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)
+        output = SetupVTKOutput(
+            SimMetaData,
+            SimParticles,
+            SimKernel,
+            Dimensions;
+            async_output=SimMetaData.async_output,
+        )
 
         # Save initial state, use 1 else this cannot be used to index fid vector
         SimMetaData.OutputIterationCounter = 1

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -47,6 +47,7 @@ struct StoreLog <: LogMode end
     VisualizeInParaview::Bool               = true
     ExportSingleVTKHDF::Bool                = true
     ExportGridCells::Bool                   = false
+    async_output::Bool                      = false
     OutputVariables::Vector{String}         = [
         "ChunkID",
         "Kernel",


### PR DESCRIPTION
## Summary
- add `async_output` flag to simulation metadata
- use background thread in `SetupVTKOutput` to write particle data without blocking
- document optional async saving in README

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: Package SPHExample errored during testing)*
- `julia --project=. -e 'using SPHExample; println("loaded")'`


------
https://chatgpt.com/codex/tasks/task_e_68c67db3b7b08323b01f4b24ae8d361b