### PR TITLE
Refactor per-particle accumulation in neighbor loop

### DIFF
--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -158,21 +158,38 @@ function AllocateSupportDataStructures(::SimulationMetaData{D,T,S,K,B,L}, Positi
 end
 
 function allocate_kernel_arrays(::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
-                                SimParticles, n_copy) where {D,T,S<:ShiftingMode,
-                                                             B<:MDBCMode,
-                                                             L<:LogMode}
-    return NamedTuple()
+                                 SimParticles, n_copy) where {D,T,S<:ShiftingMode,
+                                                              B<:MDBCMode,
+                                                              L<:LogMode}
+    KernelTouched          = [Int[] for _ in 1:n_copy]
+    KernelGradientTouched  = [Int[] for _ in 1:n_copy]
+    KernelMask             = [falses(length(SimParticles.Kernel)) for _ in 1:n_copy]
+    KernelGradientMask     = [falses(length(SimParticles.KernelGradient)) for _ in 1:n_copy]
+    return (
+        KernelTouched = KernelTouched,
+        KernelGradientTouched = KernelGradientTouched,
+        KernelMask = KernelMask,
+        KernelGradientMask = KernelGradientMask,
+    )
 end
 function allocate_kernel_arrays(::SimulationMetaData{D,T,S,K,B,L},
-                                SimParticles, n_copy) where {D,T,S<:ShiftingMode,
-                                                             K<:KernelOutputMode,
-                                                             B<:MDBCMode,
-                                                             L<:LogMode}
+                                 SimParticles, n_copy) where {D,T,S<:ShiftingMode,
+                                                              K<:KernelOutputMode,
+                                                              B<:MDBCMode,
+                                                              L<:LogMode}
     KernelThreaded         = [copy(SimParticles.Kernel) for _ in 1:n_copy]
     KernelGradientThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
+    KernelTouched          = [Int[] for _ in 1:n_copy]
+    KernelGradientTouched  = [Int[] for _ in 1:n_copy]
+    KernelMask             = [falses(length(SimParticles.Kernel)) for _ in 1:n_copy]
+    KernelGradientMask     = [falses(length(SimParticles.KernelGradient)) for _ in 1:n_copy]
     return (
         KernelThreaded = KernelThreaded,
         KernelGradientThreaded = KernelGradientThreaded,
+        KernelTouched = KernelTouched,
+        KernelGradientTouched = KernelGradientTouched,
+        KernelMask = KernelMask,
+        KernelGradientMask = KernelGradientMask,
     )
 end
 
@@ -180,7 +197,16 @@ function allocate_shifting_arrays(::SimulationMetaData{D,T,NoShifting,K,B,L},
                                   ∇Cᵢ, ∇◌rᵢ, n_copy) where {D,T,K<:KernelOutputMode,
                                                             B<:MDBCMode,
                                                             L<:LogMode}
-    return NamedTuple()
+    ∇CᵢTouched   = [Int[] for _ in 1:n_copy]
+    ∇◌rᵢTouched  = [Int[] for _ in 1:n_copy]
+    ∇CᵢMask      = [falses(length(∇Cᵢ)) for _ in 1:n_copy]
+    ∇◌rᵢMask     = [falses(length(∇◌rᵢ)) for _ in 1:n_copy]
+    return (
+        ∇CᵢTouched   = ∇CᵢTouched,
+        ∇◌rᵢTouched  = ∇◌rᵢTouched,
+        ∇CᵢMask      = ∇CᵢMask,
+        ∇◌rᵢMask     = ∇◌rᵢMask,
+    )
 end
 function allocate_shifting_arrays(::SimulationMetaData{D,T,S,K,B,L},
                                   ∇Cᵢ, ∇◌rᵢ, n_copy) where {D,T,S<:ShiftingMode,
@@ -189,9 +215,17 @@ function allocate_shifting_arrays(::SimulationMetaData{D,T,S,K,B,L},
                                                             L<:LogMode}
     ∇CᵢThreaded  = [copy(∇Cᵢ) for _ in 1:n_copy]
     ∇◌rᵢThreaded = [copy(∇◌rᵢ) for _ in 1:n_copy]
+    ∇CᵢTouched   = [Int[] for _ in 1:n_copy]
+    ∇◌rᵢTouched  = [Int[] for _ in 1:n_copy]
+    ∇CᵢMask      = [falses(length(∇Cᵢ)) for _ in 1:n_copy]
+    ∇◌rᵢMask     = [falses(length(∇◌rᵢ)) for _ in 1:n_copy]
     return (
         ∇CᵢThreaded  = ∇CᵢThreaded,
         ∇◌rᵢThreaded = ∇◌rᵢThreaded,
+        ∇CᵢTouched   = ∇CᵢTouched,
+        ∇◌rᵢTouched  = ∇◌rᵢTouched,
+        ∇CᵢMask      = ∇CᵢMask,
+        ∇◌rᵢMask     = ∇◌rᵢMask,
     )
 end
 
@@ -203,9 +237,17 @@ function AllocateThreadedArrays(SimMetaData::SimulationMetaData{D,T,S,K,B,L},
                                                                            L<:LogMode}
     dρdtIThreaded        = [copy(dρdtI) for _ in 1:n_copy]
     AccelerationThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
+    dρdtITouched         = [Int[] for _ in 1:n_copy]
+    AccelerationTouched  = [Int[] for _ in 1:n_copy]
+    dρdtIMask            = [falses(length(dρdtI)) for _ in 1:n_copy]
+    AccelerationMask     = [falses(length(SimParticles.KernelGradient)) for _ in 1:n_copy]
     nt = (
         dρdtIThreaded = dρdtIThreaded,
         AccelerationThreaded = AccelerationThreaded,
+        dρdtITouched = dρdtITouched,
+        AccelerationTouched = AccelerationTouched,
+        dρdtIMask = dρdtIMask,
+        AccelerationMask = AccelerationMask,
     )
 
     nt = merge(nt, allocate_kernel_arrays(SimMetaData, SimParticles, n_copy))

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -158,38 +158,21 @@ function AllocateSupportDataStructures(::SimulationMetaData{D,T,S,K,B,L}, Positi
 end
 
 function allocate_kernel_arrays(::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
-                                 SimParticles, n_copy) where {D,T,S<:ShiftingMode,
-                                                              B<:MDBCMode,
-                                                              L<:LogMode}
-    KernelTouched          = [Int[] for _ in 1:n_copy]
-    KernelGradientTouched  = [Int[] for _ in 1:n_copy]
-    KernelMask             = [falses(length(SimParticles.Kernel)) for _ in 1:n_copy]
-    KernelGradientMask     = [falses(length(SimParticles.KernelGradient)) for _ in 1:n_copy]
-    return (
-        KernelTouched = KernelTouched,
-        KernelGradientTouched = KernelGradientTouched,
-        KernelMask = KernelMask,
-        KernelGradientMask = KernelGradientMask,
-    )
+                                SimParticles, n_copy) where {D,T,S<:ShiftingMode,
+                                                             B<:MDBCMode,
+                                                             L<:LogMode}
+    return NamedTuple()
 end
 function allocate_kernel_arrays(::SimulationMetaData{D,T,S,K,B,L},
-                                 SimParticles, n_copy) where {D,T,S<:ShiftingMode,
-                                                              K<:KernelOutputMode,
-                                                              B<:MDBCMode,
-                                                              L<:LogMode}
+                                SimParticles, n_copy) where {D,T,S<:ShiftingMode,
+                                                             K<:KernelOutputMode,
+                                                             B<:MDBCMode,
+                                                             L<:LogMode}
     KernelThreaded         = [copy(SimParticles.Kernel) for _ in 1:n_copy]
     KernelGradientThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
