### PR TITLE
Threaded Δt reductions

### DIFF
--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -25,16 +25,27 @@ function Δt(Position, Velocity, Acceleration, SimulationConstants, SPHKernel)
     @unpack c₀, CFL = SimulationConstants
     @unpack h, η²   = SPHKernel
 
-    # Viscous timestep constraint
-    # More idiomatic and potentially faster version of max_visc
-    visc = maximum(zip(Velocity, Position)) do (v, r)
-        abs(h * dot(v, r) / (dot(r, r) + η²))
+    visc_values = fill(0.0, Threads.nthreads())
+    dt1_values = fill(Inf, Threads.nthreads())
+    Threads.@threads for i in eachindex(Position)
+        tid = Threads.threadid()
+        v = Velocity[i]
+        r = Position[i]
+        acc = Acceleration[i]
+
+        visc_values[tid] = max(
+            visc_values[tid],
+            abs(h * dot(v, r) / (dot(r, r) + η²)),
+        )
+
+        acc_norm = norm(acc)
+        if acc_norm != 0
+            dt1_values[tid] = min(dt1_values[tid], sqrt(h / acc_norm))
+        end
     end
 
-    # Force-based timestep constraint
-    # Use a generator expression with `minimum` for conciseness and efficiency
-    # The norm of the acceleration is calculated for each particle.
-    dt1 = minimum(sqrt(h / norm(acc)) for acc in Acceleration; init=Inf)
+    visc = maximum(visc_values)
+    dt1 = minimum(dt1_values)
 
     # Courant-like speed of sound condition
     dt2 = h / (c₀ + visc)


### PR DESCRIPTION
### Motivation
- Reduce contention and improve performance of the adaptive timestep computation in `Δt` by parallelizing the particle loop. 
- Preserve the existing CFL, viscous, and force-based timestep logic while decreasing per-iteration overhead. 
- Avoid atomic updates inside the hot loop by using per-thread accumulators. 

### Description
- Parallelized the main reduction loop in `src/TimeStepping.jl` by using `Threads.@threads` and `Threads.threadid()` to index per-thread arrays. 
- Added `visc_values = fill(0.0, Threads.nthreads())` and `dt1_values = fill(Inf, Threads.nthreads())` and reduced them after the loop with `visc = maximum(visc_values)` and `dt1 = minimum(dt1_values)`. 
- Kept the timestep formula unchanged: `dt2 = h / (c₀ + visc)` and `dt = CFL * min(dt1, dt2)`, and made no public API changes. 

### Testing
- Ran `julia --project=. -e 'using Pkg; Pkg.test()'`, but the run was interrupted during package precompilation so the test suite did not complete. 
- Precompilation stalled on dependencies (notably `UnicodePlots`) and the test run was aborted, so no automated tests completed. 
- No new automated tests were added as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694de27ec8d48323b3f284acbb643a37)