### PR TITLE
Avoid per-neighbor self-checks and add per-particle interaction loop

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -1327,6 +1327,30 @@ using LinearAlgebra
         return Δx + 4*maxd
     end
 
+    """
+        update_local_delta_x!(Δx_local, posₙ⁺, pos, h)
+
+    Accumulate per-particle displacement since the last neighbor update and return
+    `true` when any particle exceeds `h`.
+    """
+    @inline function update_local_delta_x!(Δx_local::AbstractVector{T},
+                                           posₙ⁺::AbstractVector{SVector{D, T}},
+                                           pos   ::AbstractVector{SVector{D, T}},
+                                           h::T) where {D, T<:Real}
+        @inbounds for i in eachindex(posₙ⁺, pos, Δx_local)
+            sumsq = zero(T)
+            @inbounds for j in 1:D
+                d = posₙ⁺[i][j] - pos[i][j]
+                sumsq += d*d
+            end
+            Δx_local[i] += 4 * sqrt(sumsq)
+            if Δx_local[i] >= h
+                return true
+            end
+        end
+        return false
+    end
+
     
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
@@ -1344,12 +1368,13 @@ using LinearAlgebra
         ParticleMarker = GroupMarker
 
         ###
-        Δx = one(eltype(Density)) + SimKernel.h
+        Δx_local = SimMetaData.LocalΔx
         UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
 
             while SimMetaData.TotalTime <= next_output_time(SimMetaData)
 
-                Δx = update_delta_x!(Δx, Positionₙ⁺, SimParticles.Position)
+                ShouldRebuild = update_local_delta_x!(Δx_local, Positionₙ⁺,
+                                                    SimParticles.Position, SimKernel.h)
 
                 # println("Δx: ", Δx, "h: ", SimKernel.h," dt: ", SimMetaData.CurrentTimeStep, " Iteration: ", SimMetaData.Iteration, " TotalTime: ", SimMetaData.TotalTime, " OutputIterationCounter: ", SimMetaData.OutputIterationCounter)
 
@@ -1363,9 +1388,9 @@ using LinearAlgebra
                     # c₀ >= maximum(norm.(Velocity))
                     # Remove if statement logic if you want to update each iteration
                     # if mod(SimMetaData.Iteration, ceil(Int, SimKernel.H / (SimConstants.c₀ * dt * (1/SimConstants.CFL)) )) == 0 || SimMetaData.Iteration == 1
-                    if Δx >= SimKernel.h
+                    if ShouldRebuild
                         @timeit SimMetaData.HourGlass "02a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellDict)
-                        Δx = zero(eltype(Density))
+                        fill!(Δx_local, zero(eltype(Δx_local)))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
                         BuildNeighborCellLists!(neighbor_cell_lists, FullStencil,
                                                 UniqueCellsView, ParticleRanges,
@@ -1448,6 +1473,7 @@ using LinearAlgebra
         Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
     
         SimThreadedArrays = AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ)
+        SimMetaData.LocalΔx = zeros(eltype(dρdtI), NumberOfPoints)
     
         # Produce sorting related variables
         ParticleRanges         = zeros(Int, NumberOfPoints + 1 + 1) # +1 for the last particle, +1 for dummy entry

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -42,6 +42,10 @@ using LinearAlgebra
         return n
     end
 