-    KernelTouched          = [Int[] for _ in 1:n_copy]
-    KernelGradientTouched  = [Int[] for _ in 1:n_copy]
-    KernelMask             = [falses(length(SimParticles.Kernel)) for _ in 1:n_copy]
-    KernelGradientMask     = [falses(length(SimParticles.KernelGradient)) for _ in 1:n_copy]
     return (
         KernelThreaded = KernelThreaded,
         KernelGradientThreaded = KernelGradientThreaded,
-        KernelTouched = KernelTouched,
-        KernelGradientTouched = KernelGradientTouched,
-        KernelMask = KernelMask,
-        KernelGradientMask = KernelGradientMask,
     )
 end
 
@@ -197,16 +180,7 @@ function allocate_shifting_arrays(::SimulationMetaData{D,T,NoShifting,K,B,L},
                                   ∇Cᵢ, ∇◌rᵢ, n_copy) where {D,T,K<:KernelOutputMode,
                                                             B<:MDBCMode,
                                                             L<:LogMode}
-    ∇CᵢTouched   = [Int[] for _ in 1:n_copy]
-    ∇◌rᵢTouched  = [Int[] for _ in 1:n_copy]
-    ∇CᵢMask      = [falses(length(∇Cᵢ)) for _ in 1:n_copy]
-    ∇◌rᵢMask     = [falses(length(∇◌rᵢ)) for _ in 1:n_copy]
-    return (
-        ∇CᵢTouched   = ∇CᵢTouched,
-        ∇◌rᵢTouched  = ∇◌rᵢTouched,
-        ∇CᵢMask      = ∇CᵢMask,
-        ∇◌rᵢMask     = ∇◌rᵢMask,
-    )
+    return NamedTuple()
 end
 function allocate_shifting_arrays(::SimulationMetaData{D,T,S,K,B,L},
                                   ∇Cᵢ, ∇◌rᵢ, n_copy) where {D,T,S<:ShiftingMode,
@@ -215,17 +189,9 @@ function allocate_shifting_arrays(::SimulationMetaData{D,T,S,K,B,L},
                                                             L<:LogMode}
     ∇CᵢThreaded  = [copy(∇Cᵢ) for _ in 1:n_copy]
     ∇◌rᵢThreaded = [copy(∇◌rᵢ) for _ in 1:n_copy]
-    ∇CᵢTouched   = [Int[] for _ in 1:n_copy]
-    ∇◌rᵢTouched  = [Int[] for _ in 1:n_copy]
-    ∇CᵢMask      = [falses(length(∇Cᵢ)) for _ in 1:n_copy]
-    ∇◌rᵢMask     = [falses(length(∇◌rᵢ)) for _ in 1:n_copy]
     return (
         ∇CᵢThreaded  = ∇CᵢThreaded,
         ∇◌rᵢThreaded = ∇◌rᵢThreaded,
-        ∇CᵢTouched   = ∇CᵢTouched,
-        ∇◌rᵢTouched  = ∇◌rᵢTouched,
-        ∇CᵢMask      = ∇CᵢMask,
-        ∇◌rᵢMask     = ∇◌rᵢMask,
     )
 end
 
@@ -237,17 +203,9 @@ function AllocateThreadedArrays(SimMetaData::SimulationMetaData{D,T,S,K,B,L},
                                                                            L<:LogMode}
     dρdtIThreaded        = [copy(dρdtI) for _ in 1:n_copy]
     AccelerationThreaded = [copy(SimParticles.KernelGradient) for _ in 1:n_copy]
-    dρdtITouched         = [Int[] for _ in 1:n_copy]
-    AccelerationTouched  = [Int[] for _ in 1:n_copy]
-    dρdtIMask            = [falses(length(dρdtI)) for _ in 1:n_copy]
-    AccelerationMask     = [falses(length(SimParticles.KernelGradient)) for _ in 1:n_copy]
     nt = (
         dρdtIThreaded = dρdtIThreaded,
         AccelerationThreaded = AccelerationThreaded,
-        dρdtITouched = dρdtITouched,
-        AccelerationTouched = AccelerationTouched,
-        dρdtIMask = dρdtIMask,
-        AccelerationMask = AccelerationMask,
     )
 
     nt = merge(nt, allocate_kernel_arrays(SimMetaData, SimParticles, n_copy))

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -62,28 +62,48 @@ using LinearAlgebra
 
     # Add contributions related to particle shifting. Dispatch on `SimulationMetaData`
     # so that no runtime checks are required.
-    @inline function add_shifting_terms!(::SimulationMetaData{D,T,NoShifting,K,B,L}, SimThreadedArrays,
-                                MotionLimiter, xᵢⱼ, ∇ᵢWᵢⱼ, m₀, ρᵢ, ρⱼ, i, j, ichunk) where {D,T,
-                                                                                                K<:KernelOutputMode,
-                                                                                                B<:MDBCMode,
-                                                                                                L<:LogMode}
-        return nothing
+    @inline function add_shifting_terms_single!(::SimulationMetaData{D,T,NoShifting,K,B,L},
+                                                _motion_limiter, _xᵢⱼ, ∇ᵢWᵢⱼ,
+                                                m₀, _ρᵢ, _ρⱼ, _i, _j) where {D,T,
+                                                                             K<:KernelOutputMode,
+                                                                             B<:MDBCMode,
+                                                                             L<:LogMode}
+        return (zero(∇ᵢWᵢⱼ), zero(∇ᵢWᵢⱼ), zero(m₀), zero(m₀))
     end
 
-    @inline function add_shifting_terms!(::SimulationMetaData{D,T,PlanarShifting,K,B,L}, SimThreadedArrays,
-                                MotionLimiter, xᵢⱼ, ∇ᵢWᵢⱼ, m₀, ρᵢ, ρⱼ, i, j, ichunk) where {D,T,
+    @inline function add_shifting_terms_single!(::SimulationMetaData{D,T,PlanarShifting,K,B,L},
+                                                MotionLimiter, xᵢⱼ, ∇ᵢWᵢⱼ,
+                                                m₀, ρᵢ, ρⱼ, i, j) where {D,T,
+                                                                         K<:KernelOutputMode,
+                                                                         B<:MDBCMode,
+                                                                         L<:LogMode}
+        MLcond = MotionLimiter[i] * MotionLimiter[j]
+
+        Δ∇Cᵢ  = (m₀/ρᵢ) *  ∇ᵢWᵢⱼ
+        Δ∇Cⱼ  = (m₀/ρⱼ) * -∇ᵢWᵢⱼ
+        # Switch signs compared to DSPH, else free surface detection does not make sense
+        # Agrees, https://arxiv.org/abs/2110.10076, it should have been r_ji
+        Δ∇◌rᵢ = (m₀/ρⱼ) * dot(-xᵢⱼ , ∇ᵢWᵢⱼ) * MLcond
+        Δ∇◌rⱼ = (m₀/ρᵢ) * dot( xᵢⱼ ,-∇ᵢWᵢⱼ) * MLcond
+        return Δ∇Cᵢ, Δ∇Cⱼ, Δ∇◌rᵢ, Δ∇◌rⱼ
+    end
+
+    @inline function record_shifting!(::SimulationMetaData{D,T,NoShifting,K,B,L},
+                                      _SimThreadedArrays, _i, _j, _Δ∇Cᵢ, _Δ∇Cⱼ, _Δ∇◌rᵢ, _Δ∇◌rⱼ, _ichunk) where {D,T,
+                                                                                                       K<:KernelOutputMode,
+                                                                                                       B<:MDBCMode,
+                                                                                                       L<:LogMode}
+        return nothing
+    end
+    @inline function record_shifting!(::SimulationMetaData{D,T,PlanarShifting,K,B,L},
+                                      SimThreadedArrays, i, j, Δ∇Cᵢ, Δ∇Cⱼ, Δ∇◌rᵢ, Δ∇◌rⱼ, ichunk) where {D,T,
                                                                                                    K<:KernelOutputMode,
                                                                                                    B<:MDBCMode,
                                                                                                    L<:LogMode}
-        MLcond = MotionLimiter[i] * MotionLimiter[j]
-
-        SimThreadedArrays.∇CᵢThreaded[ichunk][i]   += (m₀/ρᵢ) *  ∇ᵢWᵢⱼ
-        SimThreadedArrays.∇CᵢThreaded[ichunk][j]   += (m₀/ρⱼ) * -∇ᵢWᵢⱼ
-
-        # Switch signs compared to DSPH, else free surface detection does not make sense
-        # Agrees, https://arxiv.org/abs/2110.10076, it should have been r_ji
-        SimThreadedArrays.∇◌rᵢThreaded[ichunk][i]  += (m₀/ρⱼ) * dot(-xᵢⱼ , ∇ᵢWᵢⱼ) * MLcond
-        SimThreadedArrays.∇◌rᵢThreaded[ichunk][j]  += (m₀/ρᵢ) * dot( xᵢⱼ ,-∇ᵢWᵢⱼ) * MLcond
+        SimThreadedArrays.∇CᵢThreaded[ichunk][i]   += Δ∇Cᵢ
+        SimThreadedArrays.∇CᵢThreaded[ichunk][j]   += Δ∇Cⱼ
+        SimThreadedArrays.∇◌rᵢThreaded[ichunk][i]  += Δ∇◌rᵢ
+        SimThreadedArrays.∇◌rᵢThreaded[ichunk][j]  += Δ∇◌rⱼ
         return nothing
     end
 
@@ -93,25 +113,39 @@ using LinearAlgebra
     # with its body, which in this case is `nothing`. When the `SimMetaData` type
     # is concrete at the call site, the compiler can completely eliminate this call,
     # resulting in zero runtime overhead.
-    @inline function KernelOutput!(::SimulationMetaData{D,T,S,NoKernelOutput,B,L}, SimKernel,
-                            SimThreadedArrays, q, ∇ᵢWᵢⱼ, i, j, ichunk) where {D,T,S<:ShiftingMode,
-                                                                               B<:MDBCMode,
-                                                                               L<:LogMode}
-        return nothing
+    @inline function kernel_contribution(::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
+                                         SimKernel, q, ∇ᵢWᵢⱼ) where {D,T,S<:ShiftingMode,
+                                                                    B<:MDBCMode,
+                                                                    L<:LogMode}
+        return zero(eltype(∇ᵢWᵢⱼ)), zero(∇ᵢWᵢⱼ)
     end
 
     # This version is called when kernel output is requested.
     # The `@inline` annotation helps reduce function call overhead, especially
     # since this is called inside a tight loop (`ComputeInteractions!`).
-    @inline function KernelOutput!(::SimulationMetaData{D,T,S,StoreKernelOutput,B,L}, SimKernel,
-                            SimThreadedArrays, q, ∇ᵢWᵢⱼ, i, j, ichunk) where {D,T,S<:ShiftingMode,
-                                                                            B<:MDBCMode,
-                                                                            L<:LogMode}
+    @inline function kernel_contribution(::SimulationMetaData{D,T,S,StoreKernelOutput,B,L},
+                                         SimKernel, q, ∇ᵢWᵢⱼ) where {D,T,S<:ShiftingMode,
+                                                                     B<:MDBCMode,
+                                                                     L<:LogMode}
         Wᵢⱼ  = @fastpow SPHKernels.Wᵢⱼ(SimKernel, q)
+        return Wᵢⱼ, ∇ᵢWᵢⱼ
+    end
+
+    @inline function KernelOutput!(::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
+                                   _SimKernel, _SimThreadedArrays, _q, _∇ᵢWᵢⱼ, _i, _j, _ichunk) where {D,T,S<:ShiftingMode,
+                                                                                                         B<:MDBCMode,
+                                                                                                         L<:LogMode}
+        return nothing
+    end
+    @inline function KernelOutput!(SimMetaData::SimulationMetaData{D,T,S,StoreKernelOutput,B,L},
+                                   SimKernel, SimThreadedArrays, q, ∇ᵢWᵢⱼ, i, j, ichunk) where {D,T,S<:ShiftingMode,
+                                                                                                   B<:MDBCMode,
+                                                                                                   L<:LogMode}
+        Wᵢⱼ, ∇Wᵢⱼ = kernel_contribution(SimMetaData, SimKernel, q, ∇ᵢWᵢⱼ)
         SimThreadedArrays.KernelThreaded[ichunk][i]         += Wᵢⱼ
         SimThreadedArrays.KernelThreaded[ichunk][j]         += Wᵢⱼ
-        SimThreadedArrays.KernelGradientThreaded[ichunk][i] +=  ∇ᵢWᵢⱼ
-        SimThreadedArrays.KernelGradientThreaded[ichunk][j] += -∇ᵢWᵢⱼ
+        SimThreadedArrays.KernelGradientThreaded[ichunk][i] +=  ∇Wᵢⱼ
+        SimThreadedArrays.KernelGradientThreaded[ichunk][j] += -∇Wᵢⱼ
         return nothing
     end
    
@@ -164,54 +198,47 @@ using LinearAlgebra
 
 
 # Neither Polyester.@batch per core or thread is faster
-###=== Function to process each cell and its neighbors
+###=== Function to process interactions per particle
     function NeighborLoop!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                            SimMetaData, SimConstants, SimParticles,
                            SimThreadedArrays, ParticleRanges, CellDict, Stencil,
-                           Position, Density, Pressure, Velocity, MotionLimiter,
-                           UniqueCellsView) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
+                           Position, Density, Pressure, Velocity, MotionLimiter) where {SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
 
-        # Partition UniqueCellsView into contiguous chunks and use the loop index `t`
-        # as a stable per-thread buffer index instead of Threads.threadid(),
-        # avoiding issues when tasks yield and migrate between threads.
-        N = length(UniqueCellsView)
+        N = length(Position)
         num_threads = Threads.nthreads()
         chunk_size = ceil(Int, N / num_threads)
 
         @inbounds Threads.@threads for t in 1:num_threads
             ichunk = t   # stable per-thread buffer index
-            start_iter = (t-1) * chunk_size + 1
-            end_iter = min(t * chunk_size, N)
+            start_idx = (t-1) * chunk_size + 1
+            end_idx = min(t * chunk_size, N)
 
-            for iter = start_iter:end_iter
-                CellIndex = UniqueCellsView[iter]
-                StartIndex = ParticleRanges[iter]
-                EndIndex = ParticleRanges[iter+1] - 1
+            for i in start_idx:end_idx
+                cell = SimParticles.Cells[i]
+                cell_idx = get(CellDict, cell, 1)
+                start_cell = ParticleRanges[cell_idx]
+                end_cell = ParticleRanges[cell_idx + 1] - 1
 
-                # (1) Interactions within same cell
-                @inbounds for i = StartIndex:EndIndex
-                    for j = (i+1):EndIndex
+                # Interactions inside the same cell, only forward to avoid double counting
+                for j = (i + 1):end_cell
+                    ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                         SimConstants, SimParticles, SimThreadedArrays,
+                                         Position, Density, Pressure, Velocity,
+                                         i, j, MotionLimiter, ichunk)
+                end
+
+                # Interactions with neighboring cells
+                for S in Stencil
+                    n_cell = cell + S
+                    n_idx = get(CellDict, n_cell, 1)
+                    n_start = ParticleRanges[n_idx]
+                    n_end = ParticleRanges[n_idx + 1] - 1
+
+                    for j = n_start:n_end
                         ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                                              SimConstants, SimParticles, SimThreadedArrays,
                                              Position, Density, Pressure, Velocity,
                                              i, j, MotionLimiter, ichunk)
