### PR TITLE
Add optional particle counts to cell grid output

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ and adjust the simulation parameters or the `ComputerInteractions!` function.
 Run the script to start the simulation. Results are written in `hdfvtk` format
 which can be loaded with ParaView 5.12 or newer. Output is written
 asynchronously, so files finish flushing when the simulation completes.
+To color exported cell grids by particle counts, set
+`ExportGridCellParticleCounts=true` in `SimulationMetaData`.
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ Run the script to start the simulation. Results are written in `hdfvtk` format
 which can be loaded with ParaView 5.12 or newer. Output is written
 asynchronously, so files finish flushing when the simulation completes.
 To color exported cell grids by particle counts, set
-`ExportGridCellParticleCounts=true` in `SimulationMetaData`.
+`ExportGridCellParticleCounts=true` in `SimulationMetaData`. This also adds a
+`ParticleNeighborsPerCell` array that includes each cell's particle count minus
+one plus the particles in its neighbor stencil.
 
 ## Help
 

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -247,7 +247,10 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         return nothing
     end
 
-    function GenerateStepStructure(root,  variable_names = String[], args...; vtk_file_type = "PolyData", chunk_size = 1000)
+    function GenerateStepStructure(root, variable_names = String[], args...;
+                                   vtk_file_type = "PolyData",
+                                   chunk_size = 1000,
+                                   cell_data_names = ["CellData"])
         steps = HDF5.create_group(root, "Steps")
     
         NSteps, _ = HDF5.create_attribute(steps, "NSteps", Int32)
@@ -269,15 +272,20 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             for name in nTopoDSs
                 HDF5.create_dataset(steps, name, idType, ((0,),(-1,)), chunk=(chunk_size,))
             end
+            cData = HDF5.create_group(steps, "CellDataOffsets")
+            for name in cell_data_names
+                HDF5.create_dataset(cData, name, idType, ((0,),(-1,)),
+                                    chunk=(chunk_size,))
+            end
         end
             
         pData = HDF5.create_group(steps, "PointDataOffsets")
 
-
         for i ∈ eachindex(variable_names)
             var_name = variable_names[i]
 
-            HDF5.create_dataset(pData, var_name, idType, ((0,),(-1,)), chunk=(chunk_size,))
+            HDF5.create_dataset(pData, var_name, idType, ((0,),(-1,)),
+                                chunk=(chunk_size,))
         end
     
     end
@@ -450,6 +458,11 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             end
             start_index = length(root["CellData"][name]) + 1
             HDF5.set_extent_dims(
+                steps["CellDataOffsets"][name],
+                (length(steps["CellDataOffsets"][name]) + 1,),
+            )
+            steps["CellDataOffsets"][name][end] = start_index - 1
+            HDF5.set_extent_dims(
                 root["CellData"][name],
                 (length(root["CellData"][name]) + length(UniqueCells),),
             )
@@ -571,7 +584,11 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                     vtk_file_type="UnstructuredGrid",
                     cell_data_names=cell_data_names,
                 )
-                GenerateStepStructure(root_grid; vtk_file_type="UnstructuredGrid")
+                GenerateStepStructure(
+                    root_grid;
+                    vtk_file_type="UnstructuredGrid",
+                    cell_data_names=cell_data_names,
+                )
                 
                 (particle_files = OutputVTKHDF, grid_files = OutputVTKHDFGrid)
             else

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -44,6 +44,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         time::Float64
         cells::Vector{CartesianIndex{N}}
         cell_particle_counts::Union{Nothing, Vector{Int}}
+        cell_neighbor_counts::Union{Nothing, Vector{Int}}
     end
 
     """Write an ASCII attribute `name => value` to `grp`."""
@@ -136,10 +137,13 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         return points, connectivity, offsets, cell_types, cell_ids, dims
     end
 