+    function construct_full_stencil(v::Val{d}) where d
+        return CartesianIndices(ntuple(_->-1:1, v))
+    end
+
     """
     Extracts the cells for each particle based on their positions and the inverse cutoff value.
 
@@ -117,6 +121,23 @@ using LinearAlgebra
         SimThreadedArrays.KernelGradientThreaded[ichunk][i] +=  ∇ᵢWᵢⱼ
         SimThreadedArrays.KernelGradientThreaded[ichunk][j] += -∇ᵢWᵢⱼ
         return nothing
+    end
+
+    @inline function KernelOutputLocal!(::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
+                                        kernel_acc, kernel_grad_acc, SimKernel,
+                                        q, ∇ᵢWᵢⱼ) where {D,T,S<:ShiftingMode,
+                                                        B<:MDBCMode,
+                                                        L<:LogMode}
+        return kernel_acc, kernel_grad_acc
+    end
+
+    @inline function KernelOutputLocal!(::SimulationMetaData{D,T,S,StoreKernelOutput,B,L},
+                                        kernel_acc, kernel_grad_acc, SimKernel,
+                                        q, ∇ᵢWᵢⱼ) where {D,T,S<:ShiftingMode,
+                                                        B<:MDBCMode,
+                                                        L<:LogMode}
+        Wᵢⱼ  = @fastpow SPHKernels.Wᵢⱼ(SimKernel, q)
+        return kernel_acc + Wᵢⱼ, kernel_grad_acc + ∇ᵢWᵢⱼ
     end
    
     @inline function ExtractCells!(Particles, InverseCutOff)
@@ -224,6 +245,147 @@ using LinearAlgebra
         return nothing
     end
 
+    function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
+                                      SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L},
+                                      SimConstants, SimParticles, ParticleRanges,
+                                      CellDict, FullStencil, Position, Density,
+                                      Pressure, Velocity, MotionLimiter, dρdtI,
+                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
+                                      ∇◌rᵢ) where {D,T,K<:KernelOutputMode,
+                                                  B<:MDBCMode,L<:LogMode,
+                                                  SDD<:SPHDensityDiffusion,
+                                                  SV<:SPHViscosity}
+        Cells = SimParticles.Cells
+        @inbounds Threads.@threads for i in eachindex(Position)
+            dρdt_acc = zero(dρdtI[i])
+            acc_acc = zero(Acceleration[i])
+            kernel_acc = zero(Kernel[i])
+            kernel_grad_acc = zero(KernelGradient[i])
+            CellIndex = Cells[i]
+            CellListIndex = get(CellDict, CellIndex, 1)
+            SameCellStart = ParticleRanges[CellListIndex]
+            SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
+
+            for S in FullStencil
+                SCellIndex = CellIndex + S
+                NeighborIdx = get(CellDict, SCellIndex, 1)
+                StartIndex_ = ParticleRanges[NeighborIdx]
+                EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
+
+                if SCellIndex == CellIndex
+                    @inbounds for j in SameCellStart:(i - 1)
+                        dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc =
+                            ComputeInteractionsPerParticle!(
+                                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                SimConstants, SimParticles, Position, Density, Pressure,
+                                Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                                kernel_grad_acc, i, j,
+                            )
+                    end
+                    @inbounds for j in (i + 1):SameCellEnd
+                        dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc =
+                            ComputeInteractionsPerParticle!(
+                                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                SimConstants, SimParticles, Position, Density, Pressure,
+                                Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                                kernel_grad_acc, i, j,
+                            )
+                    end
+                else
+                    @inbounds for j in StartIndex_:EndIndex_
+                        dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc =
+                            ComputeInteractionsPerParticle!(
+                                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                SimConstants, SimParticles, Position, Density, Pressure,
+                                Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                                kernel_grad_acc, i, j,
+                            )
+                    end
+                end
+            end
+
+            dρdtI[i] = dρdt_acc
+            Acceleration[i] = acc_acc
+            Kernel[i] = kernel_acc
+            KernelGradient[i] = kernel_grad_acc
+        end
+
+        return nothing
+    end
+
+    function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
+                                      SimMetaData::SimulationMetaData{D,T,S,K,B,L},
+                                      SimConstants, SimParticles, ParticleRanges,
+                                      CellDict, FullStencil, Position, Density,
+                                      Pressure, Velocity, MotionLimiter, dρdtI,
+                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
+                                      ∇◌rᵢ) where {D,T,S<:ShiftingMode,
+                                                  K<:KernelOutputMode,
+                                                  B<:MDBCMode,L<:LogMode,
+                                                  SDD<:SPHDensityDiffusion,
+                                                  SV<:SPHViscosity}
+        Cells = SimParticles.Cells
+        @inbounds Threads.@threads for i in eachindex(Position)
+            dρdt_acc = zero(dρdtI[i])
+            acc_acc = zero(Acceleration[i])
+            kernel_acc = zero(Kernel[i])
+            kernel_grad_acc = zero(KernelGradient[i])
+            shift_c_acc = zero(∇Cᵢ[i])
+            shift_r_acc = zero(∇◌rᵢ[i])
+            CellIndex = Cells[i]
+            CellListIndex = get(CellDict, CellIndex, 1)
+            SameCellStart = ParticleRanges[CellListIndex]
+            SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
+
+            for S in FullStencil
+                SCellIndex = CellIndex + S
+                NeighborIdx = get(CellDict, SCellIndex, 1)
+                StartIndex_ = ParticleRanges[NeighborIdx]
+                EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
+
+                if SCellIndex == CellIndex
+                    @inbounds for j in SameCellStart:(i - 1)
+                        dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
+                        shift_r_acc = ComputeInteractionsPerParticle!(
+                            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                            SimConstants, SimParticles, Position, Density, Pressure,
+                            Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                            kernel_grad_acc, shift_c_acc, shift_r_acc, i, j,
+                        )
+                    end
+                    @inbounds for j in (i + 1):SameCellEnd
+                        dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
+                        shift_r_acc = ComputeInteractionsPerParticle!(
+                            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                            SimConstants, SimParticles, Position, Density, Pressure,
+                            Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                            kernel_grad_acc, shift_c_acc, shift_r_acc, i, j,
+                        )
+                    end
+                else
+                    @inbounds for j in StartIndex_:EndIndex_
+                        dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
+                        shift_r_acc = ComputeInteractionsPerParticle!(
+                            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                            SimConstants, SimParticles, Position, Density, Pressure,
+                            Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                            kernel_grad_acc, shift_c_acc, shift_r_acc, i, j,
+                        )
+                    end
+                end
+            end
+
+            dρdtI[i] = dρdt_acc
+            Acceleration[i] = acc_acc
+            Kernel[i] = kernel_acc
+            KernelGradient[i] = kernel_grad_acc
+            ∇Cᵢ[i] = shift_c_acc
+            ∇◌rᵢ[i] = shift_r_acc
+        end
+
+        return nothing
+    end
+
     f(SimKernel, GhostPoint) = CartesianIndex(map(x->map_floor(x,SimKernel.H⁻¹), Tuple(GhostPoint)))
     function NeighborLoopMDBC!(SimKernel,
                                SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
@@ -324,6 +486,121 @@ using LinearAlgebra
         end
 
         return nothing
+    end
+
+    Base.@propagate_inbounds function ComputeInteractionsPerParticle!(
+        SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
+        SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L}, SimConstants,
+        SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
+        dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, i, j) where {D,T,
+                                                                     K<:KernelOutputMode,
+                                                                     B<:MDBCMode,
+                                                                     L<:LogMode,
+                                                                     SDD<:SPHDensityDiffusion,
+                                                                     SV<:SPHViscosity}
+        @unpack m₀, dx = SimConstants
+        @unpack h⁻¹, H² = SimKernel
+
+        xᵢⱼ = Position[i] - Position[j]
+        xᵢⱼ² = dot(xᵢⱼ, xᵢⱼ)
+        if xᵢⱼ² <= H²
+            dᵢⱼ = sqrt(abs(xᵢⱼ²))
+            q = clamp(dᵢⱼ * h⁻¹, 0.0, 2.0)
+            ∇ᵢWᵢⱼ = @fastpow ∇Wᵢⱼ(SimKernel, q, xᵢⱼ)
+
+            ρᵢ = Density[i]
+            ρⱼ = Density[j]
+
+            vᵢ = Velocity[i]
+            vⱼ = Velocity[j]
+            vᵢⱼ = vᵢ - vⱼ
+            density_symmetric_term = dot(-vᵢⱼ, ∇ᵢWᵢⱼ)
+            dρdt⁺ = -ρᵢ * (m₀ / ρⱼ) * density_symmetric_term
+
+            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel,
+                                              SimConstants, SimParticles, xᵢⱼ,
+                                              ∇ᵢWᵢⱼ, xᵢⱼ², i, j, MotionLimiter)
+
+            dρdt_acc += dρdt⁺ + Dᵢ
+
+            Pᵢ = Pressure[i]
+            Pⱼ = Pressure[j]
+            Pfac = (Pᵢ + Pⱼ) / (ρᵢ * ρⱼ)
+            f_ab = tensile_correction(SimKernel, Pᵢ, ρᵢ, Pⱼ, ρⱼ, q, dx)
+            dvdt⁺ = -m₀ * (Pfac + f_ab) * ∇ᵢWᵢⱼ
+
+            visc_term, _ = compute_viscosity(SimViscosity, SimKernel, SimConstants,
+                                             SimParticles, xᵢⱼ, vᵢⱼ, ∇ᵢWᵢⱼ,
+                                             xᵢⱼ², i, j)
+
+            acc_acc += dvdt⁺ + visc_term
+
+            kernel_acc, kernel_grad_acc =
+                KernelOutputLocal!(SimMetaData, kernel_acc, kernel_grad_acc,
+                                   SimKernel, q, ∇ᵢWᵢⱼ)
+        end
+
+        return dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc
+    end
+
+    Base.@propagate_inbounds function ComputeInteractionsPerParticle!(
+        SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
+        SimMetaData::SimulationMetaData{D,T,S,K,B,L}, SimConstants,
+        SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
+        dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
+        shift_r_acc, i, j) where {D,T,S<:ShiftingMode,
+                                  K<:KernelOutputMode,
+                                  B<:MDBCMode,
+                                  L<:LogMode,
+                                  SDD<:SPHDensityDiffusion,
+                                  SV<:SPHViscosity}
+        @unpack m₀, dx = SimConstants
+        @unpack h⁻¹, H² = SimKernel
+
+        xᵢⱼ = Position[i] - Position[j]
+        xᵢⱼ² = dot(xᵢⱼ, xᵢⱼ)
+        if xᵢⱼ² <= H²
+            dᵢⱼ = sqrt(abs(xᵢⱼ²))
+            q = clamp(dᵢⱼ * h⁻¹, 0.0, 2.0)
+            ∇ᵢWᵢⱼ = @fastpow ∇Wᵢⱼ(SimKernel, q, xᵢⱼ)
+
+            ρᵢ = Density[i]
+            ρⱼ = Density[j]
+
+            vᵢ = Velocity[i]
+            vⱼ = Velocity[j]
+            vᵢⱼ = vᵢ - vⱼ
+            density_symmetric_term = dot(-vᵢⱼ, ∇ᵢWᵢⱼ)
+            dρdt⁺ = -ρᵢ * (m₀ / ρⱼ) * density_symmetric_term
+
+            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel,
+                                              SimConstants, SimParticles, xᵢⱼ,
+                                              ∇ᵢWᵢⱼ, xᵢⱼ², i, j, MotionLimiter)
+
+            dρdt_acc += dρdt⁺ + Dᵢ
+
+            Pᵢ = Pressure[i]
+            Pⱼ = Pressure[j]
+            Pfac = (Pᵢ + Pⱼ) / (ρᵢ * ρⱼ)
+            f_ab = tensile_correction(SimKernel, Pᵢ, ρᵢ, Pⱼ, ρⱼ, q, dx)
+            dvdt⁺ = -m₀ * (Pfac + f_ab) * ∇ᵢWᵢⱼ
+
+            visc_term, _ = compute_viscosity(SimViscosity, SimKernel, SimConstants,
+                                             SimParticles, xᵢⱼ, vᵢⱼ, ∇ᵢWᵢⱼ,
+                                             xᵢⱼ², i, j)
+
+            acc_acc += dvdt⁺ + visc_term
+
+            kernel_acc, kernel_grad_acc =
+                KernelOutputLocal!(SimMetaData, kernel_acc, kernel_grad_acc,
+                                   SimKernel, q, ∇ᵢWᵢⱼ)
+
+            MLcond = MotionLimiter[i] * MotionLimiter[j]
+            shift_c_acc += (m₀ / ρᵢ) * ∇ᵢWᵢⱼ
+            shift_r_acc += (m₀ / ρⱼ) * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
+        end
+
+        return dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc, shift_r_acc
     end
 
     Base.@propagate_inbounds function ComputeInteractionsMDBC!(SimKernel, SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode}, SimConstants, Position, Density, ParticleType, GhostPoints, i, j) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}
@@ -806,7 +1083,7 @@ using LinearAlgebra
     
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
-                                      SimConstants, SimParticles, Stencil,
+                                      SimConstants, SimParticles, FullStencil,
                                       ParticleRanges, UniqueCells, CellDict,
                                       SortingScratchSpace, SimThreadedArrays,
                                       dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
@@ -844,15 +1121,16 @@ using LinearAlgebra
 
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(Position, Velocity, ParticleType, ParticleMarker, dt₂, MotionDefinition, SimMetaData)
             
-                ###=== First step of resetting arrays
-                @timeit SimMetaData.HourGlass "ResetArrays"                              ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
-                ###===
-                 
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
                 @timeit SimMetaData.HourGlass "04 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType)
 
-                @timeit SimMetaData.HourGlass "05 First NeighborLoop"                    NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Position, Density, Pressure, Velocity, MotionLimiter, UniqueCellsView)
-                @timeit SimMetaData.HourGlass "Reduction"                                ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
+                @timeit SimMetaData.HourGlass "05 First NeighborLoop"                    NeighborLoopPerParticle!(
+                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    FullStencil, Position, Density, Pressure, Velocity,
+                    MotionLimiter, dρdtI, Acceleration, Kernel,
+                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                )
 
 
                 @timeit SimMetaData.HourGlass "06 Update To Half TimeStep"               HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
@@ -860,15 +1138,16 @@ using LinearAlgebra
 
                 @timeit SimMetaData.HourGlass "07 Half LimitDensityAtBoundary"           LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, MotionLimiter)
             
-                ###=== Second step of resetting arrays
-                @timeit SimMetaData.HourGlass "ResetArrays"                              ResetStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
-                ###===
-
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(Position, Velocity, ParticleType, ParticleMarker, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
-                @timeit SimMetaData.HourGlass "08 Second NeighborLoop"                   NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, SimThreadedArrays, ParticleRanges, CellDict, Stencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺, MotionLimiter, UniqueCellsView)
-                @timeit SimMetaData.HourGlass "Reduction"                                ReductionStep!(SimMetaData, SimThreadedArrays, dρdtI, Acceleration, Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ)
+                @timeit SimMetaData.HourGlass "08 Second NeighborLoop"                   NeighborLoopPerParticle!(
+                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    FullStencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
+                    MotionLimiter, dρdtI, Acceleration, Kernel,
+                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                )
 
             
                 @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
@@ -920,7 +1199,7 @@ using LinearAlgebra
         ParticleRanges         = zeros(Int, NumberOfPoints + 1 + 1) # +1 for the last particle, +1 for dummy entry
         UniqueCells            = zeros(CartesianIndex{Dimensions}, NumberOfPoints)
         CellDict               = Dict{CartesianIndex{Dimensions}, Int}()
-        Stencil                = ConstructStencil(Val(Dimensions))
+        FullStencil            = construct_full_stencil(Val(Dimensions))
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
 
         output = SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)
@@ -960,7 +1239,13 @@ using LinearAlgebra
 
         @inbounds while true
 
-            @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants, SimParticles, Stencil, ParticleRanges, UniqueCells, CellDict, SortingScratchSpace, SimThreadedArrays, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ, MotionDefinition)
+            @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
+                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                SimConstants, SimParticles, FullStencil, ParticleRanges,
+                UniqueCells, CellDict, SortingScratchSpace, SimThreadedArrays,
+                dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
+                MotionDefinition,
+            )
             push!(TimeSteps, SimMetaData.CurrentTimeStep)
 
             log_step!(SimMetaData, SimLogger)

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -46,6 +46,34 @@ using LinearAlgebra
         return CartesianIndices(ntuple(_->-1:1, v))
     end
 
+    function BuildNeighborCellLists!(neighbor_cell_lists, FullStencil, UniqueCellsView,
+                                     ParticleRanges, CellDict)
+        target_len = length(UniqueCellsView)
+        original_len = length(neighbor_cell_lists)
+        resize!(neighbor_cell_lists, target_len)
+        if target_len > original_len
+            @inbounds for idx in (original_len + 1):target_len
+                neighbor_cell_lists[idx] = Int[]
+            end
+        end
+        @inbounds for cell_idx in eachindex(UniqueCellsView)
+            neighbors = neighbor_cell_lists[cell_idx]
+            empty!(neighbors)
+            cell = UniqueCellsView[cell_idx]
+            for S in FullStencil
+                neighbor_cell = cell + S
+                neighbor_idx = get(CellDict, neighbor_cell, 1)
+                start_idx = ParticleRanges[neighbor_idx]
+                end_idx = ParticleRanges[neighbor_idx + 1] - 1
+                if start_idx <= end_idx
+                    push!(neighbors, neighbor_idx)
+                end
+            end
+        end
+
+        return nothing
+    end
+
     """
     Extracts the cells for each particle based on their positions and the inverse cutoff value.
 