-                    end
-                end
-
-                # (2) Interactions with neighboring cells
-                @inbounds for S in Stencil
-                    SCellIndex = CellIndex + S
-                    NeighborIdx = get(CellDict, SCellIndex, 1)
-                    StartIndex_ = ParticleRanges[NeighborIdx]
-                    EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
-
-                    for i = StartIndex:EndIndex
-                        for j = StartIndex_:EndIndex_
-                            ComputeInteractions!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                                                 SimConstants, SimParticles, SimThreadedArrays,
-                                                 Position, Density, Pressure, Velocity,
-                                                 i, j, MotionLimiter, ichunk)
-                        end
                     end
                 end
             end
@@ -314,7 +341,8 @@ using LinearAlgebra
 
             
             KernelOutput!(SimMetaData, SimKernel, SimThreadedArrays, q, ∇ᵢWᵢⱼ, i, j, ichunk)
-            add_shifting_terms!(SimMetaData, SimThreadedArrays, MotionLimiter, xᵢⱼ, ∇ᵢWᵢⱼ, m₀, ρᵢ, ρⱼ, i, j, ichunk)
+            Δ∇Cᵢ, Δ∇Cⱼ, Δ∇◌rᵢ, Δ∇◌rⱼ = add_shifting_terms_single!(SimMetaData, MotionLimiter, xᵢⱼ, ∇ᵢWᵢⱼ, m₀, ρᵢ, ρⱼ, i, j)
+            record_shifting!(SimMetaData, SimThreadedArrays, i, j, Δ∇Cᵢ, Δ∇Cⱼ, Δ∇◌rᵢ, Δ∇◌rⱼ, ichunk)
         end
 
         return nothing