-    function cell_data_payload(cell_ids, cell_particle_counts)
+    function cell_data_payload(cell_ids, cell_particle_counts, cell_neighbor_counts)
         payload = Dict("CellData" => cell_ids)
         if cell_particle_counts !== nothing
             payload["ParticleCount"] = cell_particle_counts
+        end
+        if cell_neighbor_counts !== nothing
+            payload["ParticleNeighborsPerCell"] = cell_neighbor_counts
         end
         return payload
     end
@@ -367,7 +371,8 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     end
 
     function AppendVTKHDFGridData(root, newStep, SimKernel, UniqueCells,
-                                  cell_particle_counts = nothing)
+                                  cell_particle_counts = nothing,
+                                  cell_neighbor_counts = nothing)
         points, connectivity, offsets, cell_types, cell_ids, _ =
             compute_grid_geometry(SimKernel, UniqueCells)
         vtk_type = first(cell_types)
@@ -445,7 +450,11 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         HDF5.set_extent_dims(root["Types"], (length(root["Types"]) + length(UniqueCells),))
         root["Types"][TypesStartIndex:end] = vtk_type
 
-        cell_payload = cell_data_payload(cell_ids, cell_particle_counts)
+        cell_payload = cell_data_payload(
+            cell_ids,
+            cell_particle_counts,
+            cell_neighbor_counts,
+        )
         for (name, data) in cell_payload
             if !haskey(root["CellData"], name)
                 HDF5.create_dataset(
@@ -474,7 +483,8 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     end
 
     function SaveCellGridVTKHDF(FilePath, SimKernel, UniqueCells,
-                                cell_particle_counts = nothing)
+                                cell_particle_counts = nothing,
+                                cell_neighbor_counts = nothing)
         points, connectivity, offsets, cell_types, cell_ids, _ =
             compute_grid_geometry(SimKernel, UniqueCells)
 
@@ -502,7 +512,11 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
 
         # Write CellData (cell-level variables)
         let cell_group = HDF5.create_group(gtop, "CellData")
-            for (name, data) in cell_data_payload(cell_ids, cell_particle_counts)
+            for (name, data) in cell_data_payload(
+                cell_ids,
+                cell_particle_counts,
+                cell_neighbor_counts,
+            )
                 cell_group[name] = data
             end
             close(cell_group)
@@ -578,6 +592,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                 cell_data_names = ["CellData"]
                 if SimMetaData.ExportGridCellParticleCounts
                     push!(cell_data_names, "ParticleCount")
+                    push!(cell_data_names, "ParticleNeighborsPerCell")
                 end
                 GenerateGeometryStructure(
                     root_grid;
@@ -700,6 +715,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                             SimKernel,
                             job.cells,
                             job.cell_particle_counts,
+                            job.cell_neighbor_counts,
                         )
                     else
                         AppendVTKHDFGridData(
@@ -708,6 +724,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                             SimKernel,
                             job.cells,
                             job.cell_particle_counts,
+                            job.cell_neighbor_counts,
                         )
                     end
                 end
@@ -721,18 +738,23 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             put!(job_channel, job)
         end
 
-        function enqueue_cell_grid(iteration, cells; cell_particle_counts = nothing)
+        function enqueue_cell_grid(iteration, cells;
+                                   cell_particle_counts = nothing,
+                                   cell_neighbor_counts = nothing)
             if !SimMetaData.ExportGridCells
                 return nothing
             end
             cells_snapshot = copy(cells)
             counts_snapshot = cell_particle_counts === nothing ? nothing :
                 copy(cell_particle_counts)
+            neighbors_snapshot = cell_neighbor_counts === nothing ? nothing :
+                copy(cell_neighbor_counts)
             job = GridWriteJob{Dimensions}(
                 iteration,
                 SimMetaData.TotalTime,
                 cells_snapshot,
                 counts_snapshot,
+                neighbors_snapshot,
             )
             put!(job_channel, job)
         end

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -43,6 +43,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         iteration::Int
         time::Float64
         cells::Vector{CartesianIndex{N}}