@@ -248,13 +276,14 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, FullStencil, Position, Density,
-                                      Pressure, Velocity, MotionLimiter, dρdtI,
-                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
-                                      ∇◌rᵢ) where {D,T,K<:KernelOutputMode,
-                                                  B<:MDBCMode,L<:LogMode,
-                                                  SDD<:SPHDensityDiffusion,
-                                                  SV<:SPHViscosity}
+                                      neighbor_cell_lists, Position, Density, Pressure,
+                                      Velocity, MotionLimiter, dρdtI, Acceleration,
+                                      Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ) where {D,T,
+                                                                             K<:KernelOutputMode,
+                                                                             B<:MDBCMode,
+                                                                             L<:LogMode,
+                                                                             SDD<:SPHDensityDiffusion,
+                                                                             SV<:SPHViscosity}
         Cells = SimParticles.Cells
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
@@ -265,14 +294,10 @@ using LinearAlgebra
             CellListIndex = get(CellDict, CellIndex, 1)
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
+            NeighborCellIndices = neighbor_cell_lists[CellListIndex]
 
-            for S in FullStencil
-                SCellIndex = CellIndex + S
-                NeighborIdx = get(CellDict, SCellIndex, 1)
-                StartIndex_ = ParticleRanges[NeighborIdx]
-                EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
-
-                if SCellIndex == CellIndex
+            for NeighborIdx in NeighborCellIndices
+                if NeighborIdx == CellListIndex
                     @inbounds for j in SameCellStart:(i - 1)
                         dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc =
                             ComputeInteractionsPerParticle!(
@@ -292,6 +317,8 @@ using LinearAlgebra
                             )
                     end
                 else
+                    StartIndex_ = ParticleRanges[NeighborIdx]
+                    EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
                     @inbounds for j in StartIndex_:EndIndex_
                         dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc =
                             ComputeInteractionsPerParticle!(
@@ -316,14 +343,15 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, FullStencil, Position, Density,
-                                      Pressure, Velocity, MotionLimiter, dρdtI,
-                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
-                                      ∇◌rᵢ) where {D,T,S<:ShiftingMode,
-                                                  K<:KernelOutputMode,
-                                                  B<:MDBCMode,L<:LogMode,
-                                                  SDD<:SPHDensityDiffusion,
-                                                  SV<:SPHViscosity}
+                                      neighbor_cell_lists, Position, Density, Pressure,
+                                      Velocity, MotionLimiter, dρdtI, Acceleration,
+                                      Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ) where {D,T,
+                                                                             S<:ShiftingMode,
+                                                                             K<:KernelOutputMode,
+                                                                             B<:MDBCMode,
+                                                                             L<:LogMode,
+                                                                             SDD<:SPHDensityDiffusion,
+                                                                             SV<:SPHViscosity}
         Cells = SimParticles.Cells
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
@@ -336,14 +364,10 @@ using LinearAlgebra
             CellListIndex = get(CellDict, CellIndex, 1)
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
+            NeighborCellIndices = neighbor_cell_lists[CellListIndex]
 
-            for S in FullStencil
-                SCellIndex = CellIndex + S
-                NeighborIdx = get(CellDict, SCellIndex, 1)
-                StartIndex_ = ParticleRanges[NeighborIdx]
-                EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
-
-                if SCellIndex == CellIndex
+            for NeighborIdx in NeighborCellIndices
+                if NeighborIdx == CellListIndex
                     @inbounds for j in SameCellStart:(i - 1)
                         dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
                         shift_r_acc = ComputeInteractionsPerParticle!(
@@ -363,6 +387,8 @@ using LinearAlgebra
                         )
                     end
                 else