@@ -384,6 +412,25 @@ using LinearAlgebra
         end
     end
 
+    # Overwrite the target array with the elementwise sum of all threaded arrays,
+    # avoiding a prior zeroing pass.
+    function overwrite_sum!(target_array, arrays)
+        n = length(target_array)
+        num_threads = nthreads()
+        chunk_size = ceil(Int, n / num_threads)
+        @inbounds @threads for t in 1:num_threads
+            local start_idx = 1 + (t-1) * chunk_size
+            local end_idx = min(t * chunk_size, n)
+            @simd ivdep for i in start_idx:end_idx
+                acc = zero(target_array[i])
+                @inbounds for j in eachindex(arrays)
+                    acc += arrays[j][i]
+                end
+                target_array[i] = acc
+            end
+        end
+    end
+
     # Zero arrays related to shifting depending on the selected mode.
     function zero_shifting_arrays!(::SimulationMetaData{D,T,NoShifting,K,B,L}, _...) where {D,T,
                                                                                            K<:KernelOutputMode,
@@ -418,14 +465,10 @@ using LinearAlgebra
     end
 
     function ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
-        # Threaded zeroing for main arrays
-        @threads for arr in (dρdtI, Acceleration)
-            fill!(arr, zero(eltype(arr)))
-        end
+        # Clear per-thread buffers; main arrays will be overwritten by reduction.
         zero_kernel_arrays!(SimMetaData, Kernel, KernelGradient)
         zero_shifting_arrays!(SimMetaData, ∇Cᵢ, ∇◌rᵢ)
 
-        # Threaded zeroing for fields in SimThreadedArrays
         foreachfield(f -> begin
             Threads.@threads for v in f
                 fill!(v, zero(eltype(v)))
@@ -445,8 +488,8 @@ using LinearAlgebra
                                                                                                            K<:KernelOutputMode,
                                                                                                            B<:MDBCMode,
                                                                                                            L<:LogMode}
-        reduce_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded)
-        reduce_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded)
+        overwrite_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded)
+        overwrite_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded)
         return nothing
     end
 
@@ -472,14 +515,14 @@ using LinearAlgebra
                                                                                                                      K<:KernelOutputMode,
                                                                                                                      B<:MDBCMode,
                                                                                                                      L<:LogMode}
-        reduce_sum!(Kernel, SimThreadedArrays.KernelThreaded)
-        reduce_sum!(KernelGradient, SimThreadedArrays.KernelGradientThreaded)
+        overwrite_sum!(Kernel, SimThreadedArrays.KernelThreaded)
+        overwrite_sum!(KernelGradient, SimThreadedArrays.KernelGradientThreaded)
         return nothing
     end
 
     function ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
-        reduce_sum!(dρdtI, SimThreadedArrays.dρdtIThreaded)
-        reduce_sum!(Acceleration, SimThreadedArrays.AccelerationThreaded)
+        overwrite_sum!(dρdtI, SimThreadedArrays.dρdtIThreaded)
+        overwrite_sum!(Acceleration, SimThreadedArrays.AccelerationThreaded)
 
         reduce_kernel_arrays!(SimMetaData, Kernel, KernelGradient, SimThreadedArrays)
         reduce_shifting_arrays!(SimMetaData, ∇Cᵢ, ∇◌rᵢ, SimThreadedArrays)
@@ -775,7 +818,7 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
                 @timeit SimMetaData.HourGlass "04 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType)
 
-                @timeit SimMetaData.HourGlass "05 First NeighborLoop"                    NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Position, Density, Pressure, Velocity, MotionLimiter, UniqueCellsView)
+                @timeit SimMetaData.HourGlass "05 First NeighborLoop"                    NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Position, Density, Pressure, Velocity, MotionLimiter)
                 @timeit SimMetaData.HourGlass "Reduction"                                ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
 
 
@@ -791,7 +834,7 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(Position, Velocity, ParticleType, ParticleMarker, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
-                @timeit SimMetaData.HourGlass "08 Second NeighborLoop"                   NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺, MotionLimiter, UniqueCellsView)
+                @timeit SimMetaData.HourGlass "08 Second NeighborLoop"                   NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺, MotionLimiter)
                 @timeit SimMetaData.HourGlass "Reduction"                                ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
 
             

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -42,6 +42,15 @@ using LinearAlgebra
         return n
     end
 
