### PR TITLE
Skip ghost arrays without MDBC

### DIFF
--- a/example/Dambreak2dMDBC.jl
+++ b/example/Dambreak2dMDBC.jl
@@ -25,7 +25,7 @@ let
     SimulationGeometry = [FixedBoundary; Water]
 
     # Load in particles
-    SimParticles = AllocateDataStructures(SimulationGeometry)
+    SimParticles = AllocateDataStructures(SimulationGeometry, NoKernelOutput, SimpleMDBC)
 
     SimMetaDataDambreak  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC,StoreLog}(
         SimulationName="DamBreak2D",

--- a/example/DucklingMDBC.jl
+++ b/example/DucklingMDBC.jl
@@ -24,7 +24,7 @@ let
     SimulationGeometry = [FixedBoundary;Water]
     
     # Load in particles
-    SimParticles = AllocateDataStructures(SimulationGeometry)
+    SimParticles = AllocateDataStructures(SimulationGeometry, NoKernelOutput, SimpleMDBC)
 
     SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC,StoreLog}(
         SimulationName="CaseDuckling",

--- a/example/StillWedgeMDBC.jl
+++ b/example/StillWedgeMDBC.jl
@@ -25,7 +25,7 @@ let
     SimulationGeometry = [FixedBoundary;Water]
     
     # Load in particles
-    SimParticles = AllocateDataStructures(SimulationGeometry)
+    SimParticles = AllocateDataStructures(SimulationGeometry, NoKernelOutput, SimpleMDBC)
 
     SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC,StoreLog}(
         SimulationName="StillWedge", 

--- a/example/StillWedgeMiddleSquareMDBC.jl
+++ b/example/StillWedgeMiddleSquareMDBC.jl
@@ -25,7 +25,7 @@ let
     SimulationGeometry = [FixedBoundary;Water]
     
     # Load in particles
-    SimParticles = AllocateDataStructures(SimulationGeometry)
+    SimParticles = AllocateDataStructures(SimulationGeometry, NoKernelOutput, SimpleMDBC)
 
     SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC,StoreLog}(
         SimulationName="StillWedge", 

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -42,7 +42,19 @@ function LoadSpecificCSV(::Val{D}, ::Type{T}, particle_type::ParticleType, parti
     return points, density, types, group_marker, idp
 end
 
-function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, FloatType}}) where {Dimensions, FloatType}
+"""
+    AllocateDataStructures(SimGeometry, SimMetaData)
+
+Load particle data from `SimGeometry` and return a struct array of particles.
+Kernel arrays are included or omitted based on the `KernelOutputMode` of
+`SimMetaData`. A convenience method without `SimMetaData` defaults to
+`NoKernelOutput`.
+"""
+function AllocateDataStructures(
+    SimGeometry::Vector{<:Geometry{Dimensions, FloatType}},
+    ::Type{KMode},
+    ::Type{BMode},
+) where {Dimensions, FloatType, KMode<:KernelOutputMode, BMode<:MDBCMode}
     Position    = Vector{SVector{Dimensions, FloatType}}()
     Density     = Vector{FloatType}()
     Types       = Vector{ParticleType}()
@@ -99,23 +111,77 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
 
     BoundaryBool  = UInt8.(.!Bool.(MotionLimiter))
 
-    Acceleration    = zeros(PositionType, NumberOfPoints)
-    Velocity        = zeros(PositionType, NumberOfPoints)
-    Kernel          = zeros(PositionUnderlyingType, NumberOfPoints)
-    KernelGradient  = zeros(PositionType, NumberOfPoints)
-    GhostPoints     = zeros(PositionType, NumberOfPoints)
-    GhostNormals    = zeros(PositionType, NumberOfPoints)
-
+    Acceleration   = zeros(PositionType, NumberOfPoints)
+    Velocity       = zeros(PositionType, NumberOfPoints)
     Pressureᵢ      = zeros(PositionUnderlyingType, NumberOfPoints)
-    
-    Cells          = fill(zero(CartesianIndex{Dimensions}), NumberOfPoints)
-    ChunkID        = zeros(Int, NumberOfPoints)
+    Cells   = fill(zero(CartesianIndex{Dimensions}), NumberOfPoints)
+    ChunkID = zeros(Int, NumberOfPoints)
 
