### PR TITLE
Revert to calling `Δt` for timestep and remove per-particle timestep buffer pass

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -220,7 +220,6 @@ using LinearAlgebra
 
             dρdtI[i] = dρdt_acc
             Acceleration[i] = acc_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, Position[i], Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -286,7 +285,6 @@ using LinearAlgebra
             Acceleration[i] = acc_acc
             Kernel[i] = kernel_acc
             KernelGradient[i] = kernel_grad_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, Position[i], Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -351,7 +349,6 @@ using LinearAlgebra
             Acceleration[i] = acc_acc
             ∇Cᵢ[i] = shift_c_acc
             ∇◌rᵢ[i] = shift_r_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, Position[i], Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -422,8 +419,6 @@ using LinearAlgebra
             KernelGradient[i] = kernel_grad_acc
             ∇Cᵢ[i] = shift_c_acc
             ∇◌rᵢ[i] = shift_r_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, Position[i],
-                                      Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -992,7 +987,6 @@ using LinearAlgebra
 
     # Per-particle local Δx removed: use single scalar `SimMetaData.Δx`.
 
-    
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
                                       SimConstants, SimParticles, FullStencil,
@@ -1025,9 +1019,6 @@ using LinearAlgebra
         dt = Δt(Position, Velocity, Acceleration, SimConstants, SimKernel)
 
         @no_escape begin
-            max_visc = @alloc(FloatType, length(Position))
-            min_dt_force = @alloc(FloatType, length(Position))
-
             dt₂ = dt * 0.5
 
             while SimMetaData.TotalTime <= next_output_time(SimMetaData)
@@ -1079,7 +1070,7 @@ using LinearAlgebra
                     SimConstants, SimParticles, ParticleRanges, CellDict,
                     NeighborCellLists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
                     MotionLimiter, dρdtI, Acceleration, Kernel,
-                    KernelGradient, ∇Cᵢ, ∇◌rᵢ, max_visc, min_dt_force,
+                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
                 )
 
                 @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
@@ -1090,9 +1081,7 @@ using LinearAlgebra
             
                 @timeit SimMetaData.HourGlass "12 Update MetaData"                       UpdateMetaData!(SimMetaData, dt)
 
-                @timeit SimMetaData.HourGlass "13 Update TimeStep" begin
-                    dt = FinalizeTimeStep(max_visc, min_dt_force, SimConstants, SimKernel)
-                end
+                @timeit SimMetaData.HourGlass "13 Update TimeStep" dt = Δt(Position, Velocity, Acceleration, SimConstants, SimKernel)
             end
         end
         


### PR DESCRIPTION
### Motivation
- Stop the separate batched/serial timestep-buffer aggregation and use the existing `Δt` function as the single source of timestep computation.
- Simplify the simulation loop by removing per-particle `UpdateTimeStepBuffers!` calls from threaded neighbor loops to avoid duplicated logic.
- Restore the previously used threaded implementation of `Δt` to preserve performance while centralizing timestep logic.
- Honor the requirement to call `Δt` whenever a timestep update is needed and avoid additional threading/aggregation outside of `Δt`.

### Description
- Replaced the `FinalizeTimeStep(...)` call in `SimulationLoop` with a direct call to `Δt(Position, Velocity, Acceleration, SimConstants, SimKernel)` in `src/SPHCellList.jl`.
- Removed the batched/serial `UpdateTimeStepBuffers!` invocation and removed per-particle `UpdateTimeStepBuffers!` calls from all threaded neighbor loops in `src/SPHCellList.jl`.
- Restored a threaded implementation of `Δt` in `src/TimeStepping.jl` that partitions particles across `Threads.nthreads()` and aggregates per-thread `max_visc` and `min_dt_force` into temporary buffers.
- Updated temporary buffer allocation and the timestep reduction to use per-thread buffers and a final `minimum`/`maximum` reduction inside `Δt`.

### Testing
- No automated tests were executed for these changes.
- No test results to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568ee9607483239a575085fdb5db76)