+    @inline function reset_touched!(data::Vector{T}, touched::Vector{Int}, mask::BitVector) where T
+        @inbounds for idx in touched
+            data[idx] = zero(T)
+            mask[idx] = false
+        end
+        empty!(touched)
+        return nothing
+    end
+
     """
     Extracts the cells for each particle based on their positions and the inverse cutoff value.
 
@@ -58,6 +67,20 @@ using LinearAlgebra
         # Consider -1.7 + 0.5, this would give -1.2 and then trunced 1, but we want -2, therefore absolute addition before hand
         # We add 0.5 instead of 1, to ensure proper rounding behavior when restoring the sign for negative numbers.
         Int(sign(x)) * unsafe_trunc(Int, muladd(abs(x),InverseCutOff,0.5))
+    end
+
+    @inline function mark_touched!(touched::Vector{Int}, mask::BitVector, idx::Int)
+        if !@inbounds mask[idx]
+            @inbounds mask[idx] = true
+            push!(touched, idx)
+        end
+        return nothing
+    end
+
+    @inline function mark_pair!(touched::Vector{Int}, mask::BitVector, i::Int, j::Int)
+        mark_touched!(touched, mask, i)
+        mark_touched!(touched, mask, j)
+        return nothing
     end
 
     # Add contributions related to particle shifting. Dispatch on `SimulationMetaData`
@@ -100,6 +123,8 @@ using LinearAlgebra
                                                                                                    K<:KernelOutputMode,
                                                                                                    B<:MDBCMode,
                                                                                                    L<:LogMode}
+        mark_pair!(SimThreadedArrays.∇CᵢTouched[ichunk], SimThreadedArrays.∇CᵢMask[ichunk], i, j)
+        mark_pair!(SimThreadedArrays.∇◌rᵢTouched[ichunk], SimThreadedArrays.∇◌rᵢMask[ichunk], i, j)
         SimThreadedArrays.∇CᵢThreaded[ichunk][i]   += Δ∇Cᵢ
         SimThreadedArrays.∇CᵢThreaded[ichunk][j]   += Δ∇Cⱼ
         SimThreadedArrays.∇◌rᵢThreaded[ichunk][i]  += Δ∇◌rᵢ
@@ -142,8 +167,10 @@ using LinearAlgebra
                                                                                                    B<:MDBCMode,
                                                                                                    L<:LogMode}
         Wᵢⱼ, ∇Wᵢⱼ = kernel_contribution(SimMetaData, SimKernel, q, ∇ᵢWᵢⱼ)
+        mark_pair!(SimThreadedArrays.KernelTouched[ichunk], SimThreadedArrays.KernelMask[ichunk], i, j)
         SimThreadedArrays.KernelThreaded[ichunk][i]         += Wᵢⱼ
         SimThreadedArrays.KernelThreaded[ichunk][j]         += Wᵢⱼ
+        mark_pair!(SimThreadedArrays.KernelGradientTouched[ichunk], SimThreadedArrays.KernelGradientMask[ichunk], i, j)
         SimThreadedArrays.KernelGradientThreaded[ichunk][i] +=  ∇Wᵢⱼ
         SimThreadedArrays.KernelGradientThreaded[ichunk][j] += -∇Wᵢⱼ
         return nothing
@@ -323,6 +350,7 @@ using LinearAlgebra
 
             Dᵢ, Dⱼ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, xᵢⱼ², i, j, MotionLimiter)
 
+            mark_pair!(SimThreadedArrays.dρdtITouched[ichunk], SimThreadedArrays.dρdtIMask[ichunk], i, j)
             SimThreadedArrays.dρdtIThreaded[ichunk][i] += dρdt⁺ + Dᵢ
             SimThreadedArrays.dρdtIThreaded[ichunk][j] += dρdt⁻ + Dⱼ
 
@@ -336,6 +364,7 @@ using LinearAlgebra
             visc_term, _ = compute_viscosity(SimViscosity, SimKernel, SimConstants, SimParticles, xᵢⱼ, vᵢⱼ, ∇ᵢWᵢⱼ, xᵢⱼ², i, j)
 
             uₘ = dvdt⁺ + visc_term
+            mark_pair!(SimThreadedArrays.AccelerationTouched[ichunk], SimThreadedArrays.AccelerationMask[ichunk], i, j)
             SimThreadedArrays.AccelerationThreaded[ichunk][i] += uₘ
             SimThreadedArrays.AccelerationThreaded[ichunk][j] -= uₘ 
 
@@ -412,68 +441,152 @@ using LinearAlgebra
         end
     end
 
-    # Overwrite the target array with the elementwise sum of all threaded arrays,
-    # avoiding a prior zeroing pass.
-    function overwrite_sum!(target_array, arrays)
-        n = length(target_array)
-        num_threads = nthreads()
-        chunk_size = ceil(Int, n / num_threads)
-        @inbounds @threads for t in 1:num_threads
-            local start_idx = 1 + (t-1) * chunk_size
-            local end_idx = min(t * chunk_size, n)
-            @simd ivdep for i in start_idx:end_idx
-                acc = zero(target_array[i])
-                @inbounds for j in eachindex(arrays)
-                    acc += arrays[j][i]
+    # Overwrite only touched entries in the target array with sums from the
+    # corresponding threaded arrays, avoiding full-array resets.
+    function reduce_sum!(target_array, arrays, touched)
+        zeroed = falses(length(target_array))
+        @inbounds for j in eachindex(arrays)
+            local array = arrays[j]
+            local touched_indices = touched[j]
+            for idx in touched_indices
+                if !zeroed[idx]
+                    target_array[idx] = zero(target_array[idx])
+                    zeroed[idx] = true
                 end
-                target_array[i] = acc
+                target_array[idx] += array[idx]
             end
         end
+        return nothing
     end
 
-    # Zero arrays related to shifting depending on the selected mode.
+    # Zero only touched entries for kernel and shifting arrays depending on mode.
     function zero_shifting_arrays!(::SimulationMetaData{D,T,NoShifting,K,B,L}, _...) where {D,T,
                                                                                            K<:KernelOutputMode,
                                                                                            B<:MDBCMode,
                                                                                            L<:LogMode}
         return nothing
     end
-    function zero_shifting_arrays!(::SimulationMetaData{D,T,S,K,B,L}, arrays...) where {D,T,S<:ShiftingMode,
-                                                                                       K<:KernelOutputMode,
-                                                                                       B<:MDBCMode,
-                                                                                       L<:LogMode}
-        @threads for arr in arrays
-            fill!(arr, zero(eltype(arr)))
+    function zero_shifting_arrays!(::SimulationMetaData{D,T,S,K,B,L}, targets..., touched) where {D,T,S<:ShiftingMode,
+                                                                                                 K<:KernelOutputMode,
+                                                                                                 B<:MDBCMode,
+                                                                                                 L<:LogMode}
+        zeroed = falses(length(first(targets)))
+        @inbounds for j in eachindex(touched)
+            for idx in touched[j]
+                if !zeroed[idx]
+                    for tgt in targets
+                        tgt[idx] = zero(eltype(tgt))
+                    end
+                    zeroed[idx] = true
+                end
+            end
         end
         return nothing
     end
 
-    # Zero arrays related to kernel output depending on the selected mode.
     function zero_kernel_arrays!(::SimulationMetaData{D,T,S,NoKernelOutput,B,L}, _...) where {D,T,S<:ShiftingMode,
                                                                                              B<:MDBCMode,
                                                                                              L<:LogMode}
         return nothing
     end
-    function zero_kernel_arrays!(::SimulationMetaData{D,T,S,K,B,L}, arrays...) where {D,T,S<:ShiftingMode,
-                                                                                     K<:KernelOutputMode,
-                                                                                     B<:MDBCMode,
-                                                                                     L<:LogMode}
-        @threads for arr in arrays
-            fill!(arr, zero(eltype(arr)))
+    function zero_kernel_arrays!(::SimulationMetaData{D,T,S,K,B,L}, targets..., touched) where {D,T,S<:ShiftingMode,
+                                                                                               K<:KernelOutputMode,
+                                                                                               B<:MDBCMode,
+                                                                                               L<:LogMode}
+        zeroed = falses(length(first(targets)))
+        @inbounds for j in eachindex(touched)
+            for idx in touched[j]
+                if !zeroed[idx]
+                    for tgt in targets
+                        tgt[idx] = zero(eltype(tgt))
+                    end
+                    zeroed[idx] = true
+                end
+            end
         end
         return nothing
     end
 
-    function ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
-        # Clear per-thread buffers; main arrays will be overwritten by reduction.
-        zero_kernel_arrays!(SimMetaData, Kernel, KernelGradient)
-        zero_shifting_arrays!(SimMetaData, ∇Cᵢ, ∇◌rᵢ)
-
-        foreachfield(f -> begin
-            Threads.@threads for v in f
-                fill!(v, zero(eltype(v)))
+    function zero_target_touched!(target, touched_lists)
+        zeroed = falses(length(target))
+        @inbounds for lst in touched_lists
+            for idx in lst
+                if !zeroed[idx]
+                    target[idx] = zero(eltype(target))
+                    zeroed[idx] = true
+                end
             end
-        end, SimThreadedArrays)
+        end
+        return nothing
+    end
+
+    function reset_threaded_kernel_arrays!(::SimulationMetaData{D,T,S,NoKernelOutput,B,L}, _) where {D,T,S<:ShiftingMode,
+                                                                                                     B<:MDBCMode,
+                                                                                                     L<:LogMode}
+        return nothing
+    end
+    function reset_threaded_kernel_arrays!(::SimulationMetaData{D,T,S,K,B,L}, SimThreadedArrays) where {D,T,S<:ShiftingMode,
+                                                                                                       K<:KernelOutputMode,
+                                                                                                       B<:MDBCMode,
+                                                                                                       L<:LogMode}
+        @threads for idx in eachindex(SimThreadedArrays.KernelThreaded)
+            reset_touched!(SimThreadedArrays.KernelThreaded[idx],
+                           SimThreadedArrays.KernelTouched[idx],
+                           SimThreadedArrays.KernelMask[idx])
+            reset_touched!(SimThreadedArrays.KernelGradientThreaded[idx],
+                           SimThreadedArrays.KernelGradientTouched[idx],
+                           SimThreadedArrays.KernelGradientMask[idx])
+        end
+        return nothing
+    end
+
+    function reset_threaded_shifting_arrays!(::SimulationMetaData{D,T,NoShifting,K,B,L}, _) where {D,T,
+                                                                                                   K<:KernelOutputMode,
+                                                                                                   B<:MDBCMode,
+                                                                                                   L<:LogMode}
+        return nothing
+    end
+    function reset_threaded_shifting_arrays!(::SimulationMetaData{D,T,S,K,B,L},
+                                             SimThreadedArrays) where {D,T,S<:ShiftingMode,
+                                                                       K<:KernelOutputMode,
+                                                                       B<:MDBCMode,
+                                                                       L<:LogMode}
+        @threads for idx in eachindex(SimThreadedArrays.∇CᵢThreaded)
+            reset_touched!(SimThreadedArrays.∇CᵢThreaded[idx],
+                           SimThreadedArrays.∇CᵢTouched[idx],
+                           SimThreadedArrays.∇CᵢMask[idx])
+            reset_touched!(SimThreadedArrays.∇◌rᵢThreaded[idx],
+                           SimThreadedArrays.∇◌rᵢTouched[idx],
+                           SimThreadedArrays.∇◌rᵢMask[idx])
+        end
+        return nothing
+    end
+
+    function reset_threaded_arrays!(SimMetaData, SimThreadedArrays)
+        @threads for idx in eachindex(SimThreadedArrays.dρdtIThreaded)
+            reset_touched!(SimThreadedArrays.dρdtIThreaded[idx],
+                           SimThreadedArrays.dρdtITouched[idx],
+                           SimThreadedArrays.dρdtIMask[idx])
+            reset_touched!(SimThreadedArrays.AccelerationThreaded[idx],
+                           SimThreadedArrays.AccelerationTouched[idx],
+                           SimThreadedArrays.AccelerationMask[idx])
+        end
+        reset_threaded_kernel_arrays!(SimMetaData, SimThreadedArrays)
+        reset_threaded_shifting_arrays!(SimMetaData, SimThreadedArrays)
+        return nothing
+    end
+
+    function ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
+        # Zero only components that were touched in the previous interaction sweep.
+        zero_target_touched!(dρdtI, SimThreadedArrays.dρdtITouched)
+        zero_target_touched!(Acceleration, SimThreadedArrays.AccelerationTouched)
+
+        zero_kernel_arrays!(SimMetaData, Kernel, SimThreadedArrays.KernelTouched)
+        zero_kernel_arrays!(SimMetaData, KernelGradient, SimThreadedArrays.KernelGradientTouched)
+        zero_shifting_arrays!(SimMetaData, ∇Cᵢ, SimThreadedArrays.∇CᵢTouched)
+        zero_shifting_arrays!(SimMetaData, ∇◌rᵢ, SimThreadedArrays.∇◌rᵢTouched)
+
+        reset_threaded_arrays!(SimMetaData, SimThreadedArrays)
 
         return nothing
     end
@@ -488,8 +601,8 @@ using LinearAlgebra
                                                                                                            K<:KernelOutputMode,
                                                                                                            B<:MDBCMode,
                                                                                                            L<:LogMode}
-        overwrite_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded)
-        overwrite_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded)
+        reduce_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded, SimThreadedArrays.∇CᵢTouched)
+        reduce_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded, SimThreadedArrays.∇◌rᵢTouched)
         return nothing
     end
 
@@ -515,14 +628,14 @@ using LinearAlgebra
                                                                                                                      K<:KernelOutputMode,
                                                                                                                      B<:MDBCMode,
                                                                                                                      L<:LogMode}
-        overwrite_sum!(Kernel, SimThreadedArrays.KernelThreaded)
-        overwrite_sum!(KernelGradient, SimThreadedArrays.KernelGradientThreaded)
+        reduce_sum!(Kernel, SimThreadedArrays.KernelThreaded, SimThreadedArrays.KernelTouched)
+        reduce_sum!(KernelGradient, SimThreadedArrays.KernelGradientThreaded, SimThreadedArrays.KernelGradientTouched)
         return nothing
     end
 
     function ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
-        overwrite_sum!(dρdtI, SimThreadedArrays.dρdtIThreaded)
-        overwrite_sum!(Acceleration, SimThreadedArrays.AccelerationThreaded)
+        reduce_sum!(dρdtI, SimThreadedArrays.dρdtIThreaded, SimThreadedArrays.dρdtITouched)
+        reduce_sum!(Acceleration, SimThreadedArrays.AccelerationThreaded, SimThreadedArrays.AccelerationTouched)
 
         reduce_kernel_arrays!(SimMetaData, Kernel, KernelGradient, SimThreadedArrays)
         reduce_shifting_arrays!(SimMetaData, ∇Cᵢ, ∇◌rᵢ, SimThreadedArrays)

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -42,15 +42,6 @@ using LinearAlgebra
         return n
     end
 
-    @inline function reset_touched!(data::Vector{T}, touched::Vector{Int}, mask::BitVector) where T
-        @inbounds for idx in touched
-            data[idx] = zero(T)
-            mask[idx] = false
-        end
-        empty!(touched)
-        return nothing
-    end
-
     """
     Extracts the cells for each particle based on their positions and the inverse cutoff value.
 