+        cell_particle_counts::Union{Nothing, Vector{Int}}
     end
 
     """Write an ASCII attribute `name => value` to `grp`."""
@@ -57,7 +58,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     """
     Compute points and connectivity information for an unstructured grid given
     `UniqueCells` from the SPH cell list.  Returns `(points, connectivity,
-    offsets, cell_types, cell_data, dims)` where `dims` is 2 or 3.
+    offsets, cell_types, cell_ids, dims)` where `dims` is 2 or 3.
     """
     function compute_grid_geometry(SimKernel, UniqueCells)
         ExtractDimensionality(::AbstractVector{CartesianIndex{N}}) where N = N
@@ -84,7 +85,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         connectivity = Int[]
         offsets      = Int[0]
         cell_types   = UInt8[]
-        cell_data    = Int[]
+        cell_ids     = Int[]
 
         vtk_type = dims == 2 ? UInt8(9) : UInt8(12)  # QUAD or HEXADRON
 
@@ -129,10 +130,18 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             end
             push!(offsets, length(connectivity))
             push!(cell_types, vtk_type)
-            push!(cell_data, id)
+            push!(cell_ids, id)
         end
 
-        return points, connectivity, offsets, cell_types, cell_data, dims
+        return points, connectivity, offsets, cell_types, cell_ids, dims
+    end
+
+    function cell_data_payload(cell_ids, cell_particle_counts)
+        payload = Dict("CellData" => cell_ids)
+        if cell_particle_counts !== nothing
+            payload["ParticleCount"] = cell_particle_counts
+        end
+        return payload
     end
 
     function SaveVTKHDF(fid_vector, index, filepath, points, variable_names = String[], args...)
@@ -178,7 +187,12 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     end
 
 
-    function GenerateGeometryStructure(root, variable_names = String[], args...; chunk_size = 100, vtk_file_type = "PolyData", idType = Int64, fType = Float64)
+    function GenerateGeometryStructure(root, variable_names = String[], args...;
+                                       chunk_size = 100,
+                                       vtk_file_type = "PolyData",
+                                       idType = Int64,
+                                       fType = Float64,
+                                       cell_data_names = ["CellData"])
         @assert length(variable_names) == length(args) "Same number of variable_names as args is necessary"
         # Write version of VTKHDF format as an attribute
         HDF5.attrs(root)["Version"] = Int32.([2, 3])
@@ -223,7 +237,10 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             FieldData = HDF5.create_group(root, "FieldData") #Currently just empty group
 
             CellData = HDF5.create_group(root, "CellData")
-            HDF5.create_dataset(CellData, "CellData" , idType , ((0,),(-1,)), chunk=(chunk_size,))
+            for name in cell_data_names
+                HDF5.create_dataset(CellData, name, idType, ((0,), (-1,)),
+                                    chunk=(chunk_size,))
+            end
 
         end
 
@@ -341,8 +358,10 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         end
     end
 
-    function AppendVTKHDFGridData(root, newStep, SimKernel, UniqueCells)
-        points, connectivity, offsets, cell_types, cell_data, _ = compute_grid_geometry(SimKernel, UniqueCells)
+    function AppendVTKHDFGridData(root, newStep, SimKernel, UniqueCells,
+                                  cell_particle_counts = nothing)
+        points, connectivity, offsets, cell_types, cell_ids, _ =
+            compute_grid_geometry(SimKernel, UniqueCells)
         vtk_type = first(cell_types)
 
         
@@ -418,16 +437,33 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         HDF5.set_extent_dims(root["Types"], (length(root["Types"]) + length(UniqueCells),))
         root["Types"][TypesStartIndex:end] = vtk_type
 
