### PR TITLE
Use dispatch for grid cell output counts

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -969,6 +969,35 @@ using LinearAlgebra
         end
     end
 
+    @inline function grid_cell_counts(::Val{false}, _particle_ranges, _neighbor_cell_lists,
+                                      _unique_cells_view)
+        return nothing, nothing
+    end
+
+    @inline function grid_cell_counts(::Val{true}, particle_ranges, neighbor_cell_lists,
+                                      unique_cells_view)
+        cell_particle_counts = compute_cell_particle_counts(
+            particle_ranges,
+            length(unique_cells_view),
+        )
+        cell_neighbor_counts = compute_cell_neighbor_counts(
+            particle_ranges,
+            neighbor_cell_lists,
+            length(unique_cells_view),
+        )
+        return cell_particle_counts, cell_neighbor_counts
+    end
+
+    @inline function grid_cell_counts(SimMetaData, particle_ranges, neighbor_cell_lists,
+                                      unique_cells_view)
+        return grid_cell_counts(
+            Val(SimMetaData.ExportGridCellParticleCounts),
+            particle_ranges,
+            neighbor_cell_lists,
+            unique_cells_view,
+        )
+    end
+
     """
         update_delta_x!(Δx, posₙ⁺, pos)
 
@@ -1138,19 +1167,12 @@ using LinearAlgebra
         output.enqueue_particles(SimMetaData.OutputIterationCounter)
         if SimMetaData.IndexCounter > 0
             unique_cells_view = view(UniqueCells, 1:SimMetaData.IndexCounter)
-            cell_particle_counts = nothing
-            cell_neighbor_counts = nothing
-            if SimMetaData.ExportGridCellParticleCounts
-                cell_particle_counts = compute_cell_particle_counts(
-                    ParticleRanges,
-                    SimMetaData.IndexCounter,
-                )
-                cell_neighbor_counts = compute_cell_neighbor_counts(
-                    ParticleRanges,
-                    NeighborCellLists,
-                    SimMetaData.IndexCounter,
-                )
-            end
+            cell_particle_counts, cell_neighbor_counts = grid_cell_counts(
+                SimMetaData,
+                ParticleRanges,
+                NeighborCellLists,
+                unique_cells_view,
+            )
             output.enqueue_grid(
                 SimMetaData.OutputIterationCounter,
                 unique_cells_view,
@@ -1195,19 +1217,12 @@ using LinearAlgebra
             SimMetaData.OutputIterationCounter += 1
 
             UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-            cell_particle_counts = nothing
-            cell_neighbor_counts = nothing
-            if SimMetaData.ExportGridCellParticleCounts
-                cell_particle_counts = compute_cell_particle_counts(
-                    ParticleRanges,
-                    length(UniqueCellsView),
-                )
-                cell_neighbor_counts = compute_cell_neighbor_counts(
-                    ParticleRanges,
-                    NeighborCellLists,
-                    length(UniqueCellsView),
-                )
-            end
+            cell_particle_counts, cell_neighbor_counts = grid_cell_counts(
+                SimMetaData,
+                ParticleRanges,
+                NeighborCellLists,
+                UniqueCellsView,
+            )
             @timeit SimMetaData.HourGlass "13 Save Particle Data"  begin
                 output.enqueue_particles(SimMetaData.OutputIterationCounter)
                 output.enqueue_grid(


### PR DESCRIPTION
### Motivation
- Remove repeated conditional logic in the simulation output path when preparing grid cell counts to improve clarity and enable compiler-specialized dispatch.
- Keep the hot simulation loop free of branching on `ExportGridCellParticleCounts` to reduce runtime overhead and duplication.

### Description
- Added dispatch-based helpers `grid_cell_counts(::Val{true},...)`, `grid_cell_counts(::Val{false},...)`, and a wrapper `grid_cell_counts(SimMetaData,...)` in `src/SPHCellList.jl` to compute or skip grid cell particle/neighbor counts.
- Replaced two inline conditional blocks that computed `cell_particle_counts` and `cell_neighbor_counts` with calls to the new `grid_cell_counts` helper at both initial output and periodic output points.
- Kept behaviour identical when `SimMetaData.ExportGridCellParticleCounts` is `true` or `false`, but centralised the logic for easier maintenance.

### Testing
- Ran `julia --project=. -e 'using Pkg; Pkg.test()'` to execute the test suite.
- `Pkg.test()` failed due to the `Project.toml` Julia version compatibility requirement not being satisfied in the current environment, so automated tests could not complete.
- `Pkg` also emitted a warning suggesting a manifest/compatibility resolution may be needed before tests can run successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69508059c41c8323aa69e831c5ab9374)