@@ -67,20 +58,6 @@ using LinearAlgebra
         # Consider -1.7 + 0.5, this would give -1.2 and then trunced 1, but we want -2, therefore absolute addition before hand
         # We add 0.5 instead of 1, to ensure proper rounding behavior when restoring the sign for negative numbers.
         Int(sign(x)) * unsafe_trunc(Int, muladd(abs(x),InverseCutOff,0.5))
-    end
-
-    @inline function mark_touched!(touched::Vector{Int}, mask::BitVector, idx::Int)
-        if !@inbounds mask[idx]
-            @inbounds mask[idx] = true
-            push!(touched, idx)
-        end
-        return nothing
-    end
-
-    @inline function mark_pair!(touched::Vector{Int}, mask::BitVector, i::Int, j::Int)
-        mark_touched!(touched, mask, i)
-        mark_touched!(touched, mask, j)
-        return nothing
     end
 
     # Add contributions related to particle shifting. Dispatch on `SimulationMetaData`
@@ -123,8 +100,6 @@ using LinearAlgebra
                                                                                                    K<:KernelOutputMode,
                                                                                                    B<:MDBCMode,
                                                                                                    L<:LogMode}
-        mark_pair!(SimThreadedArrays.∇CᵢTouched[ichunk], SimThreadedArrays.∇CᵢMask[ichunk], i, j)
-        mark_pair!(SimThreadedArrays.∇◌rᵢTouched[ichunk], SimThreadedArrays.∇◌rᵢMask[ichunk], i, j)
         SimThreadedArrays.∇CᵢThreaded[ichunk][i]   += Δ∇Cᵢ
         SimThreadedArrays.∇CᵢThreaded[ichunk][j]   += Δ∇Cⱼ
         SimThreadedArrays.∇◌rᵢThreaded[ichunk][i]  += Δ∇◌rᵢ