+                    StartIndex_ = ParticleRanges[NeighborIdx]
+                    EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
                     @inbounds for j in StartIndex_:EndIndex_
                         dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
                         shift_r_acc = ComputeInteractionsPerParticle!(
@@ -1086,11 +1112,12 @@ using LinearAlgebra
                                       SimConstants, SimParticles, FullStencil,
                                       ParticleRanges, UniqueCells, CellDict,
                                       SortingScratchSpace, SimThreadedArrays,
-                                      dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
-                                      ∇Cᵢ, ∇◌rᵢ, MotionDefinition) where {Dimensions, FloatType,
-                                                                        SMode, KMode, BMode,
-                                                                        LMode, SDD<:SPHDensityDiffusion,
-                                                                        SV<:SPHViscosity}
+                                      neighbor_cell_lists, dρdtI, Velocityₙ⁺,
+                                      Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
+                                      MotionDefinition) where {Dimensions, FloatType,
+                                                               SMode, KMode, BMode,
+                                                               LMode, SDD<:SPHDensityDiffusion,
+                                                               SV<:SPHViscosity}
         @unpack Position, Density, Pressure, Velocity, Acceleration, MotionLimiter, GroupMarker, Kernel, KernelGradient, GhostPoints, GhostNormals = SimParticles
         ParticleType   = SimParticles.Type
         ParticleMarker = GroupMarker
@@ -1119,6 +1146,9 @@ using LinearAlgebra
                         @timeit SimMetaData.HourGlass "02a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellDict)
                         Δx = zero(eltype(Density))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
+                        BuildNeighborCellLists!(neighbor_cell_lists, FullStencil,
+                                                UniqueCellsView, ParticleRanges,
+                                                CellDict)
                     end
                 end
 
@@ -1129,8 +1159,8 @@ using LinearAlgebra
 
                 @timeit SimMetaData.HourGlass "05 First NeighborLoop" NeighborLoopPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, CellDict,
-                    FullStencil, Position, Density, Pressure, Velocity,
+                    SimConstants, SimParticles, ParticleRanges, neighbor_cell_lists,
+                    Position, Density, Pressure, Velocity,
                     MotionLimiter, dρdtI, Acceleration, Kernel,
                     KernelGradient, ∇Cᵢ, ∇◌rᵢ,
                 )
@@ -1146,8 +1176,8 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
                 @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, CellDict,
-                    FullStencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
+                    SimConstants, SimParticles, ParticleRanges, neighbor_cell_lists,
+                    Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
                     MotionLimiter, dρdtI, Acceleration, Kernel,
                     KernelGradient, ∇Cᵢ, ∇◌rᵢ,
                 )
@@ -1203,6 +1233,7 @@ using LinearAlgebra
         UniqueCells            = zeros(CartesianIndex{Dimensions}, NumberOfPoints)
         CellDict               = Dict{CartesianIndex{Dimensions}, Int}()
         FullStencil            = ConstructFullStencil(Val(Dimensions))
+        NeighborCellLists      = [Int[] for _ in 1:length(UniqueCells)]
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
 
         output = SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)
@@ -1246,8 +1277,8 @@ using LinearAlgebra
                 SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                 SimConstants, SimParticles, FullStencil, ParticleRanges,
                 UniqueCells, CellDict, SortingScratchSpace, SimThreadedArrays,
-                dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
-                MotionDefinition,
+                NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
+                ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
             )
             push!(TimeSteps, SimMetaData.CurrentTimeStep)
 

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -1328,26 +1328,23 @@ using LinearAlgebra
     end
 
     """
-        update_local_cell_delta_x!(Δx_cell, posₙ⁺, pos, cells, cell_dict, h)
+        update_local_delta_x!(Δx_local, posₙ⁺, pos, h)
 
-    Accumulate per-particle displacement into per-cell bins since the last neighbor
-    update and return `true` when any cell exceeds `h`.
+    Accumulate per-particle displacement since the last neighbor update and return
+    `true` when any particle exceeds `h`.
     """
-    @inline function update_local_cell_delta_x!(Δx_cell::AbstractVector{T},
-                                                posₙ⁺::AbstractVector{SVector{D, T}},
-                                                pos   ::AbstractVector{SVector{D, T}},
-                                                cells::AbstractVector,
-                                                cell_dict,
-                                                h::T) where {D, T<:Real}
-        @inbounds for i in eachindex(posₙ⁺, pos, cells)
+    @inline function update_local_delta_x!(Δx_local::AbstractVector{T},
+                                           posₙ⁺::AbstractVector{SVector{D, T}},
+                                           pos   ::AbstractVector{SVector{D, T}},
+                                           h::T) where {D, T<:Real}
+        @inbounds for i in eachindex(posₙ⁺, pos, Δx_local)
             sumsq = zero(T)
             @inbounds for j in 1:D
                 d = posₙ⁺[i][j] - pos[i][j]
                 sumsq += d*d
             end
-            cell_index = get(cell_dict, cells[i], 1)
-            Δx_cell[cell_index] += 4 * sqrt(sumsq)
-            if Δx_cell[cell_index] >= h
+            Δx_local[i] += 4 * sqrt(sumsq)
+            if Δx_local[i] >= h
                 return true
             end
         end
@@ -1371,15 +1368,13 @@ using LinearAlgebra
         ParticleMarker = GroupMarker
 
         ###
-        Δx_cell = SimMetaData.LocalCellΔx
+        Δx_local = SimMetaData.LocalΔx
         UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
 
             while SimMetaData.TotalTime <= next_output_time(SimMetaData)
 
-                ShouldRebuild = update_local_cell_delta_x!(
-                    Δx_cell, Positionₙ⁺, SimParticles.Position, SimParticles.Cells,
-                    CellDict, SimKernel.h,
-                )
+                ShouldRebuild = update_local_delta_x!(Δx_local, Positionₙ⁺,
+                                                    SimParticles.Position, SimKernel.h)
 
                 # println("Δx: ", Δx, "h: ", SimKernel.h," dt: ", SimMetaData.CurrentTimeStep, " Iteration: ", SimMetaData.Iteration, " TotalTime: ", SimMetaData.TotalTime, " OutputIterationCounter: ", SimMetaData.OutputIterationCounter)
 
@@ -1395,10 +1390,7 @@ using LinearAlgebra
                     # if mod(SimMetaData.Iteration, ceil(Int, SimKernel.H / (SimConstants.c₀ * dt * (1/SimConstants.CFL)) )) == 0 || SimMetaData.Iteration == 1
                     if ShouldRebuild
                         @timeit SimMetaData.HourGlass "02a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellDict)
-                        if length(Δx_cell) != SimMetaData.IndexCounter
-                            resize!(Δx_cell, SimMetaData.IndexCounter)
-                        end
-                        fill!(Δx_cell, zero(eltype(Δx_cell)))
+                        fill!(Δx_local, zero(eltype(Δx_local)))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
                         BuildNeighborCellLists!(neighbor_cell_lists, FullStencil,
                                                 UniqueCellsView, ParticleRanges,
@@ -1481,7 +1473,7 @@ using LinearAlgebra
         Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
     
         SimThreadedArrays = AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ)
-        SimMetaData.LocalCellΔx = zeros(eltype(dρdtI), length(UniqueCells))
+        SimMetaData.LocalΔx = zeros(eltype(dρdtI), NumberOfPoints)
     
         # Produce sorting related variables
         ParticleRanges         = zeros(Int, NumberOfPoints + 1 + 1) # +1 for the last particle, +1 for dummy entry

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -1083,15 +1083,14 @@ using LinearAlgebra
     
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
-                                      SimConstants, SimParticles, HalfStencil,
-                                      FullStencil, ParticleRanges, UniqueCells,
-                                      CellDict, SortingScratchSpace,
-                                      SimThreadedArrays, dρdtI, Velocityₙ⁺,
-                                      Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
-                                      MotionDefinition) where {Dimensions, FloatType,
-                                                               SMode, KMode, BMode,
-                                                               LMode, SDD<:SPHDensityDiffusion,
-                                                               SV<:SPHViscosity}
+                                      SimConstants, SimParticles, FullStencil,
+                                      ParticleRanges, UniqueCells, CellDict,
+                                      SortingScratchSpace, SimThreadedArrays,
+                                      dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
+                                      ∇Cᵢ, ∇◌rᵢ, MotionDefinition) where {Dimensions, FloatType,
+                                                                        SMode, KMode, BMode,
+                                                                        LMode, SDD<:SPHDensityDiffusion,
+                                                                        SV<:SPHViscosity}
         @unpack Position, Density, Pressure, Velocity, Acceleration, MotionLimiter, GroupMarker, Kernel, KernelGradient, GhostPoints, GhostNormals = SimParticles
         ParticleType   = SimParticles.Type
         ParticleMarker = GroupMarker