-        CellDataStartIndex = length(root["CellData"]["CellData"]) + 1
-        HDF5.set_extent_dims(root["CellData"]["CellData"], (length(root["CellData"]["CellData"]) + length(UniqueCells),))
-        root["CellData"]["CellData"][CellDataStartIndex:end] = cell_data
+        cell_payload = cell_data_payload(cell_ids, cell_particle_counts)
+        for (name, data) in cell_payload
+            if !haskey(root["CellData"], name)
+                HDF5.create_dataset(
+                    root["CellData"],
+                    name,
+                    eltype(data),
+                    ((0,), (-1,)),
+                    chunk=(1024,),
+                )
+            end
+            start_index = length(root["CellData"][name]) + 1
+            HDF5.set_extent_dims(
+                root["CellData"][name],
+                (length(root["CellData"][name]) + length(UniqueCells),),
+            )
+            root["CellData"][name][start_index:end] = data
+        end
 
         
         return nothing
     end
 
-    function SaveCellGridVTKHDF(FilePath, SimKernel, UniqueCells)
-        points, connectivity, offsets, cell_types, cell_data, _ = compute_grid_geometry(SimKernel, UniqueCells)
+    function SaveCellGridVTKHDF(FilePath, SimKernel, UniqueCells,
+                                cell_particle_counts = nothing)
+        points, connectivity, offsets, cell_types, cell_ids, _ =
+            compute_grid_geometry(SimKernel, UniqueCells)
 
         # Open HDF5 file for writing
         io = h5open(FilePath, "w")
@@ -453,7 +489,9 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
 
         # Write CellData (cell-level variables)
         let cell_group = HDF5.create_group(gtop, "CellData")
-            cell_group["CellData"] = cell_data
+            for (name, data) in cell_data_payload(cell_ids, cell_particle_counts)
+                cell_group[name] = data
+            end
             close(cell_group)
         end
 
@@ -524,7 +562,15 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             if SimMetaData.ExportGridCells
                 OutputVTKHDFGrid = h5open("$(particle_savepath)_GridCells.vtkhdf", "w")
                 root_grid = HDF5.create_group(OutputVTKHDFGrid, "VTKHDF")
-                GenerateGeometryStructure(root_grid; vtk_file_type="UnstructuredGrid")
+                cell_data_names = ["CellData"]
+                if SimMetaData.ExportGridCellParticleCounts
+                    push!(cell_data_names, "ParticleCount")
+                end
+                GenerateGeometryStructure(
+                    root_grid;
+                    vtk_file_type="UnstructuredGrid",
+                    cell_data_names=cell_data_names,
+                )
                 GenerateStepStructure(root_grid; vtk_file_type="UnstructuredGrid")
                 
                 (particle_files = OutputVTKHDF, grid_files = OutputVTKHDFGrid)
@@ -636,6 +682,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                             grid_filename(job.iteration),
                             SimKernel,
                             job.cells,
+                            job.cell_particle_counts,
                         )
                     else
                         AppendVTKHDFGridData(
@@ -643,6 +690,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                             job.time,
                             SimKernel,
                             job.cells,
+                            job.cell_particle_counts,
                         )
                     end
                 end
@@ -656,15 +704,18 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             put!(job_channel, job)
         end
 
-        function enqueue_cell_grid(iteration, cells, SimParticles)
+        function enqueue_cell_grid(iteration, cells; cell_particle_counts = nothing)
             if !SimMetaData.ExportGridCells
                 return nothing
             end
             cells_snapshot = copy(cells)
+            counts_snapshot = cell_particle_counts === nothing ? nothing :
+                copy(cell_particle_counts)
             job = GridWriteJob{Dimensions}(
                 iteration,
                 SimMetaData.TotalTime,
                 cells_snapshot,
+                counts_snapshot,
             )
             put!(job_channel, job)
         end

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -1122,12 +1122,15 @@ using LinearAlgebra
         SimMetaData.OutputIterationCounter = 1
         output.enqueue_particles(SimMetaData.OutputIterationCounter)
         cell_particle_counts = nothing
