### PR TITLE
Avoid slice when iterating Cells in UpdateNeighbors!

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -137,7 +137,7 @@ using LinearAlgebra
         empty!(CellDict)
         CellDict[Cells[1]] = IndexCounter
 
-        @inbounds @simd ivdep for i in eachindex(Cells)[2:end]
+        @inbounds @simd ivdep for i in 2:lastindex(Cells)
             if Cells[i] != Cells[i-1] # Equivalent to diff(Cells) != 0
                 IndexCounter                 += 1
                 ParticleRanges[IndexCounter]  = i


### PR DESCRIPTION
### Motivation
- Avoid allocating a temporary slice when iterating over `Cells` in `UpdateNeighbors!` to reduce unnecessary memory allocation.
- Keep the loop semantics identical while improving performance in a hot code path.
- Make a small, targeted change with no functional behavior modifications.

### Description
- Replace `for i in eachindex(Cells)[2:end]` with `for i in 2:lastindex(Cells)` inside `UpdateNeighbors!` in `src/SPHCellList.jl` to avoid creating a slice.
- Preserve the existing loop body and all `@inbounds @simd ivdep` annotations so behavior and performance hints remain the same.
- No other files or logic were changed.

### Testing
- Ran `julia --project=. -e 'using Pkg; Pkg.test()'`, but precompilation of dependencies (notably `UnicodePlots`) was interrupted and the test run did not complete.
- No automated test failures were reported because the test run was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f19a3fb588323bd51f714f61be98b)