@@ -1128,30 +1127,13 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
                 @timeit SimMetaData.HourGlass "04 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType)
 
-                if Dimensions == 3
-                    @timeit SimMetaData.HourGlass "ResetArrays" ResetStep!(
-                        SimMetaData, SimThreadedArrays, dρdtI, Acceleration,
-                        Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                    )
-                    @timeit SimMetaData.HourGlass "05 First NeighborLoop" NeighborLoop!(
-                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, SimThreadedArrays, ParticleRanges,
-                        CellDict, HalfStencil, Position, Density, Pressure, Velocity,
-                        MotionLimiter, UniqueCellsView,
-                    )
-                    @timeit SimMetaData.HourGlass "Reduction" ReductionStep!(
-                        SimMetaData, SimThreadedArrays, dρdtI, Acceleration,
-                        Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                    )
-                else
-                    @timeit SimMetaData.HourGlass "05 First NeighborLoop" NeighborLoopPerParticle!(
-                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
-                        FullStencil, Position, Density, Pressure, Velocity,
-                        MotionLimiter, dρdtI, Acceleration, Kernel,
-                        KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                    )
-                end
+                @timeit SimMetaData.HourGlass "05 First NeighborLoop" NeighborLoopPerParticle!(
+                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    FullStencil, Position, Density, Pressure, Velocity,
+                    MotionLimiter, dρdtI, Acceleration, Kernel,
+                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                )
 
 
                 @timeit SimMetaData.HourGlass "06 Update To Half TimeStep"               HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
@@ -1162,30 +1144,13 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(Position, Velocity, ParticleType, ParticleMarker, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
-                if Dimensions == 3
-                    @timeit SimMetaData.HourGlass "ResetArrays" ResetStep!(
-                        SimMetaData, SimThreadedArrays, dρdtI, Acceleration,
-                        Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                    )
-                    @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoop!(
-                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, SimThreadedArrays, ParticleRanges,
-                        CellDict, HalfStencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
-                        MotionLimiter, UniqueCellsView,
-                    )
-                    @timeit SimMetaData.HourGlass "Reduction" ReductionStep!(
-                        SimMetaData, SimThreadedArrays, dρdtI, Acceleration,
-                        Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                    )
-                else
-                    @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
-                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
-                        FullStencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
-                        MotionLimiter, dρdtI, Acceleration, Kernel,
-                        KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                    )
-                end
+                @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
+                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    FullStencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
+                    MotionLimiter, dρdtI, Acceleration, Kernel,
+                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                )
 
             
                 @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
@@ -1237,7 +1202,6 @@ using LinearAlgebra
         ParticleRanges         = zeros(Int, NumberOfPoints + 1 + 1) # +1 for the last particle, +1 for dummy entry
         UniqueCells            = zeros(CartesianIndex{Dimensions}, NumberOfPoints)
         CellDict               = Dict{CartesianIndex{Dimensions}, Int}()
-        HalfStencil            = ConstructStencil(Val(Dimensions))
         FullStencil            = ConstructFullStencil(Val(Dimensions))
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
 
@@ -1280,10 +1244,10 @@ using LinearAlgebra
 
             @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
                 SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                SimConstants, SimParticles, HalfStencil, FullStencil,
-                ParticleRanges, UniqueCells, CellDict, SortingScratchSpace,
-                SimThreadedArrays, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
-                ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
+                SimConstants, SimParticles, FullStencil, ParticleRanges,
+                UniqueCells, CellDict, SortingScratchSpace, SimThreadedArrays,
+                dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
+                MotionDefinition,
             )
             push!(TimeSteps, SimMetaData.CurrentTimeStep)
 

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -42,7 +42,7 @@ using LinearAlgebra
         return n
     end
 
-    function construct_full_stencil(v::Val{d}) where d
+    function ConstructFullStencil(v::Val{d}) where d
         return CartesianIndices(ntuple(_->-1:1, v))
     end
 
@@ -1238,7 +1238,7 @@ using LinearAlgebra
         UniqueCells            = zeros(CartesianIndex{Dimensions}, NumberOfPoints)
         CellDict               = Dict{CartesianIndex{Dimensions}, Int}()
         HalfStencil            = ConstructStencil(Val(Dimensions))
-        FullStencil            = construct_full_stencil(Val(Dimensions))
+        FullStencil            = ConstructFullStencil(Val(Dimensions))
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
 
         output = SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -1083,11 +1083,15 @@ using LinearAlgebra
     
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
-                                      SimConstants, SimParticles, FullStencil,
-                                      ParticleRanges, UniqueCells, CellDict,
-                                      SortingScratchSpace, SimThreadedArrays,
-                                      dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
-                                      ∇Cᵢ, ∇◌rᵢ, MotionDefinition) where {Dimensions, FloatType, SMode, KMode, BMode, LMode, SDD<:SPHDensityDiffusion, SV<:SPHViscosity}
+                                      SimConstants, SimParticles, HalfStencil,
+                                      FullStencil, ParticleRanges, UniqueCells,
+                                      CellDict, SortingScratchSpace,
+                                      SimThreadedArrays, dρdtI, Velocityₙ⁺,
+                                      Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
+                                      MotionDefinition) where {Dimensions, FloatType,
+                                                               SMode, KMode, BMode,
+                                                               LMode, SDD<:SPHDensityDiffusion,
+                                                               SV<:SPHViscosity}
         @unpack Position, Density, Pressure, Velocity, Acceleration, MotionLimiter, GroupMarker, Kernel, KernelGradient, GhostPoints, GhostNormals = SimParticles
         ParticleType   = SimParticles.Type
         ParticleMarker = GroupMarker
@@ -1124,13 +1128,30 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
                 @timeit SimMetaData.HourGlass "04 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType)
 
-                @timeit SimMetaData.HourGlass "05 First NeighborLoop"                    NeighborLoopPerParticle!(
-                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, CellDict,
-                    FullStencil, Position, Density, Pressure, Velocity,
-                    MotionLimiter, dρdtI, Acceleration, Kernel,
-                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                )
+                if Dimensions == 3
+                    @timeit SimMetaData.HourGlass "ResetArrays" ResetStep!(
+                        SimMetaData, SimThreadedArrays, dρdtI, Acceleration,
+                        Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                    )
+                    @timeit SimMetaData.HourGlass "05 First NeighborLoop" NeighborLoop!(
+                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                        SimConstants, SimParticles, SimThreadedArrays, ParticleRanges,
+                        CellDict, HalfStencil, Position, Density, Pressure, Velocity,
+                        MotionLimiter, UniqueCellsView,
+                    )
+                    @timeit SimMetaData.HourGlass "Reduction" ReductionStep!(
+                        SimMetaData, SimThreadedArrays, dρdtI, Acceleration,
+                        Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                    )
+                else
+                    @timeit SimMetaData.HourGlass "05 First NeighborLoop" NeighborLoopPerParticle!(
+                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        FullStencil, Position, Density, Pressure, Velocity,
+                        MotionLimiter, dρdtI, Acceleration, Kernel,
+                        KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                    )
+                end
 
 
                 @timeit SimMetaData.HourGlass "06 Update To Half TimeStep"               HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
@@ -1141,13 +1162,30 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(Position, Velocity, ParticleType, ParticleMarker, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
-                @timeit SimMetaData.HourGlass "08 Second NeighborLoop"                   NeighborLoopPerParticle!(
-                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, CellDict,
-                    FullStencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
-                    MotionLimiter, dρdtI, Acceleration, Kernel,
-                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                )
+                if Dimensions == 3
+                    @timeit SimMetaData.HourGlass "ResetArrays" ResetStep!(
+                        SimMetaData, SimThreadedArrays, dρdtI, Acceleration,
+                        Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                    )
+                    @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoop!(
+                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                        SimConstants, SimParticles, SimThreadedArrays, ParticleRanges,
+                        CellDict, HalfStencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
+                        MotionLimiter, UniqueCellsView,
+                    )
+                    @timeit SimMetaData.HourGlass "Reduction" ReductionStep!(
+                        SimMetaData, SimThreadedArrays, dρdtI, Acceleration,
+                        Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                    )
+                else
+                    @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
+                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        FullStencil, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
+                        MotionLimiter, dρdtI, Acceleration, Kernel,
+                        KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                    )
+                end
 
             
                 @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
