### PR TITLE
Clarify MotionDefinition type and short-circuit no-motion ProgressMotion

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -817,7 +817,8 @@ using LinearAlgebra
         return nothing
     end
 
-    function ProgressMotion(SimParticles, dt₂, MotionsDefinition, SimMetaData)
+    function ProgressMotion(_SimParticles, _dt₂, ::Nothing, _SimMetaData)
+        return nothing
     end
 
     function ProgressMotion(SimParticles, dt₂, MotionsDefinition, SimMetaData)
@@ -984,10 +985,18 @@ using LinearAlgebra
                                       SortingScratchSpace,
                                       NeighborCellLists, dρdtI, Velocityₙ⁺,
                                       Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
-                                      MotionDefinition) where {Dimensions, FloatType,
-                                                               SMode, KMode, BMode,
-                                                               LMode, SDD<:SPHDensityDiffusion,
-                                                               SV<:SPHViscosity}
+                                      MotionDefinition::Union{
+                                          Nothing,
+                                          AbstractVector{
+                                              Union{
+                                                  Nothing,
+                                                  MotionDetails{Dimensions, FloatType},
+                                              },
+                                          },
+                                      }) where {Dimensions, FloatType, SMode, KMode,
+                                                BMode, LMode,
+                                                SDD<:SPHDensityDiffusion,
+                                                SV<:SPHViscosity}
         @unpack Position, Density, Pressure, Velocity, Acceleration, MotionLimiter, GroupMarker, Kernel, KernelGradient, GhostPoints, GhostNormals = SimParticles
         ParticleType   = SimParticles.Type
         ParticleMarker = GroupMarker
@@ -1119,6 +1128,9 @@ using LinearAlgebra
             else
                 MotionDefinition[group_marker] = nothing
             end
+        end
+        if !any(!isnothing, MotionDefinition)
+            MotionDefinition = nothing
         end
 
         # Normal run and save data


### PR DESCRIPTION
### Motivation
- Avoid executing the per-particle motion loop when no group motions are defined to reduce unnecessary work.
- Make the no-motion case explicit so multiple dispatch can be used to short-circuit motion updates.
- Represent the absence of any group motion uniformly as `nothing` to simplify downstream checks and call sites.

### Description
- Add a no-op dispatch `function ProgressMotion(_SimParticles, _dt₂, ::Nothing, _SimMetaData) = nothing` to handle the no-motion case immediately.
- When building `MotionDefinition`, set `MotionDefinition = nothing` if no group motions are present so the no-op dispatch is selected.
- Annotate the `SimulationLoop` argument `MotionDefinition` as `::Union{Nothing, AbstractVector{Union{Nothing, MotionDetails{Dimensions, FloatType}}}}` to document allowed shapes and enable clearer dispatch.
- Adjusted call sites and setup so motion handling is deterministic and explicit for both motion and no-motion scenarios.

### Testing
- Ran `julia --project=. -e 'using Pkg; Pkg.test()'`, but the run was interrupted during dependency precompilation so the test suite did not complete.
- The precompilation output showed work on `UnicodePlots`, `CSV`, and `HDF5` before interruption, and no full test results are available.
- Per project guidance, the repository is expected to lack a `test` directory until tests are added, so `Pkg.test()` may report an error until a proper test suite is provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d4d118aac8323b1fcb40f48b4f217)