-    SimParticles = StructArray((Cells = Cells, ChunkID = ChunkID, Kernel = Kernel, KernelGradient = KernelGradient, Position=Position, Acceleration=Acceleration, Velocity=Velocity, Density=Density, Pressure=Pressureᵢ, GravityFactor=GravityFactor, MotionLimiter=MotionLimiter, BoundaryBool = BoundaryBool, ID = Idp , Type = Types, GroupMarker = GroupMarker, GhostPoints = GhostPoints, GhostNormals=GhostNormals))
+    base_nt = (
+        Cells         = Cells,
+        ChunkID       = ChunkID,
+        Position      = Position,
+        Acceleration  = Acceleration,
+        Velocity      = Velocity,
+        Density       = Density,
+        Pressure      = Pressureᵢ,
+        GravityFactor = GravityFactor,
+        MotionLimiter = MotionLimiter,
+        BoundaryBool  = BoundaryBool,
+        ID            = Idp,
+        Type          = Types,
+        GroupMarker   = GroupMarker,
+    )
+
+    kernel_nt = kernel_particle_fields(KMode, NumberOfPoints,
+                                       PositionType, PositionUnderlyingType)
+    mdbc_nt = mdbc_particle_fields(BMode, NumberOfPoints, PositionType)
+
+    SimParticles = StructArray(merge(base_nt, kernel_nt, mdbc_nt))
 
     sort!(SimParticles, by = p -> p.ID)
 
     return SimParticles