@@ -1199,6 +1237,7 @@ using LinearAlgebra
         ParticleRanges         = zeros(Int, NumberOfPoints + 1 + 1) # +1 for the last particle, +1 for dummy entry
         UniqueCells            = zeros(CartesianIndex{Dimensions}, NumberOfPoints)
         CellDict               = Dict{CartesianIndex{Dimensions}, Int}()
+        HalfStencil            = ConstructStencil(Val(Dimensions))
         FullStencil            = construct_full_stencil(Val(Dimensions))
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
 
@@ -1241,10 +1280,10 @@ using LinearAlgebra
 
             @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
                 SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                SimConstants, SimParticles, FullStencil, ParticleRanges,
-                UniqueCells, CellDict, SortingScratchSpace, SimThreadedArrays,
-                dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
-                MotionDefinition,
+                SimConstants, SimParticles, HalfStencil, FullStencil,
+                ParticleRanges, UniqueCells, CellDict, SortingScratchSpace,
+                SimThreadedArrays, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
+                ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
             )
             push!(TimeSteps, SimMetaData.CurrentTimeStep)
 

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -60,8 +60,8 @@ using LinearAlgebra
             neighbors = neighbor_cell_lists[cell_idx]
             empty!(neighbors)
             cell = UniqueCellsView[cell_idx]
-            for S in FullStencil
-                neighbor_cell = cell + S
+            for offset in FullStencil
+                neighbor_cell = cell + offset
                 neighbor_idx = get(CellDict, neighbor_cell, 1)
                 start_idx = ParticleRanges[neighbor_idx]
                 end_idx = ParticleRanges[neighbor_idx + 1] - 1
@@ -252,8 +252,8 @@ using LinearAlgebra
                 end
 
                 # (2) Interactions with neighboring cells
-                @inbounds for S in Stencil
-                    SCellIndex = CellIndex + S
+                @inbounds for offset in Stencil
+                    SCellIndex = CellIndex + offset
                     NeighborIdx = get(CellDict, SCellIndex, 1)
                     StartIndex_ = ParticleRanges[NeighborIdx]
                     EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
@@ -276,14 +276,13 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      neighbor_cell_lists, Position, Density, Pressure,
-                                      Velocity, MotionLimiter, dρdtI, Acceleration,
-                                      Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ) where {D,T,
-                                                                             K<:KernelOutputMode,
-                                                                             B<:MDBCMode,
-                                                                             L<:LogMode,
-                                                                             SDD<:SPHDensityDiffusion,
-                                                                             SV<:SPHViscosity}
+                                      CellDict, neighbor_cell_lists, Position, Density,
+                                      Pressure, Velocity, MotionLimiter, dρdtI,
+                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
+                                      ∇◌rᵢ) where {D,T,K<:KernelOutputMode,
+                                                  B<:MDBCMode,L<:LogMode,
+                                                  SDD<:SPHDensityDiffusion,
+                                                  SV<:SPHViscosity}
         Cells = SimParticles.Cells
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
@@ -343,15 +342,14 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      neighbor_cell_lists, Position, Density, Pressure,
-                                      Velocity, MotionLimiter, dρdtI, Acceleration,
-                                      Kernel, KernelGradient, ∇Cᵢ, ∇◌rᵢ) where {D,T,
-                                                                             S<:ShiftingMode,
-                                                                             K<:KernelOutputMode,
-                                                                             B<:MDBCMode,
-                                                                             L<:LogMode,
-                                                                             SDD<:SPHDensityDiffusion,
-                                                                             SV<:SPHViscosity}
+                                      CellDict, neighbor_cell_lists, Position, Density,
+                                      Pressure, Velocity, MotionLimiter, dρdtI,
+                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
+                                      ∇◌rᵢ) where {D,T,S<:ShiftingMode,
+                                                  K<:KernelOutputMode,
+                                                  B<:MDBCMode,L<:LogMode,
+                                                  SDD<:SPHDensityDiffusion,
+                                                  SV<:SPHViscosity}
         Cells = SimParticles.Cells
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
@@ -431,8 +429,8 @@ using LinearAlgebra
             
                 # compute and accumulate into the locals
                 GhostCellIndex = f(SimKernel, GhostPoints[iter])
-                @inbounds for S ∈ FullStencil
-                    SCellIndex = GhostCellIndex + S
+                @inbounds for offset ∈ FullStencil
+                    SCellIndex = GhostCellIndex + offset
 
                     # Returns a range, x>:x for exact match and x=:x for no match
                     # utilizes that it is a sorted array and requires no isequal constructor,
@@ -1159,8 +1157,8 @@ using LinearAlgebra
 
                 @timeit SimMetaData.HourGlass "05 First NeighborLoop" NeighborLoopPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, neighbor_cell_lists,
-                    Position, Density, Pressure, Velocity,
+                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    neighbor_cell_lists, Position, Density, Pressure, Velocity,
                     MotionLimiter, dρdtI, Acceleration, Kernel,
                     KernelGradient, ∇Cᵢ, ∇◌rᵢ,
                 )
@@ -1176,8 +1174,8 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "03 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
                 @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, neighbor_cell_lists,
-                    Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
+                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    neighbor_cell_lists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
                     MotionLimiter, dρdtI, Acceleration, Kernel,
                     KernelGradient, ∇Cᵢ, ∇◌rᵢ,
                 )

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -1328,23 +1328,26 @@ using LinearAlgebra
     end
 
     """
-        update_local_delta_x!(Δx_local, posₙ⁺, pos, h)
+        update_local_cell_delta_x!(Δx_cell, posₙ⁺, pos, cells, cell_dict, h)
 
-    Accumulate per-particle displacement since the last neighbor update and return
-    `true` when any particle exceeds `h`.
+    Accumulate per-particle displacement into per-cell bins since the last neighbor
+    update and return `true` when any cell exceeds `h`.
     """
-    @inline function update_local_delta_x!(Δx_local::AbstractVector{T},
-                                           posₙ⁺::AbstractVector{SVector{D, T}},
-                                           pos   ::AbstractVector{SVector{D, T}},
-                                           h::T) where {D, T<:Real}
-        @inbounds for i in eachindex(posₙ⁺, pos, Δx_local)
+    @inline function update_local_cell_delta_x!(Δx_cell::AbstractVector{T},
+                                                posₙ⁺::AbstractVector{SVector{D, T}},
+                                                pos   ::AbstractVector{SVector{D, T}},
+                                                cells::AbstractVector,
+                                                cell_dict,
+                                                h::T) where {D, T<:Real}
+        @inbounds for i in eachindex(posₙ⁺, pos, cells)
             sumsq = zero(T)
             @inbounds for j in 1:D
                 d = posₙ⁺[i][j] - pos[i][j]
                 sumsq += d*d
             end
-            Δx_local[i] += 4 * sqrt(sumsq)
-            if Δx_local[i] >= h
+            cell_index = get(cell_dict, cells[i], 1)
+            Δx_cell[cell_index] += 4 * sqrt(sumsq)
+            if Δx_cell[cell_index] >= h
                 return true
             end
         end
@@ -1368,13 +1371,15 @@ using LinearAlgebra
         ParticleMarker = GroupMarker
 
         ###
-        Δx_local = SimMetaData.LocalΔx
+        Δx_cell = SimMetaData.LocalCellΔx
         UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
 
             while SimMetaData.TotalTime <= next_output_time(SimMetaData)
 
-                ShouldRebuild = update_local_delta_x!(Δx_local, Positionₙ⁺,
-                                                    SimParticles.Position, SimKernel.h)
+                ShouldRebuild = update_local_cell_delta_x!(
+                    Δx_cell, Positionₙ⁺, SimParticles.Position, SimParticles.Cells,
+                    CellDict, SimKernel.h,
+                )
 
                 # println("Δx: ", Δx, "h: ", SimKernel.h," dt: ", SimMetaData.CurrentTimeStep, " Iteration: ", SimMetaData.Iteration, " TotalTime: ", SimMetaData.TotalTime, " OutputIterationCounter: ", SimMetaData.OutputIterationCounter)
 