@@ -167,10 +142,8 @@ using LinearAlgebra
                                                                                                    B<:MDBCMode,
                                                                                                    L<:LogMode}
         Wᵢⱼ, ∇Wᵢⱼ = kernel_contribution(SimMetaData, SimKernel, q, ∇ᵢWᵢⱼ)
-        mark_pair!(SimThreadedArrays.KernelTouched[ichunk], SimThreadedArrays.KernelMask[ichunk], i, j)
         SimThreadedArrays.KernelThreaded[ichunk][i]         += Wᵢⱼ
         SimThreadedArrays.KernelThreaded[ichunk][j]         += Wᵢⱼ
-        mark_pair!(SimThreadedArrays.KernelGradientTouched[ichunk], SimThreadedArrays.KernelGradientMask[ichunk], i, j)
         SimThreadedArrays.KernelGradientThreaded[ichunk][i] +=  ∇Wᵢⱼ
         SimThreadedArrays.KernelGradientThreaded[ichunk][j] += -∇Wᵢⱼ
         return nothing
@@ -350,7 +323,6 @@ using LinearAlgebra
 
             Dᵢ, Dⱼ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, xᵢⱼ², i, j, MotionLimiter)
 
-            mark_pair!(SimThreadedArrays.dρdtITouched[ichunk], SimThreadedArrays.dρdtIMask[ichunk], i, j)
             SimThreadedArrays.dρdtIThreaded[ichunk][i] += dρdt⁺ + Dᵢ
             SimThreadedArrays.dρdtIThreaded[ichunk][j] += dρdt⁻ + Dⱼ
 
@@ -364,7 +336,6 @@ using LinearAlgebra
             visc_term, _ = compute_viscosity(SimViscosity, SimKernel, SimConstants, SimParticles, xᵢⱼ, vᵢⱼ, ∇ᵢWᵢⱼ, xᵢⱼ², i, j)
 
             uₘ = dvdt⁺ + visc_term
-            mark_pair!(SimThreadedArrays.AccelerationTouched[ichunk], SimThreadedArrays.AccelerationMask[ichunk], i, j)
             SimThreadedArrays.AccelerationThreaded[ichunk][i] += uₘ
             SimThreadedArrays.AccelerationThreaded[ichunk][j] -= uₘ 
 
@@ -441,152 +412,68 @@ using LinearAlgebra
         end
     end
 
-    # Overwrite only touched entries in the target array with sums from the
-    # corresponding threaded arrays, avoiding full-array resets.
-    function reduce_sum!(target_array, arrays, touched)
-        zeroed = falses(length(target_array))
-        @inbounds for j in eachindex(arrays)
-            local array = arrays[j]
-            local touched_indices = touched[j]
-            for idx in touched_indices
-                if !zeroed[idx]
-                    target_array[idx] = zero(target_array[idx])
-                    zeroed[idx] = true
+    # Overwrite the target array with the elementwise sum of all threaded arrays,
+    # avoiding a prior zeroing pass.
+    function overwrite_sum!(target_array, arrays)
+        n = length(target_array)
+        num_threads = nthreads()
+        chunk_size = ceil(Int, n / num_threads)
+        @inbounds @threads for t in 1:num_threads
+            local start_idx = 1 + (t-1) * chunk_size
+            local end_idx = min(t * chunk_size, n)
+            @simd ivdep for i in start_idx:end_idx
+                acc = zero(target_array[i])
+                @inbounds for j in eachindex(arrays)
+                    acc += arrays[j][i]
                 end
-                target_array[idx] += array[idx]
+                target_array[i] = acc
             end
         end
-        return nothing
     end
 
-    # Zero only touched entries for kernel and shifting arrays depending on mode.
+    # Zero arrays related to shifting depending on the selected mode.
     function zero_shifting_arrays!(::SimulationMetaData{D,T,NoShifting,K,B,L}, _...) where {D,T,
                                                                                            K<:KernelOutputMode,
                                                                                            B<:MDBCMode,
                                                                                            L<:LogMode}
         return nothing
     end
-    function zero_shifting_arrays!(::SimulationMetaData{D,T,S,K,B,L}, targets..., touched) where {D,T,S<:ShiftingMode,
-                                                                                                 K<:KernelOutputMode,
-                                                                                                 B<:MDBCMode,
-                                                                                                 L<:LogMode}
-        zeroed = falses(length(first(targets)))
-        @inbounds for j in eachindex(touched)
-            for idx in touched[j]
-                if !zeroed[idx]
-                    for tgt in targets
-                        tgt[idx] = zero(eltype(tgt))
-                    end
-                    zeroed[idx] = true
-                end
-            end
+    function zero_shifting_arrays!(::SimulationMetaData{D,T,S,K,B,L}, arrays...) where {D,T,S<:ShiftingMode,
+                                                                                       K<:KernelOutputMode,
+                                                                                       B<:MDBCMode,
+                                                                                       L<:LogMode}
+        @threads for arr in arrays
+            fill!(arr, zero(eltype(arr)))
         end
         return nothing
     end
 
+    # Zero arrays related to kernel output depending on the selected mode.
     function zero_kernel_arrays!(::SimulationMetaData{D,T,S,NoKernelOutput,B,L}, _...) where {D,T,S<:ShiftingMode,
                                                                                              B<:MDBCMode,
                                                                                              L<:LogMode}
         return nothing
     end
-    function zero_kernel_arrays!(::SimulationMetaData{D,T,S,K,B,L}, targets..., touched) where {D,T,S<:ShiftingMode,
-                                                                                               K<:KernelOutputMode,
-                                                                                               B<:MDBCMode,
-                                                                                               L<:LogMode}
-        zeroed = falses(length(first(targets)))
-        @inbounds for j in eachindex(touched)
-            for idx in touched[j]
-                if !zeroed[idx]
-                    for tgt in targets
-                        tgt[idx] = zero(eltype(tgt))
-                    end
-                    zeroed[idx] = true
-                end
-            end
+    function zero_kernel_arrays!(::SimulationMetaData{D,T,S,K,B,L}, arrays...) where {D,T,S<:ShiftingMode,
+                                                                                     K<:KernelOutputMode,
+                                                                                     B<:MDBCMode,
+                                                                                     L<:LogMode}
+        @threads for arr in arrays
+            fill!(arr, zero(eltype(arr)))
         end