-        if SimMetaData.ExportGridCellParticleCounts &&
-           SimMetaData.IndexCounter > 0
-            cell_particle_counts = compute_cell_particle_counts(
-                ParticleRanges,
-                SimMetaData.IndexCounter,
-            )
+        if SimMetaData.ExportGridCellParticleCounts
+            if SimMetaData.IndexCounter > 0
+                cell_particle_counts = compute_cell_particle_counts(
+                    ParticleRanges,
+                    SimMetaData.IndexCounter,
+                )
+            else
+                cell_particle_counts = zeros(Int, length(UniqueCells))
+            end
         end
         output.enqueue_grid(
             SimMetaData.OutputIterationCounter,

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -158,6 +158,19 @@ using LinearAlgebra
         return counts
     end
 
+    function compute_cell_neighbor_counts(particle_ranges, neighbor_cell_lists, n_cells)
+        counts = compute_cell_particle_counts(particle_ranges, n_cells)
+        neighbors = Vector{Int}(undef, n_cells)
+        @inbounds for i in 1:n_cells
+            neighbor_total = 0
+            for neighbor_idx in neighbor_cell_lists[i]
+                neighbor_total += counts[neighbor_idx]
+            end
+            neighbors[i] = max(counts[i] - 1, 0) + neighbor_total
+        end
+        return neighbors
+    end
+
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
@@ -1121,22 +1134,28 @@ using LinearAlgebra
         # Save initial state, use 1 else this cannot be used to index fid vector
         SimMetaData.OutputIterationCounter = 1
         output.enqueue_particles(SimMetaData.OutputIterationCounter)
-        cell_particle_counts = nothing
-        if SimMetaData.ExportGridCellParticleCounts
-            if SimMetaData.IndexCounter > 0
+        if SimMetaData.IndexCounter > 0
+            unique_cells_view = view(UniqueCells, 1:SimMetaData.IndexCounter)
+            cell_particle_counts = nothing
+            cell_neighbor_counts = nothing
+            if SimMetaData.ExportGridCellParticleCounts
                 cell_particle_counts = compute_cell_particle_counts(
                     ParticleRanges,
                     SimMetaData.IndexCounter,
                 )
-            else
-                cell_particle_counts = zeros(Int, length(UniqueCells))
+                cell_neighbor_counts = compute_cell_neighbor_counts(
+                    ParticleRanges,
+                    NeighborCellLists,
+                    SimMetaData.IndexCounter,
+                )
             end
+            output.enqueue_grid(
+                SimMetaData.OutputIterationCounter,
+                unique_cells_view,
+                cell_particle_counts=cell_particle_counts,
+                cell_neighbor_counts=cell_neighbor_counts,
+            )
         end
-        output.enqueue_grid(
-            SimMetaData.OutputIterationCounter,
-            UniqueCells,
-            cell_particle_counts=cell_particle_counts,
-        )
 
 
         # Assuming group markers are sequential
@@ -1186,9 +1205,15 @@ using LinearAlgebra
 
             UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
             cell_particle_counts = nothing
+            cell_neighbor_counts = nothing
             if SimMetaData.ExportGridCellParticleCounts
                 cell_particle_counts = compute_cell_particle_counts(
                     ParticleRanges,
+                    length(UniqueCellsView),
+                )
+                cell_neighbor_counts = compute_cell_neighbor_counts(
+                    ParticleRanges,
+                    NeighborCellLists,
                     length(UniqueCellsView),
                 )
             end
@@ -1198,6 +1223,7 @@ using LinearAlgebra
                     SimMetaData.OutputIterationCounter,
                     UniqueCellsView,
                     cell_particle_counts=cell_particle_counts,
+                    cell_neighbor_counts=cell_neighbor_counts,
                 )
             end
     

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -150,6 +150,14 @@ using LinearAlgebra
         return IndexCounter 
     end
 