@@ -1390,7 +1395,10 @@ using LinearAlgebra
                     # if mod(SimMetaData.Iteration, ceil(Int, SimKernel.H / (SimConstants.c₀ * dt * (1/SimConstants.CFL)) )) == 0 || SimMetaData.Iteration == 1
                     if ShouldRebuild
                         @timeit SimMetaData.HourGlass "02a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellDict)
-                        fill!(Δx_local, zero(eltype(Δx_local)))
+                        if length(Δx_cell) != SimMetaData.IndexCounter
+                            resize!(Δx_cell, SimMetaData.IndexCounter)
+                        end
+                        fill!(Δx_cell, zero(eltype(Δx_cell)))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
                         BuildNeighborCellLists!(neighbor_cell_lists, FullStencil,
                                                 UniqueCellsView, ParticleRanges,
@@ -1473,7 +1481,7 @@ using LinearAlgebra
         Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
     
         SimThreadedArrays = AllocateThreadedArrays(SimMetaData, SimParticles, dρdtI, ∇Cᵢ, ∇◌rᵢ)
-        SimMetaData.LocalΔx = zeros(eltype(dρdtI), NumberOfPoints)
+        SimMetaData.LocalCellΔx = zeros(eltype(dρdtI), length(UniqueCells))
     
         # Produce sorting related variables
         ParticleRanges         = zeros(Int, NumberOfPoints + 1 + 1) # +1 for the last particle, +1 for dummy entry

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -274,6 +274,61 @@ using LinearAlgebra
     end
 
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
+                                      SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L},
+                                      SimConstants, SimParticles, ParticleRanges,
+                                      CellDict, neighbor_cell_lists, Position, Density,
+                                      Pressure, Velocity, MotionLimiter, dρdtI,
+                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
+                                      ∇◌rᵢ) where {D,T,B<:MDBCMode,L<:LogMode,
+                                                  SDD<:SPHDensityDiffusion,
+                                                  SV<:SPHViscosity}
+        Cells = SimParticles.Cells
+        @inbounds Threads.@threads for i in eachindex(Position)
+            dρdt_acc = zero(dρdtI[i])
+            acc_acc = zero(Acceleration[i])
+            CellIndex = Cells[i]
+            CellListIndex = get(CellDict, CellIndex, 1)
+            SameCellStart = ParticleRanges[CellListIndex]
+            SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
+            NeighborCellIndices = neighbor_cell_lists[CellListIndex]
+
+            for NeighborIdx in NeighborCellIndices
+                if NeighborIdx == CellListIndex
+                    @inbounds for j in SameCellStart:(i - 1)
+                        dρdt_acc, acc_acc = ComputeInteractionsPerParticleNoKernel!(
+                            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                            SimConstants, SimParticles, Position, Density, Pressure,
+                            Velocity, MotionLimiter, dρdt_acc, acc_acc, i, j,
+                        )
+                    end
+                    @inbounds for j in (i + 1):SameCellEnd
+                        dρdt_acc, acc_acc = ComputeInteractionsPerParticleNoKernel!(
+                            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                            SimConstants, SimParticles, Position, Density, Pressure,
+                            Velocity, MotionLimiter, dρdt_acc, acc_acc, i, j,
+                        )
+                    end
+                else
+                    StartIndex_ = ParticleRanges[NeighborIdx]
+                    EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
+                    @inbounds for j in StartIndex_:EndIndex_
+                        dρdt_acc, acc_acc = ComputeInteractionsPerParticleNoKernel!(
+                            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                            SimConstants, SimParticles, Position, Density, Pressure,
+                            Velocity, MotionLimiter, dρdt_acc, acc_acc, i, j,
+                        )
+                    end
+                end
+            end
+
+            dρdtI[i] = dρdt_acc
+            Acceleration[i] = acc_acc
+        end
+
+        return nothing
+    end
+
+    function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
                                       CellDict, neighbor_cell_lists, Position, Density,
@@ -334,6 +389,71 @@ using LinearAlgebra
             Acceleration[i] = acc_acc
             Kernel[i] = kernel_acc
             KernelGradient[i] = kernel_grad_acc
+        end
+
+        return nothing
+    end
+
+    function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
+                                      SimMetaData::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
+                                      SimConstants, SimParticles, ParticleRanges,
+                                      CellDict, neighbor_cell_lists, Position, Density,
+                                      Pressure, Velocity, MotionLimiter, dρdtI,
+                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
+                                      ∇◌rᵢ) where {D,T,S<:ShiftingMode,B<:MDBCMode,
+                                                  L<:LogMode,SDD<:SPHDensityDiffusion,
+                                                  SV<:SPHViscosity}
+        Cells = SimParticles.Cells
+        @inbounds Threads.@threads for i in eachindex(Position)
+            dρdt_acc = zero(dρdtI[i])
+            acc_acc = zero(Acceleration[i])
+            shift_c_acc = zero(∇Cᵢ[i])
+            shift_r_acc = zero(∇◌rᵢ[i])
+            CellIndex = Cells[i]
+            CellListIndex = get(CellDict, CellIndex, 1)
+            SameCellStart = ParticleRanges[CellListIndex]
+            SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
+            NeighborCellIndices = neighbor_cell_lists[CellListIndex]
+
+            for NeighborIdx in NeighborCellIndices
+                if NeighborIdx == CellListIndex
+                    @inbounds for j in SameCellStart:(i - 1)
+                        dρdt_acc, acc_acc, shift_c_acc, shift_r_acc =
+                            ComputeInteractionsPerParticleNoKernel!(
+                                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                SimConstants, SimParticles, Position, Density, Pressure,
+                                Velocity, MotionLimiter, dρdt_acc, acc_acc, shift_c_acc,
+                                shift_r_acc, i, j,
+                            )
+                    end
+                    @inbounds for j in (i + 1):SameCellEnd
+                        dρdt_acc, acc_acc, shift_c_acc, shift_r_acc =
+                            ComputeInteractionsPerParticleNoKernel!(
+                                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                SimConstants, SimParticles, Position, Density, Pressure,
+                                Velocity, MotionLimiter, dρdt_acc, acc_acc, shift_c_acc,
+                                shift_r_acc, i, j,
+                            )
+                    end
+                else
+                    StartIndex_ = ParticleRanges[NeighborIdx]
+                    EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
+                    @inbounds for j in StartIndex_:EndIndex_
+                        dρdt_acc, acc_acc, shift_c_acc, shift_r_acc =
+                            ComputeInteractionsPerParticleNoKernel!(
+                                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                                SimConstants, SimParticles, Position, Density, Pressure,
+                                Velocity, MotionLimiter, dρdt_acc, acc_acc, shift_c_acc,
+                                shift_r_acc, i, j,
+                            )
+                    end
+                end
+            end
+
+            dρdtI[i] = dρdt_acc
+            Acceleration[i] = acc_acc
+            ∇Cᵢ[i] = shift_c_acc
+            ∇◌rᵢ[i] = shift_r_acc
         end
 
         return nothing
@@ -567,6 +687,54 @@ using LinearAlgebra
         return dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc
     end
 
