### PR TITLE
Use Polyester-style batching for threaded loops

### DIFF
--- a/src/PolyesterCompat.jl
+++ b/src/PolyesterCompat.jl
@@ -1,0 +1,65 @@
+module PolyesterCompat
+
+using Base.Threads
+
+"""
+    Polyester.batch(iterable; threads=Threads.nthreads(), batch_size=nothing)
+
+Lightweight, allocation-free batching helper that mirrors the key interface of
+`Polyester.batch`. It splits `iterable` into contiguous ranges sized for the
+available threads.
+"""
+module Polyester
+    using Base.Threads
+
+    struct StaticBatch
+        len::Int
+        chunk::Int
+    end
+
+    Base.eltype(::Type{StaticBatch}) = UnitRange{Int}
+
+    @inline function Base.length(b::StaticBatch)
+        return b.len == 0 ? 0 : cld(b.len, b.chunk)
+    end
+
+    @inline Base.iterate(b::StaticBatch) = iterate(b, 1)
+    @inline function Base.iterate(b::StaticBatch, state::Int)
+        state > b.len && return nothing
+
+        stop = min(state + b.chunk - 1, b.len)
+        return (state:stop, stop + 1)
+    end
+
+    @inline function chunk_range(b::StaticBatch, chunk_id::Int)
+        start = (chunk_id - 1) * b.chunk + 1
+        stop = min(chunk_id * b.chunk, b.len)
+        return start:stop
+    end
+
+    @inline function batch(len::Int; threads::Int = Threads.nthreads(),
+                           batch_size::Union{Nothing, Int} = nothing)
+        chunk = something(batch_size, threads == 0 ? len : cld(len, threads))
+        return StaticBatch(len, max(chunk, 1))
+    end
+
+    @inline function batch(iterable; threads::Int = Threads.nthreads(),
+                           batch_size::Union{Nothing, Int} = nothing)
+        return batch(length(iterable); threads, batch_size)
+    end
+end
+
+export Polyester, foreach_batch
+
+@inline function foreach_batch(batches::Polyester.StaticBatch, f)
+    nbatches = length(batches)
+
+    @inbounds Threads.@threads for chunk_id in 1:nbatches
+        range = Polyester.chunk_range(batches, chunk_id)
+        f(chunk_id, range)
+    end
+
+    return nothing
+end
+
+end

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -175,7 +175,7 @@ using LinearAlgebra
         N = length(UniqueCellsView)
         batches = Polyester.batch(N; threads=Threads.nthreads())
 
-        @inbounds foreach_batch(batches) do ichunk, iter_range
+        @inbounds foreach_batch(batches, (ichunk, iter_range) -> begin
             for iter in iter_range
                 CellIndex = UniqueCellsView[iter]
                 StartIndex = ParticleRanges[iter]
@@ -208,7 +208,7 @@ using LinearAlgebra
                     end
                 end
             end
-        end
+        end)
 
         return nothing
     end
@@ -364,14 +364,14 @@ using LinearAlgebra
     function reduce_sum!(target_array, arrays)
         batches = Polyester.batch(length(target_array); threads = nthreads())
 
-        @inbounds foreach_batch(batches) do _, range
+        @inbounds foreach_batch(batches, (_, range) -> begin
             for j in eachindex(arrays)
                 local array = arrays[j]
                 @simd ivdep for i in range
                     @inbounds target_array[i] += array[i]
                 end
             end
-        end
+        end)
     end
 
     # Zero arrays related to shifting depending on the selected mode.

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -18,6 +18,7 @@ using ..OpenExternalPrograms
 using ..SPHKernels
 using ..SPHViscosityModels
 using ..SPHDensityDiffusionModels
+using ..PolyesterCompat: Polyester, foreach_batch
 
 using StaticArrays
 import StructArrays: StructArray, foreachfield
@@ -171,26 +172,18 @@ using LinearAlgebra
                            Position, Density, Pressure, Velocity, MotionLimiter,
                            UniqueCellsView) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
 
-        # Partition UniqueCellsView into contiguous chunks and use the loop index `t`
-        # as a stable per-thread buffer index instead of Threads.threadid(),
-        # avoiding issues when tasks yield and migrate between threads.
         N = length(UniqueCellsView)
-        num_threads = Threads.nthreads()
-        chunk_size = ceil(Int, N / num_threads)
+        batches = Polyester.batch(N; threads=Threads.nthreads())
 
-        @inbounds Threads.@threads for t in 1:num_threads
-            ichunk = t   # stable per-thread buffer index
-            start_iter = (t-1) * chunk_size + 1
-            end_iter = min(t * chunk_size, N)
-
-            for iter = start_iter:end_iter
+        @inbounds foreach_batch(batches) do ichunk, iter_range
+            for iter in iter_range
                 CellIndex = UniqueCellsView[iter]
                 StartIndex = ParticleRanges[iter]
-                EndIndex = ParticleRanges[iter+1] - 1
+                EndIndex = ParticleRanges[iter + 1] - 1
 
                 # (1) Interactions within same cell
                 @inbounds for i = StartIndex:EndIndex
-                    for j = (i+1):EndIndex
+                    for j = (i + 1):EndIndex
                         ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                                              SimConstants, SimParticles, SimThreadedArrays,
                                              Position, Density, Pressure, Velocity,
@@ -369,15 +362,12 @@ using LinearAlgebra
     end
 
     function reduce_sum!(target_array, arrays)
-        n = length(target_array)
-        num_threads = nthreads()
-        chunk_size = ceil(Int, n / num_threads)
-        @inbounds @threads for t in 1:num_threads
-            local start_idx = 1 + (t-1) * chunk_size
-            local end_idx = min(t * chunk_size, n)
+        batches = Polyester.batch(length(target_array); threads = nthreads())
+
+        @inbounds foreach_batch(batches) do _, range
             for j in eachindex(arrays)
-                local array = arrays[j]  # Access array only once per thread
-                @simd ivdep for i in start_idx:end_idx
+                local array = arrays[j]
+                @simd ivdep for i in range
                     @inbounds target_array[i] += array[i]
                 end
             end

--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -12,6 +12,7 @@ module SPHExample
     include("SimulationLoggerConfiguration.jl");
     include("PreProcess.jl");
     include("OpenExternalPrograms.jl")
+    include("PolyesterCompat.jl")
     include("SPHDensityDiffusionModels.jl")  
     include("SPHCellList.jl") #Must be last    
 
@@ -62,4 +63,3 @@ module SPHExample
     export AutoOpenLogFile, AutoOpenParaview
 
 end
-


### PR DESCRIPTION
## Summary
- add a lightweight PolyesterCompat helper that provides allocation-free static batching across threads
- switch neighbor interaction and reduction loops to use the shared batching helper for thread-local buffers

## Testing
- julia --project=. -e 'using Pkg; Pkg.test()'


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948a2ea127c83238c9e4b88fe87f466)