+    function compute_cell_particle_counts(particle_ranges, n_cells)
+        counts = Vector{Int}(undef, n_cells)
+        @inbounds for i in 1:n_cells
+            counts[i] = particle_ranges[i + 1] - particle_ranges[i]
+        end
+        return counts
+    end
+
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
@@ -1113,7 +1121,19 @@ using LinearAlgebra
         # Save initial state, use 1 else this cannot be used to index fid vector
         SimMetaData.OutputIterationCounter = 1
         output.enqueue_particles(SimMetaData.OutputIterationCounter)
-        output.enqueue_grid(SimMetaData.OutputIterationCounter, UniqueCells, SimParticles)
+        cell_particle_counts = nothing
+        if SimMetaData.ExportGridCellParticleCounts &&
+           SimMetaData.IndexCounter > 0
+            cell_particle_counts = compute_cell_particle_counts(
+                ParticleRanges,
+                SimMetaData.IndexCounter,
+            )
+        end
+        output.enqueue_grid(
+            SimMetaData.OutputIterationCounter,
+            UniqueCells,
+            cell_particle_counts=cell_particle_counts,
+        )
 
 
         # Assuming group markers are sequential
@@ -1162,9 +1182,20 @@ using LinearAlgebra
             SimMetaData.OutputIterationCounter += 1
 
             UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
+            cell_particle_counts = nothing
+            if SimMetaData.ExportGridCellParticleCounts
+                cell_particle_counts = compute_cell_particle_counts(
+                    ParticleRanges,
+                    length(UniqueCellsView),
+                )
+            end
             @timeit SimMetaData.HourGlass "13 Save Particle Data"  begin
                 output.enqueue_particles(SimMetaData.OutputIterationCounter)
-                output.enqueue_grid(SimMetaData.OutputIterationCounter, UniqueCellsView, SimParticles)
+                output.enqueue_grid(
+                    SimMetaData.OutputIterationCounter,
+                    UniqueCellsView,
+                    cell_particle_counts=cell_particle_counts,
+                )
             end
     
             if !SimLogger.ToConsole

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -48,6 +48,7 @@ struct StoreLog <: LogMode end
     VisualizeInParaview::Bool               = true
     ExportSingleVTKHDF::Bool                = true
     ExportGridCells::Bool                   = false
+    ExportGridCellParticleCounts::Bool      = false
     OutputVariables::Vector{String}         = [
         "Kernel",
         "KernelGradient",


### PR DESCRIPTION
### Motivation
- Provide an option to colour exported cell grids in ParaView by the number of particles in each cell for easier debugging and analysis.
- Avoid changing existing default behaviour by making the feature opt-in via a SimulationMetaData flag.

### Description
- Added `ExportGridCellParticleCounts::Bool` to `SimulationMetaData` to toggle writing per-cell particle counts.
- Threaded a `cell_particle_counts` payload through neighbor/cell-list code to the grid enqueue/write path and extended `GridWriteJob` to carry counts.
- Extended `compute_grid_geometry`, `SaveCellGridVTKHDF`, `AppendVTKHDFGridData`, and `GenerateGeometryStructure` to produce and persist an optional `ParticleCount` dataset alongside the cell ID data.
- Updated `README.md` with usage notes for the new `ExportGridCellParticleCounts` option.

### Testing
- Ran the project test command: `julia --project=. -e 'using Pkg; Pkg.test()'` to exercise precompilation and the test harness, but the run repeatedly hung during dependency precompilation (UnicodePlots) and was interrupted. 
- Observed a precompilation warning/error about method overwriting during iterative edits which was addressed by converting overloaded enqueue helpers to a single keyword-argument function, however full test completion was not achieved due to the precompilation hang. 
- No automated tests were added or modified in this PR; existing test runs could not finish successfully in the CI-like environment used here. 
- Commands executed: `julia --project=. -e 'using Pkg; Pkg.test()'` (precompilation hung; interrupted).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ddccfbe948323bd3f1e3402341237)