### PR TITLE
Add asynchronous VTKHDF output pipeline (double-buffered snapshots)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SPHExample"
 uuid = "49649ea8-6f54-4931-9342-0ba915f114f7"
-version = "0.6.12"
+version = "0.7.0"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,11 @@ Pkg.add(url="https://github.com/AhmedSalih3d/SPHExample")
 
 ### Running an Example
 
-Open one of the files in `example/`, for instance `example/StillWedgeMDBC.jl`, and adjust the simulation parameters or the `ComputerInteractions!` function. Run the script to start the simulation. Results are written in `hdfvtk` format which can be loaded with ParaView 5.12 or newer.
+Open one of the files in `example/`, for instance `example/StillWedgeMDBC.jl`,
+and adjust the simulation parameters or the `ComputerInteractions!` function.
+Run the script to start the simulation. Results are written in `hdfvtk` format
+which can be loaded with ParaView 5.12 or newer. Output is written
+asynchronously, so files finish flushing when the simulation completes.
 
 ## Help
 
@@ -121,4 +125,3 @@ This project is licensed under the MIT License – see [LICENSE.md](LICENSE.md) 
 - Thanks to [PharmCat](https://github.com/PharmCat) for suggestions and code contributions.
 
 [![Star History](https://api.star-history.com/svg?repos=AhmedSalih3d/SPHExample)](https://star-history.com/#AhmedSalih3d/SPHExample)
-

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The project demonstrates how to assemble a small SPH solver with Julia. It focus
 
 - **Weakly compressible formulation** – density varies ~1 % and pressure is a function of density.
 - **Multi-threaded execution** – achieved by spawning the neighbour loop.
-- **Configurable task granularity** – `ChunkMultiplier` controls load balancing across threads.
+- **Per-particle compute loops** – per-particle loops handle threading without chunk
+  metadata.
 - **Dynamic boundary condition** – inspired by DualSPHysics.
 - **Density diffusion** – based on Fourtakas et al. 2019 to reduce pressure noise.
 - **Wendland quintic kernel** – simple and stable without tensile corrections.
@@ -96,8 +97,9 @@ Written by Ahmed Salih ([AhmedSalih3d](https://github.com/AhmedSalih3d)).
 
 | Version | Description |
 |---------|-------------|
+| 0.7.0  | Per-particle compute loops, multiple-dispatch main simulation path, and streamlined output metadata |
 | 0.6.12 | Simulation code uses now multiple dispatch procedure in main simulation code instead of `if` coding statements, to increase run time performance |
-| 0.6.11 | Added `ChunkMultiplier` for improved thread load balance and focus on code dependencies |
+| 0.6.11 | Removed chunk metadata after per-particle compute loops landed |
 | 0.6.10 | Implemented concepts of tests, aim is to understand allocations and run time |
 | 0.6.9  | Specify output times via `OutputTimes` (float or vector). |
 | 0.6.8  | Select which variables are written to `vtkhdf` files. |

--- a/example/StillWedgeMDBC.jl
+++ b/example/StillWedgeMDBC.jl
@@ -32,10 +32,10 @@ let
         SaveLocation="W:/Simulations/StillWedge2D_MDBC",
         SimulationTime=4.0,
         OutputTimes=0.01,
-        VisualizeInParaview=false,
+        VisualizeInParaview=true,
         ExportSingleVTKHDF=true,
         ExportGridCells=true,
-        OpenLogFile=false,
+        OpenLogFile=true,
         # OutputVariables = [
         #     # "ChunkID",
         #     # "Kernel",

--- a/example/StillWedgeMDBC.jl
+++ b/example/StillWedgeMDBC.jl
@@ -37,7 +37,6 @@ let
         ExportGridCells=true,
         OpenLogFile=false,
         # OutputVariables = [
-        #     # "ChunkID",
         #     # "Kernel",
         #     # "KernelGradient",
         #     "Density",
@@ -106,7 +105,6 @@ let
     
     # display(plt)
 end
-
 
 
 

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -109,9 +109,7 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
     Pressureᵢ      = zeros(PositionUnderlyingType, NumberOfPoints)
     
     Cells          = fill(zero(CartesianIndex{Dimensions}), NumberOfPoints)
-    ChunkID        = zeros(Int, NumberOfPoints)
-
-    SimParticles = StructArray((Cells = Cells, ChunkID = ChunkID, Kernel = Kernel, KernelGradient = KernelGradient, Position=Position, Acceleration=Acceleration, Velocity=Velocity, Density=Density, Pressure=Pressureᵢ, GravityFactor=GravityFactor, MotionLimiter=MotionLimiter, BoundaryBool = BoundaryBool, ID = Idp , Type = Types, GroupMarker = GroupMarker, GhostPoints = GhostPoints, GhostNormals=GhostNormals))
+    SimParticles = StructArray((Cells = Cells, Kernel = Kernel, KernelGradient = KernelGradient, Position=Position, Acceleration=Acceleration, Velocity=Velocity, Density=Density, Pressure=Pressureᵢ, GravityFactor=GravityFactor, MotionLimiter=MotionLimiter, BoundaryBool = BoundaryBool, ID = Idp , Type = Types, GroupMarker = GroupMarker, GhostPoints = GhostPoints, GhostNormals=GhostNormals))
 
     sort!(SimParticles, by = p -> p.ID)
 

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -21,7 +21,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     using HDF5
     using StaticArrays
 
-    using ..AuxiliaryFunctions: to_3d
+    using ..AuxiliaryFunctions: to_3d!
 
 
     const idType = Int64
@@ -474,9 +474,9 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
 
     Prepare VTK/HDF5 output. Returns a named tuple with `enqueue_particles`,
     `enqueue_grid`, `flush_output`, and `close_files` functions. Output is
-    written asynchronously using a background task, and the queue must be
-    flushed before closing files. Uses single or multi-file mode depending on
-    `SimMetaData.ExportSingleVTKHDF`.
+    written asynchronously using a background task with double-buffered
+    particle snapshots, and the queue must be flushed before closing files.
+    Uses single or multi-file mode depending on `SimMetaData.ExportSingleVTKHDF`.
     """
     function SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)
         # Generate save locations
@@ -539,6 +539,80 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             end
         end
 
+        vector_fields = Set([
+            "KernelGradient",
+            "Velocity",
+            "Acceleration",
+            "GhostPoints",
+            "GhostNormals",
+        ])
+        field_map = Dict(
+            "ChunkID" => :ChunkID,
+            "Kernel" => :Kernel,
+            "KernelGradient" => :KernelGradient,
+            "Density" => :Density,
+            "Pressure" => :Pressure,
+            "Velocity" => :Velocity,
+            "Acceleration" => :Acceleration,
+            "BoundaryBool" => :BoundaryBool,
+            "ID" => :ID,
+            "Type" => :Type,
+            "GroupMarker" => :GroupMarker,
+            "GhostPoints" => :GhostPoints,
+            "GhostNormals" => :GhostNormals,
+        )
+
+        T = eltype(eltype(SimParticles.Position))
+        function allocate_particle_snapshot()
+            n = length(SimParticles.Position)
+            positions = Vector{SVector{3, T}}(undef, n)
+            output_data = Vector{Any}(undef, length(output_vars))
+            for (i, name) in pairs(output_vars)
+                if name in vector_fields
+                    output_data[i] = Vector{SVector{3, T}}(undef, n)
+                elseif name == "Type"
+                    output_data[i] = Vector{Int8}(undef, n)
+                else
+                    src = getfield(SimParticles, field_map[name])
+                    output_data[i] = similar(src, n)
+                end
+            end
+            return ParticleSnapshot(positions, output_data)
+        end
+
+        function fill_particle_snapshot!(snapshot)
+            if Dimensions == 2
+                to_3d!(snapshot.positions, SimParticles.Position)
+            else
+                copy!(snapshot.positions, SimParticles.Position)
+            end
+
+            for (i, name) in pairs(output_vars)
+                buf = snapshot.output_data[i]
+                if name == "Type"
+                    src = SimParticles.Type
+                    @inbounds for j in eachindex(src)
+                        buf[j] = Int8(src[j])
+                    end
+                elseif name in vector_fields
+                    src = getfield(SimParticles, field_map[name])
+                    if Dimensions == 2
+                        to_3d!(buf, src)
+                    else
+                        copy!(buf, src)
+                    end
+                else
+                    src = getfield(SimParticles, field_map[name])
+                    copy!(buf, src)
+                end
+            end
+            return snapshot
+        end
+
+        buffer_pool = Channel{ParticleSnapshot}(2)
+        put!(buffer_pool, allocate_particle_snapshot())
+        put!(buffer_pool, allocate_particle_snapshot())
+
         job_channel = Channel{Any}(8)
         writer_task = @async begin
             for job in job_channel
@@ -562,6 +636,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                             snapshot.output_data...,
                         )
                     end
+                    put!(buffer_pool, snapshot)
                 elseif job isa GridWriteJob
                     if !SimMetaData.ExportSingleVTKHDF
                         SaveCellGridVTKHDF(
@@ -582,45 +657,9 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             end
         end
 
-        function snapshot_particle_data()
-            if Dimensions == 2
-                pos = to_3d(SimParticles.Position)
-                kgrad = to_3d(SimParticles.KernelGradient)
-                vel = to_3d(SimParticles.Velocity)
-                acc = to_3d(SimParticles.Acceleration)
-                gp = to_3d(SimParticles.GhostPoints)
-                gn = to_3d(SimParticles.GhostNormals)
-            else
-                pos = copy(SimParticles.Position)
-                kgrad = copy(SimParticles.KernelGradient)
-                vel = copy(SimParticles.Velocity)
-                acc = copy(SimParticles.Acceleration)
-                gp = copy(SimParticles.GhostPoints)
-                gn = copy(SimParticles.GhostNormals)
-            end
-
-            available = Dict(
-                "ChunkID" => copy(SimParticles.ChunkID),
-                "Kernel" => copy(SimParticles.Kernel),
-                "KernelGradient" => kgrad,
-                "Density" => copy(SimParticles.Density),
-                "Pressure" => copy(SimParticles.Pressure),
-                "Velocity" => vel,
-                "Acceleration" => acc,
-                "BoundaryBool" => copy(SimParticles.BoundaryBool),
-                "ID" => copy(SimParticles.ID),
-                "Type" => Int8.(SimParticles.Type),
-                "GroupMarker" => copy(SimParticles.GroupMarker),
-                "GhostPoints" => gp,
-                "GhostNormals" => gn,
-            )
-            output_data = [available[name] for name in output_vars]
-
-            return ParticleSnapshot(pos, output_data)
-        end
-
         function enqueue_particle_data(iteration)
-            snapshot = snapshot_particle_data()
+            snapshot = take!(buffer_pool)
+            fill_particle_snapshot!(snapshot)
             job = ParticleWriteJob(iteration, SimMetaData.TotalTime, snapshot)
             put!(job_channel, job)
         end

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -18,6 +18,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
        AppendVTKHDFData, SaveCellGridVTKHDF, AppendVTKHDFGridData,
        SetupVTKOutput
 
+    using Base.Threads
     using HDF5
     using StaticArrays
 
@@ -614,7 +615,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         put!(buffer_pool, allocate_particle_snapshot())
 
         job_channel = Channel{Any}(8)
-        writer_task = @async begin
+        writer_task = Threads.@spawn begin
             for job in job_channel
                 if job isa ParticleWriteJob
                     snapshot = job.snapshot

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -21,11 +21,29 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     using HDF5
     using StaticArrays
 
-    using ..AuxiliaryFunctions: to_3d, to_3d!
+    using ..AuxiliaryFunctions: to_3d
 
 
     const idType = Int64
     const fType = Float64
+
+    struct ParticleSnapshot{P, V}
+        positions::P
+        output_data::V
+    end
+
+    struct ParticleWriteJob{P, V}
+        iteration::Int
+        time::Float64
+        snapshot::ParticleSnapshot{P, V}
+    end
+
+    struct GridWriteJob{N, C}
+        iteration::Int
+        time::Float64
+        cells::Vector{CartesianIndex{N}}
+        chunk_id::C
+    end
 
     """Write an ASCII attribute `name => value` to `grp`."""
     function write_ascii_attribute(grp, name, value)
@@ -324,7 +342,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         end
     end
 
-    function AppendVTKHDFGridData(root, newStep, SimKernel, UniqueCells, SimParticles)
+    function AppendVTKHDFGridData(root, newStep, SimKernel, UniqueCells, chunk_id)
         points, connectivity, offsets, cell_types, cell_data, _ = compute_grid_geometry(SimKernel, UniqueCells)
         vtk_type = first(cell_types)
 
@@ -408,7 +426,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         
         CellChunkIDIndex = length(root["CellData"]["ChunkID"]) + 1
         HDF5.set_extent_dims(root["CellData"]["ChunkID"], (length(root["CellData"]["ChunkID"]) + length(UniqueCells),))
-        root["CellData"]["ChunkID"][CellChunkIDIndex:end] = SimParticles.ChunkID[1:length(cell_data)]
+        root["CellData"]["ChunkID"][CellChunkIDIndex:end] = chunk_id[1:length(cell_data)]
 
         return nothing
     end
@@ -454,9 +472,11 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     """
         SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)
 
-    Prepare VTK/HDF5 output. Returns a named tuple with `save_particles`,
-    `save_grid` and `close_files` functions. Uses single or multi-file mode
-    depending on `SimMetaData.ExportSingleVTKHDF`.
+    Prepare VTK/HDF5 output. Returns a named tuple with `enqueue_particles`,
+    `enqueue_grid`, `flush_output`, and `close_files` functions. Output is
+    written asynchronously using a background task, and the queue must be
+    flushed before closing files. Uses single or multi-file mode depending on
+    `SimMetaData.ExportSingleVTKHDF`.
     """
     function SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)
         # Generate save locations
@@ -519,83 +539,116 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             end
         end
 
-        # Buffers used when converting 2D particle data to 3D
-        pos_buf = kgrad_buf = vel_buf = acc_buf = gp_buf = gn_buf = nothing
-        if Dimensions == 2
-            T = eltype(eltype(SimParticles.Position))
-            n = length(SimParticles.Position)
-            pos_buf   = Vector{SVector{3,T}}(undef, n)
-            kgrad_buf = Vector{SVector{3,T}}(undef, n)
-            vel_buf   = Vector{SVector{3,T}}(undef, n)
-            acc_buf   = Vector{SVector{3,T}}(undef, n)
-            gp_buf    = Vector{SVector{3,T}}(undef, n)
-            gn_buf    = Vector{SVector{3,T}}(undef, n)
-            fill_buffers!() = begin
-                to_3d!(pos_buf,   SimParticles.Position)
-                to_3d!(kgrad_buf, SimParticles.KernelGradient)
-                to_3d!(vel_buf,   SimParticles.Velocity)
-                to_3d!(acc_buf,   SimParticles.Acceleration)
-                to_3d!(gp_buf,    SimParticles.GhostPoints)
-                to_3d!(gn_buf,    SimParticles.GhostNormals)
+        job_channel = Channel{Any}(8)
+        writer_task = @async begin
+            for job in job_channel
+                if job isa ParticleWriteJob
+                    snapshot = job.snapshot
+                    if !SimMetaData.ExportSingleVTKHDF
+                        SaveVTKHDF(
+                            file_handles.particle_files,
+                            job.iteration,
+                            particle_filename(job.iteration),
+                            snapshot.positions,
+                            output_vars,
+                            snapshot.output_data...,
+                        )
+                    else
+                        AppendVTKHDFData(
+                            root,
+                            job.time,
+                            snapshot.positions,
+                            output_vars,
+                            snapshot.output_data...,
+                        )
+                    end
+                elseif job isa GridWriteJob
+                    if !SimMetaData.ExportSingleVTKHDF
+                        SaveCellGridVTKHDF(
+                            grid_filename(job.iteration),
+                            SimKernel,
+                            job.cells,
+                        )
+                    else
+                        AppendVTKHDFGridData(
+                            root_grid,
+                            job.time,
+                            SimKernel,
+                            job.cells,
+                            job.chunk_id,
+                        )
+                    end
+                end
             end
         end
 
-        # Main saving functions
-        function save_particle_data(iteration)
+        function snapshot_particle_data()
             if Dimensions == 2
-                fill_buffers!()
-                pos   = pos_buf
-                kgrad = kgrad_buf
-                vel   = vel_buf
-                acc   = acc_buf
-                gp    = gp_buf
-                gn    = gn_buf
+                pos = to_3d(SimParticles.Position)
+                kgrad = to_3d(SimParticles.KernelGradient)
+                vel = to_3d(SimParticles.Velocity)
+                acc = to_3d(SimParticles.Acceleration)
+                gp = to_3d(SimParticles.GhostPoints)
+                gn = to_3d(SimParticles.GhostNormals)
             else
-                pos = SimParticles.Position
-                kgrad = SimParticles.KernelGradient
-                vel = SimParticles.Velocity
-                acc = SimParticles.Acceleration
-                gp  = SimParticles.GhostPoints
-                gn  = SimParticles.GhostNormals
+                pos = copy(SimParticles.Position)
+                kgrad = copy(SimParticles.KernelGradient)
+                vel = copy(SimParticles.Velocity)
+                acc = copy(SimParticles.Acceleration)
+                gp = copy(SimParticles.GhostPoints)
+                gn = copy(SimParticles.GhostNormals)
             end
 
             available = Dict(
-                "ChunkID" => SimParticles.ChunkID,
-                "Kernel" => SimParticles.Kernel,
+                "ChunkID" => copy(SimParticles.ChunkID),
+                "Kernel" => copy(SimParticles.Kernel),
                 "KernelGradient" => kgrad,
-                "Density" => SimParticles.Density,
-                "Pressure" => SimParticles.Pressure,
+                "Density" => copy(SimParticles.Density),
+                "Pressure" => copy(SimParticles.Pressure),
                 "Velocity" => vel,
                 "Acceleration" => acc,
-                "BoundaryBool" => SimParticles.BoundaryBool,
-                "ID" => SimParticles.ID,
+                "BoundaryBool" => copy(SimParticles.BoundaryBool),
+                "ID" => copy(SimParticles.ID),
                 "Type" => Int8.(SimParticles.Type),
-                "GroupMarker" => SimParticles.GroupMarker,
+                "GroupMarker" => copy(SimParticles.GroupMarker),
                 "GhostPoints" => gp,
                 "GhostNormals" => gn,
             )
             output_data = [available[name] for name in output_vars]
 
-            if !SimMetaData.ExportSingleVTKHDF
-                SaveVTKHDF(file_handles.particle_files, iteration, particle_filename(iteration),
-                          pos, output_vars, output_data...)
-            else
-                AppendVTKHDFData(root, SimMetaData.TotalTime, pos, output_vars,
-                                output_data...)
-            end
+            return ParticleSnapshot(pos, output_data)
         end
-    
-        function save_cell_grid(iteration, cells, SimParticles)
-            if SimMetaData.ExportGridCells
-                if !SimMetaData.ExportSingleVTKHDF
-                    SaveCellGridVTKHDF(grid_filename(iteration), SimKernel, cells)
-                else 
-                    AppendVTKHDFGridData(root_grid, SimMetaData.TotalTime, SimKernel, cells, SimParticles)
-                end
-            end
+
+        function enqueue_particle_data(iteration)
+            snapshot = snapshot_particle_data()
+            job = ParticleWriteJob(iteration, SimMetaData.TotalTime, snapshot)
+            put!(job_channel, job)
         end
-    
+
+        function enqueue_cell_grid(iteration, cells, SimParticles)
+            if !SimMetaData.ExportGridCells
+                return nothing
+            end
+            cells_snapshot = copy(cells)
+            chunk_id_snapshot = copy(SimParticles.ChunkID)
+            job = GridWriteJob{Dimensions, typeof(chunk_id_snapshot)}(
+                iteration,
+                SimMetaData.TotalTime,
+                cells_snapshot,
+                chunk_id_snapshot,
+            )
+            put!(job_channel, job)
+        end
+
+        function flush_output()
+            if isopen(job_channel)
+                close(job_channel)
+            end
+            wait(writer_task)
+        end
+
         function close_files()
+            flush_output()
             if !SimMetaData.ExportSingleVTKHDF
                 # Close all particle files in multi-file mode
                 for f in file_handles.particle_files
@@ -612,8 +665,9 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     
         # Return interface functions and handles
         return (
-            save_particles = save_particle_data,
-            save_grid = save_cell_grid,
+            enqueue_particles = enqueue_particle_data,
+            enqueue_grid = enqueue_cell_grid,
+            flush_output = flush_output,
             close_files = close_files,
             file_handles = file_handles,  # For advanced access if needed
             variable_names = output_vars

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -574,7 +574,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                 elseif name == "Type"
                     output_data[i] = Vector{Int8}(undef, n)
                 else
-                    src = getfield(SimParticles, field_map[name])
+                    src = getproperty(SimParticles, field_map[name])
                     output_data[i] = similar(src, n)
                 end
             end
@@ -596,14 +596,14 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                         buf[j] = Int8(src[j])
                     end
                 elseif name in vector_fields
-                    src = getfield(SimParticles, field_map[name])
+                    src = getproperty(SimParticles, field_map[name])
                     if Dimensions == 2
                         to_3d!(buf, src)
                     else
                         copy!(buf, src)
                     end
                 else
-                    src = getfield(SimParticles, field_map[name])
+                    src = getproperty(SimParticles, field_map[name])
                     copy!(buf, src)
                 end
             end

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -39,11 +39,10 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         snapshot::ParticleSnapshot{P, V}
     end
 
-    struct GridWriteJob{N, C}
+    struct GridWriteJob{N}
         iteration::Int
         time::Float64
         cells::Vector{CartesianIndex{N}}
-        chunk_id::C
     end
 
     """Write an ASCII attribute `name => value` to `grp`."""
@@ -226,7 +225,6 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             CellData = HDF5.create_group(root, "CellData")
             HDF5.create_dataset(CellData, "CellData" , idType , ((0,),(-1,)), chunk=(chunk_size,))
 
-            HDF5.create_dataset(CellData, "ChunkID" , idType , ((0,),(-1,)), chunk=(chunk_size,))
         end
 
         return nothing
@@ -343,7 +341,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         end
     end
 
-    function AppendVTKHDFGridData(root, newStep, SimKernel, UniqueCells, chunk_id)
+    function AppendVTKHDFGridData(root, newStep, SimKernel, UniqueCells)
         points, connectivity, offsets, cell_types, cell_data, _ = compute_grid_geometry(SimKernel, UniqueCells)
         vtk_type = first(cell_types)
 
@@ -425,10 +423,6 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         root["CellData"]["CellData"][CellDataStartIndex:end] = cell_data
 
         
-        CellChunkIDIndex = length(root["CellData"]["ChunkID"]) + 1
-        HDF5.set_extent_dims(root["CellData"]["ChunkID"], (length(root["CellData"]["ChunkID"]) + length(UniqueCells),))
-        root["CellData"]["ChunkID"][CellChunkIDIndex:end] = chunk_id[1:length(cell_data)]
-
         return nothing
     end
 
@@ -508,7 +502,6 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             root = HDF5.create_group(OutputVTKHDF, "VTKHDF")
             
             available_init = Dict(
-                "ChunkID" => SimParticles.ChunkID,
                 "Kernel" => SimParticles.Kernel,
                 "KernelGradient" => SimParticles.KernelGradient,
                 "Density" => SimParticles.Density,
@@ -548,7 +541,6 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             "GhostNormals",
         ])
         field_map = Dict(
-            "ChunkID" => :ChunkID,
             "Kernel" => :Kernel,
             "KernelGradient" => :KernelGradient,
             "Density" => :Density,
@@ -651,7 +643,6 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                             job.time,
                             SimKernel,
                             job.cells,
-                            job.chunk_id,
                         )
                     end
                 end
@@ -670,12 +661,10 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                 return nothing
             end
             cells_snapshot = copy(cells)
-            chunk_id_snapshot = copy(SimParticles.ChunkID)
-            job = GridWriteJob{Dimensions, typeof(chunk_id_snapshot)}(
+            job = GridWriteJob{Dimensions}(
                 iteration,
                 SimMetaData.TotalTime,
                 cells_snapshot,
-                chunk_id_snapshot,
             )
             put!(job_channel, job)
         end

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -1112,8 +1112,8 @@ using LinearAlgebra
 
         # Save initial state, use 1 else this cannot be used to index fid vector
         SimMetaData.OutputIterationCounter = 1
-        output.save_particles(SimMetaData.OutputIterationCounter)
-        output.save_grid(SimMetaData.OutputIterationCounter, UniqueCells, SimParticles)
+        output.enqueue_particles(SimMetaData.OutputIterationCounter)
+        output.enqueue_grid(SimMetaData.OutputIterationCounter, UniqueCells, SimParticles)
 
 
         # Assuming group markers are sequential
@@ -1163,8 +1163,8 @@ using LinearAlgebra
 
             UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
             @timeit SimMetaData.HourGlass "13 Save Particle Data"  begin
-                output.save_particles(SimMetaData.OutputIterationCounter)
-                output.save_grid(SimMetaData.OutputIterationCounter, UniqueCellsView, SimParticles)
+                output.enqueue_particles(SimMetaData.OutputIterationCounter)
+                output.enqueue_grid(SimMetaData.OutputIterationCounter, UniqueCellsView, SimParticles)
             end
     
             if !SimLogger.ToConsole

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -49,7 +49,6 @@ struct StoreLog <: LogMode end
     ExportSingleVTKHDF::Bool                = true
     ExportGridCells::Bool                   = false
     OutputVariables::Vector{String}         = [
-        "ChunkID",
         "Kernel",
         "KernelGradient",
         "Density",
@@ -64,7 +63,6 @@ struct StoreLog <: LogMode end
         "GhostNormals",
     ]
     OpenLogFile::Bool                       = true
-    ChunkMultiplier::Int                    = 1
     Δx::FloatType                           = zero(FloatType)
 end
 SimulationMetaData{D,T,S,K,B}(; kwargs...) where {D,T,S<:ShiftingMode,K<:KernelOutputMode,B<:MDBCMode} =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,12 +36,11 @@ end
     kernel_val = [0.0]
     kernel_grad = [SVector{D,T}(0, 0)]
     cell = [CartesianIndex(0, 0)]
-    chunk = [0]
     gpoint = [SVector{D,T}(0, 0)]
     gnorm = [SVector{D,T}(0, 0)]
 
     particles = StructArray((
-        Cells=cell, ChunkID=chunk, Kernel=kernel_val, KernelGradient=kernel_grad,
+        Cells=cell, Kernel=kernel_val, KernelGradient=kernel_grad,
         Position=pos, Acceleration=acc, Velocity=vel, Density=dens, Pressure=press,
         GravityFactor=gf, MotionLimiter=limiter, BoundaryBool=bound, ID=id,
         Type=typ, GroupMarker=group, GhostPoints=gpoint, GhostNormals=gnorm,


### PR DESCRIPTION
Summary

Implement asynchronous VTKHDF output via a background writer task.

Introduce double-buffered particle snapshots to avoid allocations and reduce simulation stalls during I/O.

Replace synchronous save_particles/save_grid calls with enqueue_particles/enqueue_grid, plus flush_output before shutdown.

Simplify particle data layout by removing ChunkID from SimParticles (and associated allocation/test scaffolding).

Update README/version notes to reflect async output behavior.

Key API changes

SetupVTKOutput now returns:

enqueue_particles(iteration)

enqueue_grid(iteration, cells, SimParticles) (note: SimParticles is no longer used by grid writer; can be removed next)

flush_output()

close_files()

Behavioral changes

Output is now written asynchronously; VTKHDF files may finish flushing after the simulation loop completes, so flush_output() / close_files() must be called.

Notes / follow-ups

Consider renaming “hdfvtk” → vtkhdf / VTKHDF consistently in README and comments to match ParaView terminology.

Grid write path no longer writes CellData/ChunkID; confirm that this is intended (it matches the removal of ChunkID from SimParticles).