-        return nothing
-    end
-
-    function zero_target_touched!(target, touched_lists)
-        zeroed = falses(length(target))
-        @inbounds for lst in touched_lists
-            for idx in lst
-                if !zeroed[idx]
-                    target[idx] = zero(eltype(target))
-                    zeroed[idx] = true
-                end
-            end
-        end
-        return nothing
-    end
-
-    function reset_threaded_kernel_arrays!(::SimulationMetaData{D,T,S,NoKernelOutput,B,L}, _) where {D,T,S<:ShiftingMode,
-                                                                                                     B<:MDBCMode,
-                                                                                                     L<:LogMode}
-        return nothing
-    end
-    function reset_threaded_kernel_arrays!(::SimulationMetaData{D,T,S,K,B,L}, SimThreadedArrays) where {D,T,S<:ShiftingMode,
-                                                                                                       K<:KernelOutputMode,
-                                                                                                       B<:MDBCMode,
-                                                                                                       L<:LogMode}
-        @threads for idx in eachindex(SimThreadedArrays.KernelThreaded)
-            reset_touched!(SimThreadedArrays.KernelThreaded[idx],
-                           SimThreadedArrays.KernelTouched[idx],
-                           SimThreadedArrays.KernelMask[idx])
-            reset_touched!(SimThreadedArrays.KernelGradientThreaded[idx],
-                           SimThreadedArrays.KernelGradientTouched[idx],
-                           SimThreadedArrays.KernelGradientMask[idx])
-        end
-        return nothing
-    end
-
-    function reset_threaded_shifting_arrays!(::SimulationMetaData{D,T,NoShifting,K,B,L}, _) where {D,T,
-                                                                                                   K<:KernelOutputMode,
-                                                                                                   B<:MDBCMode,
-                                                                                                   L<:LogMode}
-        return nothing
-    end
-    function reset_threaded_shifting_arrays!(::SimulationMetaData{D,T,S,K,B,L},
-                                             SimThreadedArrays) where {D,T,S<:ShiftingMode,
-                                                                       K<:KernelOutputMode,
-                                                                       B<:MDBCMode,
-                                                                       L<:LogMode}
-        @threads for idx in eachindex(SimThreadedArrays.∇CᵢThreaded)
-            reset_touched!(SimThreadedArrays.∇CᵢThreaded[idx],
-                           SimThreadedArrays.∇CᵢTouched[idx],
-                           SimThreadedArrays.∇CᵢMask[idx])
-            reset_touched!(SimThreadedArrays.∇◌rᵢThreaded[idx],
-                           SimThreadedArrays.∇◌rᵢTouched[idx],
-                           SimThreadedArrays.∇◌rᵢMask[idx])
-        end
-        return nothing
-    end
-
-    function reset_threaded_arrays!(SimMetaData, SimThreadedArrays)
-        @threads for idx in eachindex(SimThreadedArrays.dρdtIThreaded)
-            reset_touched!(SimThreadedArrays.dρdtIThreaded[idx],
-                           SimThreadedArrays.dρdtITouched[idx],
-                           SimThreadedArrays.dρdtIMask[idx])
-            reset_touched!(SimThreadedArrays.AccelerationThreaded[idx],
-                           SimThreadedArrays.AccelerationTouched[idx],
-                           SimThreadedArrays.AccelerationMask[idx])
-        end
-        reset_threaded_kernel_arrays!(SimMetaData, SimThreadedArrays)
-        reset_threaded_shifting_arrays!(SimMetaData, SimThreadedArrays)
         return nothing
     end
 
     function ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
-        # Zero only components that were touched in the previous interaction sweep.
-        zero_target_touched!(dρdtI, SimThreadedArrays.dρdtITouched)
-        zero_target_touched!(Acceleration, SimThreadedArrays.AccelerationTouched)
+        # Clear per-thread buffers; main arrays will be overwritten by reduction.
+        zero_kernel_arrays!(SimMetaData, Kernel, KernelGradient)
+        zero_shifting_arrays!(SimMetaData, ∇Cᵢ, ∇◌rᵢ)
 
-        zero_kernel_arrays!(SimMetaData, Kernel, SimThreadedArrays.KernelTouched)
-        zero_kernel_arrays!(SimMetaData, KernelGradient, SimThreadedArrays.KernelGradientTouched)
-        zero_shifting_arrays!(SimMetaData, ∇Cᵢ, SimThreadedArrays.∇CᵢTouched)
-        zero_shifting_arrays!(SimMetaData, ∇◌rᵢ, SimThreadedArrays.∇◌rᵢTouched)
-
-        reset_threaded_arrays!(SimMetaData, SimThreadedArrays)
+        foreachfield(f -> begin
+            Threads.@threads for v in f
+                fill!(v, zero(eltype(v)))
+            end
+        end, SimThreadedArrays)
 
         return nothing
     end
@@ -601,8 +488,8 @@ using LinearAlgebra
                                                                                                            K<:KernelOutputMode,
                                                                                                            B<:MDBCMode,
                                                                                                            L<:LogMode}
-        reduce_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded, SimThreadedArrays.∇CᵢTouched)
-        reduce_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded, SimThreadedArrays.∇◌rᵢTouched)
+        overwrite_sum!(∇Cᵢ, SimThreadedArrays.∇CᵢThreaded)
+        overwrite_sum!(∇◌rᵢ, SimThreadedArrays.∇◌rᵢThreaded)
         return nothing
     end
 
@@ -628,14 +515,14 @@ using LinearAlgebra
                                                                                                                      K<:KernelOutputMode,
                                                                                                                      B<:MDBCMode,
                                                                                                                      L<:LogMode}
-        reduce_sum!(Kernel, SimThreadedArrays.KernelThreaded, SimThreadedArrays.KernelTouched)
-        reduce_sum!(KernelGradient, SimThreadedArrays.KernelGradientThreaded, SimThreadedArrays.KernelGradientTouched)
+        overwrite_sum!(Kernel, SimThreadedArrays.KernelThreaded)
+        overwrite_sum!(KernelGradient, SimThreadedArrays.KernelGradientThreaded)
         return nothing
     end
 
     function ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
-        reduce_sum!(dρdtI, SimThreadedArrays.dρdtIThreaded, SimThreadedArrays.dρdtITouched)
-        reduce_sum!(Acceleration, SimThreadedArrays.AccelerationThreaded, SimThreadedArrays.AccelerationTouched)
+        overwrite_sum!(dρdtI, SimThreadedArrays.dρdtIThreaded)
+        overwrite_sum!(Acceleration, SimThreadedArrays.AccelerationThreaded)
 
         reduce_kernel_arrays!(SimMetaData, Kernel, KernelGradient, SimThreadedArrays)
         reduce_shifting_arrays!(SimMetaData, ∇Cᵢ, ∇◌rᵢ, SimThreadedArrays)

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -191,7 +191,7 @@ using LinearAlgebra
                 CellDict[Cells[i]]           = IndexCounter
             end
         end
-        ParticleRanges[IndexCounter + 1]  = length(ParticleRanges)
+        ParticleRanges[IndexCounter + 1]  = length(Cells) + 1
 
         return IndexCounter 
     end


### PR DESCRIPTION
## Summary
- switch neighbor traversal to per-particle chunks while preserving cell-based neighbor discovery
- accumulate kernel and shifting contributions with mode-specific no-ops to avoid unnecessary resets
- replace reduction with overwrite sums so main arrays no longer require pre-zeroing

## Testing
- Not run (no automated tests provided; repository currently lacks a test suite)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694aadfe718c832384b3f5308707730b)