+end
+
+function AllocateDataStructures(
+    SimGeometry::Vector{<:Geometry{Dimensions, FloatType}},
+    ::Type{KMode},
+) where {Dimensions, FloatType, KMode<:KernelOutputMode}
+    AllocateDataStructures(SimGeometry, KMode, NoMDBC)
+end
+
+AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, FloatType}}) where {Dimensions, FloatType} =
+    AllocateDataStructures(SimGeometry, NoKernelOutput, NoMDBC)
+
+function AllocateDataStructures(
+    SimGeometry::Vector{<:Geometry{Dimensions, FloatType}},
+    SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
+) where {Dimensions, FloatType, SMode<:ShiftingMode, KMode<:KernelOutputMode,
+         BMode<:MDBCMode, LMode<:LogMode}
+    AllocateDataStructures(SimGeometry, KMode, BMode)
+end
+
+function kernel_particle_fields(::Type{NoKernelOutput}, n, _, _)
+    NamedTuple()
+end
+
+function kernel_particle_fields(::Type{StoreKernelOutput}, n, position_type, underlying_type)
+    (
+        Kernel         = zeros(underlying_type, n),
+        KernelGradient = zeros(position_type, n),
+    )
+end
+
+function mdbc_particle_fields(::Type{NoMDBC}, _, _)
+    NamedTuple()
+end
+
+function mdbc_particle_fields(::Type{BMode}, n, position_type) where {BMode<:MDBCMode}
+    (
+        GhostPoints  = zeros(position_type, n),
+        GhostNormals = zeros(position_type, n),
+    )
 end
 
 function AllocateSupportDataStructures(::SimulationMetaData{D,T,NoShifting,K,B,L}, Position) where {D,T,K<:KernelOutputMode,
@@ -202,7 +268,7 @@ function AllocateThreadedArrays(SimMetaData::SimulationMetaData{D,T,S,K,B,L},
                                                                            B<:MDBCMode,
                                                                            L<:LogMode}
     dρdtIThreaded        = [copy(dρdtI) for _ in 1:n_copy]
-    AccelerationThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
+    AccelerationThreaded = [copy(SimParticles.Acceleration) for _ in 1:n_copy]
     nt = (
         dρdtIThreaded = dρdtIThreaded,
         AccelerationThreaded = AccelerationThreaded,

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -468,7 +468,8 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         grid_filename = (iter) -> "$(grid_savepath)_$(lpad(iter,6,"0")).vtkhdf"
         
         output_vars = SimMetaData.OutputVariables
-    
+        has_ghost_fields = hasproperty(SimParticles, :GhostPoints)
+
         # Initialize storage for file handles
         file_handles = if !SimMetaData.ExportSingleVTKHDF
             # Multi-file mode: vector for particle files
@@ -488,8 +489,6 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             
             available_init = Dict(
                 "ChunkID" => SimParticles.ChunkID,
-                "Kernel" => SimParticles.Kernel,
-                "KernelGradient" => SimParticles.KernelGradient,
                 "Density" => SimParticles.Density,
                 "Pressure" => SimParticles.Pressure,
                 "Velocity" => SimParticles.Velocity,
@@ -498,9 +497,15 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                 "ID" => SimParticles.ID,
                 "Type" => Int8.(SimParticles.Type),
                 "GroupMarker" => SimParticles.GroupMarker,
-                "GhostPoints" => SimParticles.GhostPoints,
-                "GhostNormals" => SimParticles.GhostNormals,
             )
+            if has_ghost_fields
+                available_init["GhostPoints"]  = SimParticles.GhostPoints
+                available_init["GhostNormals"] = SimParticles.GhostNormals
+            end
+            if hasproperty(SimParticles, :Kernel)
+                available_init["Kernel"] = SimParticles.Kernel
+                available_init["KernelGradient"] = SimParticles.KernelGradient
+            end
             output_data_init = [available_init[name] for name in output_vars]
 
             GenerateGeometryStructure(root, output_vars, output_data_init...; chunk_size=1024)
@@ -524,19 +529,27 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         if Dimensions == 2
             T = eltype(eltype(SimParticles.Position))
             n = length(SimParticles.Position)
-            pos_buf   = Vector{SVector{3,T}}(undef, n)
-            kgrad_buf = Vector{SVector{3,T}}(undef, n)
-            vel_buf   = Vector{SVector{3,T}}(undef, n)
-            acc_buf   = Vector{SVector{3,T}}(undef, n)
-            gp_buf    = Vector{SVector{3,T}}(undef, n)
-            gn_buf    = Vector{SVector{3,T}}(undef, n)
+            pos_buf = Vector{SVector{3,T}}(undef, n)
+            vel_buf = Vector{SVector{3,T}}(undef, n)
+            acc_buf = Vector{SVector{3,T}}(undef, n)
+            if has_ghost_fields
+                gp_buf  = Vector{SVector{3,T}}(undef, n)
+                gn_buf  = Vector{SVector{3,T}}(undef, n)
+            end
+            if hasproperty(SimParticles, :KernelGradient)
+                kgrad_buf = Vector{SVector{3,T}}(undef, n)
+            end
             fill_buffers!() = begin
-                to_3d!(pos_buf,   SimParticles.Position)
-                to_3d!(kgrad_buf, SimParticles.KernelGradient)
-                to_3d!(vel_buf,   SimParticles.Velocity)
-                to_3d!(acc_buf,   SimParticles.Acceleration)
-                to_3d!(gp_buf,    SimParticles.GhostPoints)
-                to_3d!(gn_buf,    SimParticles.GhostNormals)
+                to_3d!(pos_buf, SimParticles.Position)
+                if kgrad_buf !== nothing
+                    to_3d!(kgrad_buf, SimParticles.KernelGradient)
+                end
+                to_3d!(vel_buf, SimParticles.Velocity)
+                to_3d!(acc_buf, SimParticles.Acceleration)
+                if gp_buf !== nothing
+                    to_3d!(gp_buf, SimParticles.GhostPoints)
+                    to_3d!(gn_buf, SimParticles.GhostNormals)
+                end
             end
         end
 
@@ -544,25 +557,24 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         function save_particle_data(iteration)
             if Dimensions == 2
                 fill_buffers!()
-                pos   = pos_buf
+                pos = pos_buf
                 kgrad = kgrad_buf
-                vel   = vel_buf
-                acc   = acc_buf
-                gp    = gp_buf
-                gn    = gn_buf
+                vel = vel_buf
+                acc = acc_buf
+                gp = gp_buf
+                gn = gn_buf
             else
                 pos = SimParticles.Position
-                kgrad = SimParticles.KernelGradient
+                kgrad = hasproperty(SimParticles, :KernelGradient) ?
+                        SimParticles.KernelGradient : nothing
                 vel = SimParticles.Velocity
                 acc = SimParticles.Acceleration
-                gp  = SimParticles.GhostPoints
-                gn  = SimParticles.GhostNormals
+                gp  = has_ghost_fields ? SimParticles.GhostPoints  : nothing
+                gn  = has_ghost_fields ? SimParticles.GhostNormals : nothing
             end
 
             available = Dict(
                 "ChunkID" => SimParticles.ChunkID,
-                "Kernel" => SimParticles.Kernel,
-                "KernelGradient" => kgrad,
                 "Density" => SimParticles.Density,
                 "Pressure" => SimParticles.Pressure,
                 "Velocity" => vel,
@@ -571,9 +583,15 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                 "ID" => SimParticles.ID,
                 "Type" => Int8.(SimParticles.Type),
                 "GroupMarker" => SimParticles.GroupMarker,
-                "GhostPoints" => gp,
-                "GhostNormals" => gn,
             )
+            if has_ghost_fields
+                available["GhostPoints"]  = gp
+                available["GhostNormals"] = gn
+            end
+            if hasproperty(SimParticles, :Kernel)
+                available["Kernel"] = SimParticles.Kernel
+                available["KernelGradient"] = kgrad
+            end
             output_data = [available[name] for name in output_vars]
 
             if !SimMetaData.ExportSingleVTKHDF

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -731,7 +731,19 @@ using LinearAlgebra
                                       SortingScratchSpace, SimThreadedArrays,
                                       dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
                                       ∇Cᵢ, ∇◌rᵢ, MotionDefinition) where {Dimensions, FloatType, SMode, KMode, BMode, LMode, SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
-        @unpack Position, Density, Pressure, Velocity, Acceleration, MotionLimiter, GroupMarker, Kernel, KernelGradient, GhostPoints, GhostNormals = SimParticles
+        Position      = SimParticles.Position
+        Density       = SimParticles.Density
+        Pressure      = SimParticles.Pressure
+        Velocity      = SimParticles.Velocity
+        Acceleration  = SimParticles.Acceleration
+        MotionLimiter = SimParticles.MotionLimiter
+        GroupMarker   = SimParticles.GroupMarker
+
+        Kernel         = hasproperty(SimParticles, :Kernel) ? SimParticles.Kernel : nothing
+        KernelGradient = hasproperty(SimParticles, :KernelGradient) ?
+                          SimParticles.KernelGradient : nothing
+        GhostPoints    = hasproperty(SimParticles, :GhostPoints) ? SimParticles.GhostPoints : nothing
+        GhostNormals   = hasproperty(SimParticles, :GhostNormals) ? SimParticles.GhostNormals : nothing
         ParticleType   = SimParticles.Type
         ParticleMarker = GroupMarker
 

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -25,6 +25,49 @@ abstract type LogMode end
 struct NoLog    <: LogMode end
 struct StoreLog <: LogMode end
 
+function base_output_variables(::Type{NoKernelOutput})
+    [
+        "ChunkID",
+        "Density",
+        "Pressure",
+        "Velocity",
+        "Acceleration",
+        "BoundaryBool",
+        "ID",
+        "Type",
+        "GroupMarker",
+    ]
+end
+
+function base_output_variables(::Type{StoreKernelOutput})
+    [
+        "ChunkID",
+        "Kernel",
+        "KernelGradient",
+        "Density",
+        "Pressure",
+        "Velocity",
+        "Acceleration",
+        "BoundaryBool",
+        "ID",
+        "Type",
+        "GroupMarker",
+    ]
+end
+
+function default_output_variables(::Type{K}, ::Type{B}) where {K<:KernelOutputMode, B<:MDBCMode}
+    vars = base_output_variables(K)
+    if !(B <: NoMDBC)
+        push!(vars, "GhostPoints")
+        push!(vars, "GhostNormals")
+    end
+    return vars
+end
+
+function default_output_variables(::Type{K}) where {K<:KernelOutputMode}
+    default_output_variables(K, NoMDBC)
+end
+
 @with_kw mutable struct SimulationMetaData{Dimensions,
                                            FloatType <: AbstractFloat,
                                            SMode <: ShiftingMode,
@@ -47,21 +90,7 @@ struct StoreLog <: LogMode end
     VisualizeInParaview::Bool               = true
     ExportSingleVTKHDF::Bool                = true
     ExportGridCells::Bool                   = false
-    OutputVariables::Vector{String}         = [
-        "ChunkID",
-        "Kernel",
-        "KernelGradient",
-        "Density",
-        "Pressure",
-        "Velocity",
-        "Acceleration",
-        "BoundaryBool",
-        "ID",
-        "Type",
-        "GroupMarker",
-        "GhostPoints",
-        "GhostNormals",
-    ]
+    OutputVariables::Vector{String}         = default_output_variables(KMode, BMode)
     OpenLogFile::Bool                       = true
     ChunkMultiplier::Int                    = 1
 end


### PR DESCRIPTION
## Summary
- extend particle allocation to dispatch on the MDBC mode so ghost point data is only created when required
- guard VTK export and the main simulation loop when ghost arrays are absent and derive default output variables from both kernel and boundary modes
- update MDBC example scripts to request ghost fields explicitly when allocating particles

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(hangs during package precompilation, command aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c57462fc5883239c6c73d49c867ee0