+    Base.@propagate_inbounds function ComputeInteractionsPerParticleNoKernel!(
+        SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
+        SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L}, SimConstants,
+        SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
+        dρdt_acc, acc_acc, i, j) where {D,T,B<:MDBCMode,L<:LogMode,
+                                        SDD<:SPHDensityDiffusion,
+                                        SV<:SPHViscosity}
+        @unpack m₀, dx = SimConstants
+        @unpack h⁻¹, H² = SimKernel
+
+        xᵢⱼ = Position[i] - Position[j]
+        xᵢⱼ² = dot(xᵢⱼ, xᵢⱼ)
+        if xᵢⱼ² <= H²
+            dᵢⱼ = sqrt(abs(xᵢⱼ²))
+            q = clamp(dᵢⱼ * h⁻¹, 0.0, 2.0)
+            ∇ᵢWᵢⱼ = @fastpow ∇Wᵢⱼ(SimKernel, q, xᵢⱼ)
+
+            ρᵢ = Density[i]
+            ρⱼ = Density[j]
+
+            vᵢ = Velocity[i]
+            vⱼ = Velocity[j]
+            vᵢⱼ = vᵢ - vⱼ
+            density_symmetric_term = dot(-vᵢⱼ, ∇ᵢWᵢⱼ)
+            dρdt⁺ = -ρᵢ * (m₀ / ρⱼ) * density_symmetric_term
+
+            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel,
+                                              SimConstants, SimParticles, xᵢⱼ,
+                                              ∇ᵢWᵢⱼ, xᵢⱼ², i, j, MotionLimiter)
+
+            dρdt_acc += dρdt⁺ + Dᵢ
+
+            Pᵢ = Pressure[i]
+            Pⱼ = Pressure[j]
+            Pfac = (Pᵢ + Pⱼ) / (ρᵢ * ρⱼ)
+            f_ab = tensile_correction(SimKernel, Pᵢ, ρᵢ, Pⱼ, ρⱼ, q, dx)
+            dvdt⁺ = -m₀ * (Pfac + f_ab) * ∇ᵢWᵢⱼ
+
+            visc_term, _ = compute_viscosity(SimViscosity, SimKernel, SimConstants,
+                                             SimParticles, xᵢⱼ, vᵢⱼ, ∇ᵢWᵢⱼ,
+                                             xᵢⱼ², i, j)
+
+            acc_acc += dvdt⁺ + visc_term
+        end
+
+        return dρdt_acc, acc_acc
+    end
+
     Base.@propagate_inbounds function ComputeInteractionsPerParticle!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,S,K,B,L}, SimConstants,
@@ -625,6 +793,61 @@ using LinearAlgebra
         end
 
         return dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc, shift_r_acc
+    end
+
+    Base.@propagate_inbounds function ComputeInteractionsPerParticleNoKernel!(
+        SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
+        SimMetaData::SimulationMetaData{D,T,S,NoKernelOutput,B,L}, SimConstants,
+        SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
+        dρdt_acc, acc_acc, shift_c_acc, shift_r_acc, i, j) where {D,T,
+                                                                  S<:ShiftingMode,
+                                                                  B<:MDBCMode,
+                                                                  L<:LogMode,
+                                                                  SDD<:SPHDensityDiffusion,
+                                                                  SV<:SPHViscosity}
+        @unpack m₀, dx = SimConstants
+        @unpack h⁻¹, H² = SimKernel
+
+        xᵢⱼ = Position[i] - Position[j]
+        xᵢⱼ² = dot(xᵢⱼ, xᵢⱼ)
+        if xᵢⱼ² <= H²
+            dᵢⱼ = sqrt(abs(xᵢⱼ²))
+            q = clamp(dᵢⱼ * h⁻¹, 0.0, 2.0)
+            ∇ᵢWᵢⱼ = @fastpow ∇Wᵢⱼ(SimKernel, q, xᵢⱼ)
+
+            ρᵢ = Density[i]
+            ρⱼ = Density[j]
+
+            vᵢ = Velocity[i]
+            vⱼ = Velocity[j]
+            vᵢⱼ = vᵢ - vⱼ
+            density_symmetric_term = dot(-vᵢⱼ, ∇ᵢWᵢⱼ)
+            dρdt⁺ = -ρᵢ * (m₀ / ρⱼ) * density_symmetric_term
+
+            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel,
+                                              SimConstants, SimParticles, xᵢⱼ,
+                                              ∇ᵢWᵢⱼ, xᵢⱼ², i, j, MotionLimiter)
+
+            dρdt_acc += dρdt⁺ + Dᵢ
+
+            Pᵢ = Pressure[i]
+            Pⱼ = Pressure[j]
+            Pfac = (Pᵢ + Pⱼ) / (ρᵢ * ρⱼ)
+            f_ab = tensile_correction(SimKernel, Pᵢ, ρᵢ, Pⱼ, ρⱼ, q, dx)
+            dvdt⁺ = -m₀ * (Pfac + f_ab) * ∇ᵢWᵢⱼ
+
+            visc_term, _ = compute_viscosity(SimViscosity, SimKernel, SimConstants,
+                                             SimParticles, xᵢⱼ, vᵢⱼ, ∇ᵢWᵢⱼ,
+                                             xᵢⱼ², i, j)
+
+            acc_acc += dvdt⁺ + visc_term
+
+            MLcond = MotionLimiter[i] * MotionLimiter[j]
+            shift_c_acc += (m₀ / ρᵢ) * ∇ᵢWᵢⱼ
+            shift_r_acc += (m₀ / ρⱼ) * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
+        end
+
+        return dρdt_acc, acc_acc, shift_c_acc, shift_r_acc
     end
 
     Base.@propagate_inbounds function ComputeInteractionsMDBC!(SimKernel, SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode}, SimConstants, Position, Density, ParticleType, GhostPoints, i, j) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -64,7 +64,7 @@ struct StoreLog <: LogMode end
     ]
     OpenLogFile::Bool                       = true
     ChunkMultiplier::Int                    = 1
-    LocalCellΔx::Vector{FloatType}          = Vector{FloatType}()
+    LocalΔx::Vector{FloatType}              = Vector{FloatType}()
 end
 SimulationMetaData{D,T,S,K,B}(; kwargs...) where {D,T,S<:ShiftingMode,K<:KernelOutputMode,B<:MDBCMode} =
     SimulationMetaData{D,T,S,K,B,NoLog}(; kwargs...)

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -64,6 +64,7 @@ struct StoreLog <: LogMode end
     ]
     OpenLogFile::Bool                       = true
     ChunkMultiplier::Int                    = 1
+    LocalΔx::Vector{FloatType}              = Vector{FloatType}()
 end
 SimulationMetaData{D,T,S,K,B}(; kwargs...) where {D,T,S<:ShiftingMode,K<:KernelOutputMode,B<:MDBCMode} =
     SimulationMetaData{D,T,S,K,B,NoLog}(; kwargs...)
@@ -75,4 +76,3 @@ SimulationMetaData{D,T}(; kwargs...) where {D,T} =
     SimulationMetaData{D,T,NoShifting,NoKernelOutput,NoMDBC,NoLog}(; kwargs...)
 
 end
-

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -64,7 +64,7 @@ struct StoreLog <: LogMode end
     ]
     OpenLogFile::Bool                       = true
     ChunkMultiplier::Int                    = 1
-    LocalΔx::Vector{FloatType}              = Vector{FloatType}()
+    LocalCellΔx::Vector{FloatType}          = Vector{FloatType}()
 end
 SimulationMetaData{D,T,S,K,B}(; kwargs...) where {D,T,S<:ShiftingMode,K<:KernelOutputMode,B<:MDBCMode} =
     SimulationMetaData{D,T,S,K,B,NoLog}(; kwargs...)


### PR DESCRIPTION
### Motivation
- Remove the per-neighbor `i == j` branch to reduce branch mispredictions and speed up inner loops in high-dimensional cases.  
- Improve cache locality and reduce repeated lookups by reusing per-particle cell range indices.  
- Move interaction accumulation to per-particle locals to avoid costly threaded reduction/reset overhead.  
- Make kernel-output accumulation zero-cost when disabled via `SimulationMetaData` dispatch.  

### Description
- Split same-cell neighbor iteration into two ranges around the current particle (`SameCellStart:(i-1)` and `(i+1):SameCellEnd`) and use `CellListIndex` / `SameCellStart` / `SameCellEnd` to avoid `if i == j` inside the inner loop.  
- Added `KernelOutputLocal!` overloads and local-returning `ComputeInteractionsPerParticle!` variants that return updated local accumulators instead of mutating threaded reduction arrays.  
- Implemented `NeighborLoopPerParticle!` (shifting and non-shifting overloads) which iterate per-particle, locally accumulate `dρdt`, acceleration, kernel values, kernel gradients, and shifting terms, then write them once per particle.  
- Switched `SimulationLoop` / `RunSimulation` to call the new per-particle neighbor loops (`FullStencil` naming updated) and removed the intermediate threaded reduction/reset calls for the main interaction pass.  

### Testing
- Attempted to run `Pkg.test()` via `julia --project=. -e 'using Pkg; Pkg.test()'`, but package precompilation of dependencies was interrupted before tests completed.  
- No automated unit tests in this run completed successfully due to the interrupted precompilation stage.  
- No additional CI or numeric-regression tests were executed as part of this change.  
- Recommend running full test suite and comparing numerical outputs / benchmarks locally before deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bc8cf3b3c83238a011991a3d777f8)