### PR TITLE
Keep CUDA simulation state on GPU and add CUDA kernels

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -529,16 +529,26 @@ using LinearAlgebra
         density
         pressure
         velocity
+        gravity_factor
         motion_limiter
         neighbor_offsets
         neighbor_indices
         dρdtI
         acceleration
+        position_half
+        velocity_half
+        rho_half
+        max_visc
+        min_dt_force
+        neighbor_dirty::Bool
+        state_initialized::Bool
+        active::Bool
     end
 
     function EnsureCudaNeighborBuffers!(SimMetaData, Position, Density, Pressure, Velocity,
-                                        MotionLimiter, neighbor_offsets, neighbor_indices,
-                                        dρdtI, Acceleration)
+                                        GravityFactor, MotionLimiter, neighbor_offsets,
+                                        neighbor_indices, dρdtI, Acceleration; sync_state = true,
+                                        sync_neighbors = true)
         n_particles = length(Position)
         offsets_len = length(neighbor_offsets)
         indices_len = length(neighbor_indices)
@@ -556,26 +566,89 @@ using LinearAlgebra
                 CuArray(Density),
                 CuArray(Pressure),
                 CuArray(Velocity),
+                CuArray(GravityFactor),
                 CuArray(MotionLimiter),
                 CuArray(neighbor_offsets),
                 CuArray(neighbor_indices),
                 similar(CuArray(dρdtI)),
                 similar(CuArray(Acceleration)),
+                similar(CuArray(Position)),
+                similar(CuArray(Velocity)),
+                similar(CuArray(Density)),
+                similar(CuArray(Density)),
+                similar(CuArray(Density)),
+                true,
+                false,
+                false,
             )
             SimMetaData.CudaBuffers = buffers
-        else
-            buffers.host_neighbor_offsets = neighbor_offsets
-            buffers.host_neighbor_indices = neighbor_indices
+        end
+        buffers.n_particles = n_particles
+        buffers.host_neighbor_offsets = neighbor_offsets
+        buffers.host_neighbor_indices = neighbor_indices
+
+        if sync_state
             copyto!(buffers.position, Position)
             copyto!(buffers.density, Density)
             copyto!(buffers.pressure, Pressure)
             copyto!(buffers.velocity, Velocity)
+            copyto!(buffers.gravity_factor, GravityFactor)
             copyto!(buffers.motion_limiter, MotionLimiter)
+        end
+
+        if sync_neighbors && (needs_alloc || buffers.neighbor_dirty)
             copyto!(buffers.neighbor_offsets, neighbor_offsets)
             copyto!(buffers.neighbor_indices, neighbor_indices)
+            buffers.neighbor_dirty = false
         end
 
         return buffers
+    end
+
+    function SyncCudaStateToDevice!(buffers, Position, Density, Pressure, Velocity,
+                                    GravityFactor, MotionLimiter, dρdtI, Acceleration,
+                                    Positionₙ⁺, Velocityₙ⁺, ρₙ⁺)
+        copyto!(buffers.position, Position)
+        copyto!(buffers.density, Density)
+        copyto!(buffers.pressure, Pressure)
+        copyto!(buffers.velocity, Velocity)
+        copyto!(buffers.gravity_factor, GravityFactor)
+        copyto!(buffers.motion_limiter, MotionLimiter)
+        copyto!(buffers.dρdtI, dρdtI)
+        copyto!(buffers.acceleration, Acceleration)
+        copyto!(buffers.position_half, Positionₙ⁺)
+        copyto!(buffers.velocity_half, Velocityₙ⁺)
+        copyto!(buffers.rho_half, ρₙ⁺)
+        buffers.state_initialized = true
+        return nothing
+    end
+
+    function SyncCudaStateToHost!(buffers, SimParticles)
+        copyto!(SimParticles.Position, buffers.position)
+        copyto!(SimParticles.Density, buffers.density)
+        copyto!(SimParticles.Pressure, buffers.pressure)
+        copyto!(SimParticles.Velocity, buffers.velocity)
+        copyto!(SimParticles.Acceleration, buffers.acceleration)
+        return nothing
+    end
+
+    function SyncCudaPositionsToHost!(buffers, Position)
+        copyto!(Position, buffers.position)
+        return nothing
+    end
+
+    function UpdateΔx!(Δx::T, posₙ⁺::CUDA.AbstractGPUArray{SVector{D, T}},
+                       pos::CUDA.AbstractGPUArray{SVector{D, T}}) where {D, T<:Real}
+        maxd = CUDA.mapreduce(
+            (pₙ⁺, p) -> begin
+                diff = pₙ⁺ - p
+                sqrt(dot(diff, diff))
+            end,
+            max,
+            posₙ⁺,
+            pos,
+        )
+        return Δx + 4 * maxd
     end
 
     function UpdateCudaNeighborPairList!(SimMetaData, SimParticles, CellDict, ParticleRanges,
@@ -583,7 +656,9 @@ using LinearAlgebra
         buffers = SimMetaData.CudaBuffers
         if buffers === nothing
             buffers = CudaNeighborBuffers(0, Int[], Int[], nothing, nothing, nothing, nothing,
-                                          nothing, nothing, nothing, nothing, nothing)
+                                          nothing, nothing, Int[], Int[], nothing, nothing,
+                                          nothing, nothing, nothing, nothing, nothing,
+                                          nothing, true, false, false)
             SimMetaData.CudaBuffers = buffers
         end
 
@@ -591,6 +666,32 @@ using LinearAlgebra
         neighbor_indices = buffers.host_neighbor_indices
         BuildNeighborPairList!(neighbor_offsets, neighbor_indices, SimParticles.Cells,
                                CellDict, ParticleRanges, NeighborCellLists)
+        buffers.neighbor_dirty = true
+        return nothing
+    end
+
+    function NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel,
+                               SimConstants; position = buffers.position,
+                               density = buffers.density, pressure = buffers.pressure,
+                               velocity = buffers.velocity)
+        n_particles = buffers.n_particles
+        threads = 256
+        blocks = cld(n_particles, threads)
+        CUDA.@sync CUDA.@cuda threads=threads blocks=blocks NeighborLoopCudaKernel!(
+            buffers.dρdtI,
+            buffers.acceleration,
+            position,
+            density,
+            pressure,
+            velocity,
+            buffers.motion_limiter,
+            buffers.neighbor_offsets,
+            buffers.neighbor_indices,
+            SimKernel,
+            SimConstants,
+            SimDensityDiffusion,
+            SimViscosity,
+        )
         return nothing
     end
 
@@ -687,30 +788,15 @@ using LinearAlgebra
         neighbor_offsets = SimMetaData.CudaBuffers.host_neighbor_offsets
         neighbor_indices = SimMetaData.CudaBuffers.host_neighbor_indices
 
-        n_particles = length(Position)
         buffers = EnsureCudaNeighborBuffers!(SimMetaData, Position, Density, Pressure, Velocity,
-                                             MotionLimiter, neighbor_offsets, neighbor_indices,
-                                             dρdtI, Acceleration)
-        d_position = buffers.position
-        d_density = buffers.density
-        d_pressure = buffers.pressure
-        d_velocity = buffers.velocity
-        d_motion_limiter = buffers.motion_limiter
-        d_neighbor_offsets = buffers.neighbor_offsets
-        d_neighbor_indices = buffers.neighbor_indices
-        d_dρdtI = buffers.dρdtI
-        d_acceleration = buffers.acceleration
+                                             SimParticles.GravityFactor, MotionLimiter,
+                                             neighbor_offsets, neighbor_indices, dρdtI,
+                                             Acceleration)
 
-        threads = 256
-        blocks = cld(n_particles, threads)
-        CUDA.@sync CUDA.@cuda threads=threads blocks=blocks NeighborLoopCudaKernel!(
-            d_dρdtI, d_acceleration, d_position, d_density, d_pressure,
-            d_velocity, d_motion_limiter, d_neighbor_offsets, d_neighbor_indices,
-            SimKernel, SimConstants, SimDensityDiffusion, SimViscosity,
-        )
+        NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel, SimConstants)
 
-        copyto!(dρdtI, d_dρdtI)
-        copyto!(Acceleration, d_acceleration)
+        copyto!(dρdtI, buffers.dρdtI)
+        copyto!(Acceleration, buffers.acceleration)
 
         return nothing
     end
@@ -1223,6 +1309,39 @@ using LinearAlgebra
         return nothing
     end
 
+    function HalfTimeStepCudaKernel!(Position, Density, Velocity, Acceleration, GravityFactor,
+                                     MotionLimiter, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂, g)
+        i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+        if i <= length(Position)
+            acc = Acceleration[i] + ConstructGravitySVector(Acceleration[i], g * GravityFactor[i])
+            Acceleration[i] = acc
+            Positionₙ⁺[i] = Position[i] + Velocity[i] * dt₂ * MotionLimiter[i]
+            Velocityₙ⁺[i] = Velocity[i] + acc * dt₂ * MotionLimiter[i]
+            ρₙ⁺[i] = Density[i] + dρdtI[i] * dt₂
+        end
+        return nothing
+    end
+
+    function HalfTimeStepCuda!(SimConstants, buffers, dt₂)
+        threads = 256
+        blocks = cld(buffers.n_particles, threads)
+        CUDA.@sync CUDA.@cuda threads=threads blocks=blocks HalfTimeStepCudaKernel!(
+            buffers.position,
+            buffers.density,
+            buffers.velocity,
+            buffers.acceleration,
+            buffers.gravity_factor,
+            buffers.motion_limiter,
+            buffers.position_half,
+            buffers.velocity_half,
+            buffers.rho_half,
+            buffers.dρdtI,
+            dt₂,
+            SimConstants.g,
+        )
+        return nothing
+    end
+
     function FullTimeStep(::SimulationMetaData{D,T,NoShifting,K,B,L}, SimKernel,
                           SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt) where {D,T,
                                                                              K<:KernelOutputMode,
@@ -1234,6 +1353,46 @@ using LinearAlgebra
             Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
             Position[i]       +=  (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt) * MotionLimiter[i]
         end
+        return nothing
+    end
+
+    function FullTimeStepCudaKernel!(Position, Velocity, Acceleration, GravityFactor,
+                                     MotionLimiter, dt, g, h, η², max_visc, min_dt_force)
+        i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+        if i <= length(Position)
+            acc = Acceleration[i] + ConstructGravitySVector(Acceleration[i], g * GravityFactor[i])
+            Acceleration[i] = acc
+            limiter = MotionLimiter[i]
+            vel = Velocity[i] + acc * dt * limiter
+            Velocity[i] = vel
+            Position[i] = Position[i] + (((vel + (vel - acc * dt * limiter)) / 2) * dt) * limiter
+
+            r = Position[i]
+            r_sq = sqrt(dot(r, r))^2
+            max_visc[i] = abs(h * dot(vel, r) / (r_sq + η²))
+
+            a_mag = norm(acc)
+            min_dt_force[i] = a_mag > 0 ? sqrt(h / a_mag) : typemax(eltype(min_dt_force))
+        end
+        return nothing
+    end
+
+    function FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
+        threads = 256
+        blocks = cld(buffers.n_particles, threads)
+        CUDA.@sync CUDA.@cuda threads=threads blocks=blocks FullTimeStepCudaKernel!(
+            buffers.position,
+            buffers.velocity,
+            buffers.acceleration,
+            buffers.gravity_factor,
+            buffers.motion_limiter,
+            dt,
+            SimConstants.g,
+            SimKernel.h,
+            SimKernel.η²,
+            buffers.max_visc,
+            buffers.min_dt_force,
+        )
         return nothing
     end
 
@@ -1340,8 +1499,44 @@ using LinearAlgebra
 
         ###
         UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-        # This code here is to initialize the first time step for each simulation loop
-        dt = Δt(Position, Velocity, Acceleration, SimConstants, SimKernel)
+        UseCudaLoop = SimMetaData.UseCuda &&
+                        SimMetaData isa SimulationMetaData{Dimensions, FloatType, NoShifting, NoKernelOutput, NoMDBC, LMode} &&
+                        MotionDefinition === nothing &&
+                        CudaNeighborLoopSupported(SimDensityDiffusion, SimViscosity)
+        if UseCudaLoop && !CUDA.functional()
+            @warn "CUDA requested but not functional; falling back to CPU simulation loop."
+            UseCudaLoop = false
+        end
+
+        buffers = SimMetaData.CudaBuffers
+        if UseCudaLoop
+            if buffers === nothing || isempty(buffers.host_neighbor_offsets)
+                UpdateCudaNeighborPairList!(SimMetaData, SimParticles, CellDict, ParticleRanges,
+                                            NeighborCellLists)
+                buffers = SimMetaData.CudaBuffers
+            end
+
+            neighbor_offsets = buffers.host_neighbor_offsets
+            neighbor_indices = buffers.host_neighbor_indices
+            buffers = EnsureCudaNeighborBuffers!(SimMetaData, Position, Density, Pressure, Velocity,
+                                                 SimParticles.GravityFactor, MotionLimiter,
+                                                 neighbor_offsets, neighbor_indices, dρdtI,
+                                                 Acceleration; sync_state = false,
+                                                 sync_neighbors = true)
+            if !buffers.state_initialized
+                SyncCudaStateToDevice!(buffers, Position, Density, Pressure, Velocity,
+                                       SimParticles.GravityFactor, MotionLimiter, dρdtI,
+                                       Acceleration, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺)
+            end
+            buffers.active = true
+            dt = Δt(buffers.position, buffers.velocity, buffers.acceleration, SimConstants, SimKernel)
+        else
+            if buffers !== nothing
+                buffers.active = false
+            end
+            # This code here is to initialize the first time step for each simulation loop
+            dt = Δt(Position, Velocity, Acceleration, SimConstants, SimKernel)
+        end
 
         @no_escape begin
             dt₂ = dt * 0.5
@@ -1349,7 +1544,11 @@ using LinearAlgebra
             while SimMetaData.TotalTime <= next_output_time(SimMetaData)
                 @timeit SimMetaData.HourGlass "01 Calculate IndexCounter"  begin
 
-                    SimMetaData.Δx = UpdateΔx!(SimMetaData.Δx, Positionₙ⁺, SimParticles.Position)
+                    if UseCudaLoop
+                        SimMetaData.Δx = UpdateΔx!(SimMetaData.Δx, buffers.position_half, buffers.position)
+                    else
+                        SimMetaData.Δx = UpdateΔx!(SimMetaData.Δx, Positionₙ⁺, SimParticles.Position)
+                    end
                     ShouldRebuild = SimMetaData.Δx >= SimKernel.h
 
                     # println("Δx: ", Δx, "h: ", SimKernel.h," dt: ", SimMetaData.CurrentTimeStep, " Iteration: ", SimMetaData.Iteration, " TotalTime: ", SimMetaData.TotalTime, " OutputIterationCounter: ", SimMetaData.OutputIterationCounter)
@@ -1361,6 +1560,9 @@ using LinearAlgebra
                     # Remove if statement logic if you want to update each iteration
                     # if mod(SimMetaData.Iteration, ceil(Int, SimKernel.H / (SimConstants.c₀ * dt * (1/SimConstants.CFL)) )) == 0 || SimMetaData.Iteration == 1
                     if ShouldRebuild
+                        if UseCudaLoop
+                            SyncCudaPositionsToHost!(buffers, Position)
+                        end
                         @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellDict)
                         SimMetaData.Δx    = zero(eltype(dρdtI))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
@@ -1368,52 +1570,120 @@ using LinearAlgebra
                         if SimMetaData.UseCuda
                             UpdateCudaNeighborPairList!(SimMetaData, SimParticles, CellDict,
                                                         ParticleRanges, NeighborCellLists)
+                            if UseCudaLoop
+                                neighbor_offsets = SimMetaData.CudaBuffers.host_neighbor_offsets
+                                neighbor_indices = SimMetaData.CudaBuffers.host_neighbor_indices
+                                buffers = EnsureCudaNeighborBuffers!(
+                                    SimMetaData, Position, Density, Pressure, Velocity,
+                                    SimParticles.GravityFactor, MotionLimiter, neighbor_offsets,
+                                    neighbor_indices, dρdtI, Acceleration; sync_state = false,
+                                    sync_neighbors = true,
+                                )
+                            end
                         end
                     end
                 end
 
-                @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
-            
-                @timeit SimMetaData.HourGlass "02 Pressure"                              Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
-                @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType)
+                @timeit SimMetaData.HourGlass "Motion" ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
 
-                @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoop!(
-                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, CellDict,
-                    NeighborCellLists, Position, Density, Pressure, Velocity,
-                    MotionLimiter, dρdtI, Acceleration, Kernel,
-                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                @timeit SimMetaData.HourGlass "02 Pressure" begin
+                    if UseCudaLoop
+                        Pressure!(buffers.pressure, buffers.density, SimConstants)
+                    else
+                        Pressure!(SimParticles.Pressure, SimParticles.Density, SimConstants)
+                    end
+                end
+                @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep" ApplyMDBCBeforeHalf!(
+                    SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
+                    Position, Density, GhostPoints, GhostNormals, ParticleType,
                 )
 
+                @timeit SimMetaData.HourGlass "04 First NeighborLoop" begin
+                    if UseCudaLoop
+                        NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel, SimConstants)
+                    else
+                        NeighborLoop!(
+                            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                            SimConstants, SimParticles, ParticleRanges, CellDict,
+                            NeighborCellLists, Position, Density, Pressure, Velocity,
+                            MotionLimiter, dρdtI, Acceleration, Kernel,
+                            KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                        )
+                    end
+                end
 
-                @timeit SimMetaData.HourGlass "05 Update To Half TimeStep"               HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
+                @timeit SimMetaData.HourGlass "05 Update To Half TimeStep" begin
+                    if UseCudaLoop
+                        HalfTimeStepCuda!(SimConstants, buffers, dt₂)
+                    else
+                        HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
+                    end
+                end
 
+                @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary" begin
+                    if UseCudaLoop
+                        LimitDensityAtBoundary!(buffers.rho_half, SimConstants.ρ₀, buffers.motion_limiter)
+                    else
+                        LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, MotionLimiter)
+                    end
+                end
 
-                @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary"           LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, MotionLimiter)
-            
-                @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
-            
-                @timeit SimMetaData.HourGlass "07 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
-                @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoop!(
-                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, CellDict,
-                    NeighborCellLists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
-                    MotionLimiter, dρdtI, Acceleration, Kernel,
-                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                )
+                @timeit SimMetaData.HourGlass "Motion" ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
 
-        @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
-            
-                @timeit SimMetaData.HourGlass "10 Final Density"                         DensityEpsi!(Density, dρdtI, ρₙ⁺, dt)
-            
-                @timeit SimMetaData.HourGlass "11 Update To Final TimeStep"              FullTimeStep(SimMetaData, SimKernel, SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt)
-            
-                @timeit SimMetaData.HourGlass "12 Update MetaData"                       UpdateMetaData!(SimMetaData, dt)
+                @timeit SimMetaData.HourGlass "07 Pressure" begin
+                    if UseCudaLoop
+                        Pressure!(buffers.pressure, buffers.rho_half, SimConstants)
+                    else
+                        Pressure!(SimParticles.Pressure, ρₙ⁺, SimConstants)
+                    end
+                end
+                @timeit SimMetaData.HourGlass "08 Second NeighborLoop" begin
+                    if UseCudaLoop
+                        NeighborLoopCuda!(
+                            buffers, SimDensityDiffusion, SimViscosity, SimKernel, SimConstants;
+                            position=buffers.position_half, density=buffers.rho_half,
+                            pressure=buffers.pressure, velocity=buffers.velocity_half,
+                        )
+                    else
+                        NeighborLoop!(
+                            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                            SimConstants, SimParticles, ParticleRanges, CellDict,
+                            NeighborCellLists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
+                            MotionLimiter, dρdtI, Acceleration, Kernel,
+                            KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                        )
+                    end
+                end
+
+                @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary" begin
+                    if UseCudaLoop
+                        LimitDensityAtBoundary!(buffers.density, SimConstants.ρ₀, buffers.motion_limiter)
+                    else
+                        LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
+                    end
+                end
+
+                @timeit SimMetaData.HourGlass "10 Final Density" begin
+                    if UseCudaLoop
+                        DensityEpsi!(buffers.density, buffers.dρdtI, buffers.rho_half, dt)
+                    else
+                        DensityEpsi!(Density, dρdtI, ρₙ⁺, dt)
+                    end
+                end
+
+                @timeit SimMetaData.HourGlass "11 Update To Final TimeStep" begin
+                    if UseCudaLoop
+                        FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
+                    else
+                        FullTimeStep(SimMetaData, SimKernel, SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt)
+                    end
+                end
+
+                @timeit SimMetaData.HourGlass "12 Update MetaData" UpdateMetaData!(SimMetaData, dt)
 
                 @timeit SimMetaData.HourGlass "13 Update TimeStep" begin
-                    if SimMetaData.UseCuda && SimMetaData.CudaBuffers !== nothing
-                        buffers = SimMetaData.CudaBuffers
-                        dt = Δt(buffers.position, buffers.velocity, buffers.acceleration, SimConstants, SimKernel)
+                    if UseCudaLoop
+                        dt = FinalizeTimeStep(buffers.max_visc, buffers.min_dt_force, SimConstants, SimKernel)
                     else
                         dt = Δt(Position, Velocity, Acceleration, SimConstants, SimKernel)
                     end
@@ -1509,6 +1779,11 @@ using LinearAlgebra
                 NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
                 ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
             )
+            if SimMetaData.UseCuda &&
+               SimMetaData.CudaBuffers !== nothing &&
+               SimMetaData.CudaBuffers.active
+                SyncCudaStateToHost!(SimMetaData.CudaBuffers, SimParticles)
+            end
             push!(SimMetaData.TimeSteps, SimMetaData.CurrentTimeStep)
 
             LogStep!(SimMetaData, SimLogger)

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -649,7 +649,7 @@ using LinearAlgebra
                              KernelGradient, ∇Cᵢ, ∇◌rᵢ, max_visc, min_dt_force)
     end
 
-    function NeighborLoopCudaKernel!(dρdtI, Acceleration, Position, Density, Pressure,
+    function NeighborLoopCudaKernel!(dρdtI, Acceleration, Position, Density,
                                      Velocity, MotionLimiter, NeighborOffsets,
                                      NeighborIndices, SimKernel, SimConstants,
                                      SimDensityDiffusion, SimViscosity)
@@ -689,8 +689,8 @@ using LinearAlgebra
 
                     dρdt_acc += dρdt⁺ + Dᵢ
 
-                    Pᵢ = Pressure[i]
-                    Pⱼ = Pressure[j]
+                    Pᵢ = EquationOfStateGamma7(ρᵢ, SimConstants.c₀, SimConstants.ρ₀)
+                    Pⱼ = EquationOfStateGamma7(ρⱼ, SimConstants.c₀, SimConstants.ρ₀)
                     Pfac = (Pᵢ + Pⱼ) / (ρᵢ * ρⱼ)
                     f_ab = tensile_correction(SimKernel, Pᵢ, ρᵢ, Pⱼ, ρⱼ, q, dx)
                     dvdt⁺ = -m₀ * (Pfac + f_ab) * ∇ᵢWᵢⱼ

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -565,7 +565,6 @@ using LinearAlgebra
             nothing,
             nothing,
             nothing,
-            nothing,
             true,
             false,
             false,

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -649,7 +649,7 @@ using LinearAlgebra
                              KernelGradient, ∇Cᵢ, ∇◌rᵢ, max_visc, min_dt_force)
     end
 
-    function NeighborLoopCudaKernel!(dρdtI, Acceleration, Position, Density,
+    function NeighborLoopCudaKernel!(dρdtI, Acceleration, Position, Density, Pressure,
                                      Velocity, MotionLimiter, NeighborOffsets,
                                      NeighborIndices, SimKernel, SimConstants,
                                      SimDensityDiffusion, SimViscosity)
@@ -689,8 +689,8 @@ using LinearAlgebra
 
                     dρdt_acc += dρdt⁺ + Dᵢ
 
-                    Pᵢ = EquationOfStateGamma7(ρᵢ, SimConstants.c₀, SimConstants.ρ₀)
-                    Pⱼ = EquationOfStateGamma7(ρⱼ, SimConstants.c₀, SimConstants.ρ₀)
+                    Pᵢ = Pressure[i]
+                    Pⱼ = Pressure[j]
                     Pfac = (Pᵢ + Pⱼ) / (ρᵢ * ρⱼ)
                     f_ab = tensile_correction(SimKernel, Pᵢ, ρᵢ, Pⱼ, ρⱼ, q, dx)
                     dvdt⁺ = -m₀ * (Pfac + f_ab) * ∇ᵢWᵢⱼ

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -1534,6 +1534,14 @@ using LinearAlgebra
         buffers = SimMetaData.CudaBuffers
         if UseCudaLoop
             if buffers === nothing || isempty(buffers.host_neighbor_offsets)
+                if SimMetaData.IndexCounter == 0
+                    SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹,
+                                                               SortingScratchSpace, ParticleRanges,
+                                                               UniqueCells, CellDict)
+                    UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
+                    BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView,
+                                            ParticleRanges, CellDict)
+                end
                 UpdateCudaNeighborPairList!(SimMetaData, SimParticles, CellDict, ParticleRanges,
                                             NeighborCellLists)
                 buffers = SimMetaData.CudaBuffers

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -545,6 +545,33 @@ using LinearAlgebra
         active::Bool
     end
 
+    function EmptyCudaNeighborBuffers()
+        return CudaNeighborBuffers(
+            0,
+            Int[],
+            Int[],
+            nothing,
+            nothing,
+            nothing,
+            nothing,
+            nothing,
+            nothing,
+            Int[],
+            Int[],
+            nothing,
+            nothing,
+            nothing,
+            nothing,
+            nothing,
+            nothing,
+            nothing,
+            nothing,
+            true,
+            false,
+            false,
+        )
+    end
+
     function EnsureCudaNeighborBuffers!(SimMetaData, Position, Density, Pressure, Velocity,
                                         GravityFactor, MotionLimiter, neighbor_offsets,
                                         neighbor_indices, dρdtI, Acceleration; sync_state = true,
@@ -655,10 +682,7 @@ using LinearAlgebra
                                          NeighborCellLists)
         buffers = SimMetaData.CudaBuffers
         if buffers === nothing
-            buffers = CudaNeighborBuffers(0, Int[], Int[], nothing, nothing, nothing, nothing,
-                                          nothing, nothing, Int[], Int[], nothing, nothing,
-                                          nothing, nothing, nothing, nothing, nothing,
-                                          nothing, true, false, false)
+            buffers = EmptyCudaNeighborBuffers()
             SimMetaData.CudaBuffers = buffers
         end
 

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -521,203 +521,6 @@ using LinearAlgebra
     @inline CudaNeighborLoopSupported(::LinearDensityDiffusion, ::ArtificialViscosity) = true
     @inline CudaNeighborLoopSupported(::SPHDensityDiffusion, ::SPHViscosity) = false
 
-    mutable struct CudaNeighborBuffers
-        n_particles::Int
-        host_neighbor_offsets::Vector{Int}
-        host_neighbor_indices::Vector{Int}
-        position
-        density
-        pressure
-        velocity
-        gravity_factor
-        motion_limiter
-        neighbor_offsets
-        neighbor_indices
-        dρdtI
-        acceleration
-        position_half
-        velocity_half
-        rho_half
-        max_visc
-        min_dt_force
-        neighbor_dirty::Bool
-        state_initialized::Bool
-        active::Bool
-    end
-
-    function EmptyCudaNeighborBuffers()
-        return CudaNeighborBuffers(
-            0,
-            Int[],
-            Int[],
-            nothing,
-            nothing,
-            nothing,
-            nothing,
-            nothing,
-            nothing,
-            Int[],
-            Int[],
-            nothing,
-            nothing,
-            nothing,
-            nothing,
-            nothing,
-            nothing,
-            nothing,
-            true,
-            false,
-            false,
-        )
-    end
-
-    function EnsureCudaNeighborBuffers!(SimMetaData, Position, Density, Pressure, Velocity,
-                                        GravityFactor, MotionLimiter, neighbor_offsets,
-                                        neighbor_indices, dρdtI, Acceleration; sync_state = true,
-                                        sync_neighbors = true)
-        n_particles = length(Position)
-        offsets_len = length(neighbor_offsets)
-        indices_len = length(neighbor_indices)
-        buffers = SimMetaData.CudaBuffers
-        needs_alloc = buffers === nothing ||
-                      buffers.n_particles != n_particles ||
-                      length(buffers.neighbor_offsets) != offsets_len ||
-                      length(buffers.neighbor_indices) != indices_len
-        if needs_alloc
-            buffers = CudaNeighborBuffers(
-                n_particles,
-                neighbor_offsets,
-                neighbor_indices,
-                CuArray(Position),
-                CuArray(Density),
-                CuArray(Pressure),
-                CuArray(Velocity),
-                CuArray(GravityFactor),
-                CuArray(MotionLimiter),
-                CuArray(neighbor_offsets),
-                CuArray(neighbor_indices),
-                similar(CuArray(dρdtI)),
-                similar(CuArray(Acceleration)),
-                similar(CuArray(Position)),
-                similar(CuArray(Velocity)),
-                similar(CuArray(Density)),
-                similar(CuArray(Density)),
-                similar(CuArray(Density)),
-                true,
-                false,
-                false,
-            )
-            SimMetaData.CudaBuffers = buffers
-        end
-        buffers.n_particles = n_particles
-        buffers.host_neighbor_offsets = neighbor_offsets
-        buffers.host_neighbor_indices = neighbor_indices
-
-        if sync_state
-            copyto!(buffers.position, Position)
-            copyto!(buffers.density, Density)
-            copyto!(buffers.pressure, Pressure)
-            copyto!(buffers.velocity, Velocity)
-            copyto!(buffers.gravity_factor, GravityFactor)
-            copyto!(buffers.motion_limiter, MotionLimiter)
-        end
-
-        if sync_neighbors && (needs_alloc || buffers.neighbor_dirty)
-            copyto!(buffers.neighbor_offsets, neighbor_offsets)
-            copyto!(buffers.neighbor_indices, neighbor_indices)
-            buffers.neighbor_dirty = false
-        end
-
-        return buffers
-    end
-
-    function SyncCudaStateToDevice!(buffers, Position, Density, Pressure, Velocity,
-                                    GravityFactor, MotionLimiter, dρdtI, Acceleration,
-                                    Positionₙ⁺, Velocityₙ⁺, ρₙ⁺)
-        copyto!(buffers.position, Position)
-        copyto!(buffers.density, Density)
-        copyto!(buffers.pressure, Pressure)
-        copyto!(buffers.velocity, Velocity)
-        copyto!(buffers.gravity_factor, GravityFactor)
-        copyto!(buffers.motion_limiter, MotionLimiter)
-        copyto!(buffers.dρdtI, dρdtI)
-        copyto!(buffers.acceleration, Acceleration)
-        copyto!(buffers.position_half, Positionₙ⁺)
-        copyto!(buffers.velocity_half, Velocityₙ⁺)
-        copyto!(buffers.rho_half, ρₙ⁺)
-        buffers.state_initialized = true
-        return nothing
-    end
-
-    function SyncCudaStateToHost!(buffers, SimParticles)
-        copyto!(SimParticles.Position, buffers.position)
-        copyto!(SimParticles.Density, buffers.density)
-        copyto!(SimParticles.Pressure, buffers.pressure)
-        copyto!(SimParticles.Velocity, buffers.velocity)
-        copyto!(SimParticles.Acceleration, buffers.acceleration)
-        return nothing
-    end
-
-    function SyncCudaPositionsToHost!(buffers, Position)
-        copyto!(Position, buffers.position)
-        return nothing
-    end
-
-    function UpdateΔx!(Δx::T, posₙ⁺::CUDA.AbstractGPUArray{SVector{D, T}},
-                       pos::CUDA.AbstractGPUArray{SVector{D, T}}) where {D, T<:Real}
-        maxd = CUDA.mapreduce(
-            (pₙ⁺, p) -> begin
-                diff = pₙ⁺ - p
-                sqrt(dot(diff, diff))
-            end,
-            max,
-            posₙ⁺,
-            pos,
-        )
-        return Δx + 4 * maxd
-    end
-
-    function UpdateCudaNeighborPairList!(SimMetaData, SimParticles, CellDict, ParticleRanges,
-                                         NeighborCellLists)
-        buffers = SimMetaData.CudaBuffers
-        if buffers === nothing
-            buffers = EmptyCudaNeighborBuffers()
-            SimMetaData.CudaBuffers = buffers
-        end
-
-        neighbor_offsets = buffers.host_neighbor_offsets
-        neighbor_indices = buffers.host_neighbor_indices
-        BuildNeighborPairList!(neighbor_offsets, neighbor_indices, SimParticles.Cells,
-                               CellDict, ParticleRanges, NeighborCellLists)
-        buffers.neighbor_dirty = true
-        return nothing
-    end
-
-    function NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel,
-                               SimConstants; position = buffers.position,
-                               density = buffers.density, pressure = buffers.pressure,
-                               velocity = buffers.velocity)
-        n_particles = buffers.n_particles
-        threads = 256
-        blocks = cld(n_particles, threads)
-        CUDA.@sync CUDA.@cuda threads=threads blocks=blocks NeighborLoopCudaKernel!(
-            buffers.dρdtI,
-            buffers.acceleration,
-            position,
-            density,
-            pressure,
-            velocity,
-            buffers.motion_limiter,
-            buffers.neighbor_offsets,
-            buffers.neighbor_indices,
-            SimKernel,
-            SimConstants,
-            SimDensityDiffusion,
-            SimViscosity,
-        )
-        return nothing
-    end
-
     """
         NeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                       SimConstants, SimParticles, ParticleRanges, CellDict,
@@ -1332,39 +1135,6 @@ using LinearAlgebra
         return nothing
     end
 
-    function HalfTimeStepCudaKernel!(Position, Density, Velocity, Acceleration, GravityFactor,
-                                     MotionLimiter, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂, g)
-        i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-        if i <= length(Position)
-            acc = Acceleration[i] + ConstructGravitySVector(Acceleration[i], g * GravityFactor[i])
-            Acceleration[i] = acc
-            Positionₙ⁺[i] = Position[i] + Velocity[i] * dt₂ * MotionLimiter[i]
-            Velocityₙ⁺[i] = Velocity[i] + acc * dt₂ * MotionLimiter[i]
-            ρₙ⁺[i] = Density[i] + dρdtI[i] * dt₂
-        end
-        return nothing
-    end
-
-    function HalfTimeStepCuda!(SimConstants, buffers, dt₂)
-        threads = 256
-        blocks = cld(buffers.n_particles, threads)
-        CUDA.@sync CUDA.@cuda threads=threads blocks=blocks HalfTimeStepCudaKernel!(
-            buffers.position,
-            buffers.density,
-            buffers.velocity,
-            buffers.acceleration,
-            buffers.gravity_factor,
-            buffers.motion_limiter,
-            buffers.position_half,
-            buffers.velocity_half,
-            buffers.rho_half,
-            buffers.dρdtI,
-            dt₂,
-            SimConstants.g,
-        )
-        return nothing
-    end
-
     function FullTimeStep(::SimulationMetaData{D,T,NoShifting,K,B,L}, SimKernel,
                           SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt) where {D,T,
                                                                              K<:KernelOutputMode,
@@ -1376,46 +1146,6 @@ using LinearAlgebra
             Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
             Position[i]       +=  (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt) * MotionLimiter[i]
         end
-        return nothing
-    end
-
-    function FullTimeStepCudaKernel!(Position, Velocity, Acceleration, GravityFactor,
-                                     MotionLimiter, dt, g, h, η², max_visc, min_dt_force)
-        i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-        if i <= length(Position)
-            acc = Acceleration[i] + ConstructGravitySVector(Acceleration[i], g * GravityFactor[i])
-            Acceleration[i] = acc
-            limiter = MotionLimiter[i]
-            vel = Velocity[i] + acc * dt * limiter
-            Velocity[i] = vel
-            Position[i] = Position[i] + (((vel + (vel - acc * dt * limiter)) / 2) * dt) * limiter
-
-            r = Position[i]
-            r_sq = sqrt(dot(r, r))^2
-            max_visc[i] = abs(h * dot(vel, r) / (r_sq + η²))
-
-            a_mag = norm(acc)
-            min_dt_force[i] = a_mag > 0 ? sqrt(h / a_mag) : typemax(eltype(min_dt_force))
-        end
-        return nothing
-    end
-
-    function FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
-        threads = 256
-        blocks = cld(buffers.n_particles, threads)
-        CUDA.@sync CUDA.@cuda threads=threads blocks=blocks FullTimeStepCudaKernel!(
-            buffers.position,
-            buffers.velocity,
-            buffers.acceleration,
-            buffers.gravity_factor,
-            buffers.motion_limiter,
-            dt,
-            SimConstants.g,
-            SimKernel.h,
-            SimKernel.η²,
-            buffers.max_visc,
-            buffers.min_dt_force,
-        )
         return nothing
     end
 
@@ -1493,8 +1223,22 @@ using LinearAlgebra
 
     # Per-particle local Δx removed: use single scalar `SimMetaData.Δx`.
 
+    abstract type SimulationBackend end
+    struct CPUBackend <: SimulationBackend end
+    struct GPUBackend <: SimulationBackend end
+
+    SelectBackend(::Val{false}, _SimMetaData, _MotionDefinition, _SimDensityDiffusion,
+                  _SimViscosity) = CPUBackend()
+
+    function SelectBackend(::Val{true}, SimMetaData, MotionDefinition,
+                           SimDensityDiffusion, SimViscosity)
+        return SelectCudaBackend(SimMetaData, MotionDefinition, SimDensityDiffusion, SimViscosity)
+    end
+
+    SyncBackendState!(::CPUBackend, _SimParticles, _SimMetaData) = nothing
+
     
-    @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
+    @inbounds function SimulationLoop(::CPUBackend, SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
                                       SimConstants, SimParticles, FullStencil,
                                       ParticleRanges, UniqueCells, CellDict,
@@ -1522,64 +1266,15 @@ using LinearAlgebra
 
         ###
         UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-        UseCudaLoop = SimMetaData.UseCuda &&
-                        SimMetaData isa SimulationMetaData{Dimensions, FloatType, NoShifting, NoKernelOutput, NoMDBC, LMode} &&
-                        MotionDefinition === nothing &&
-                        CudaNeighborLoopSupported(SimDensityDiffusion, SimViscosity)
-        if UseCudaLoop && !CUDA.functional()
-            @warn "CUDA requested but not functional; falling back to CPU simulation loop."
-            UseCudaLoop = false
-        end
-
-        buffers = SimMetaData.CudaBuffers
-        if UseCudaLoop
-            if buffers === nothing || isempty(buffers.host_neighbor_offsets)
-                if SimMetaData.IndexCounter == 0
-                    SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹,
-                                                               SortingScratchSpace, ParticleRanges,
-                                                               UniqueCells, CellDict)
-                    UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-                    BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView,
-                                            ParticleRanges, CellDict)
-                end
-                UpdateCudaNeighborPairList!(SimMetaData, SimParticles, CellDict, ParticleRanges,
-                                            NeighborCellLists)
-                buffers = SimMetaData.CudaBuffers
-            end
-
-            neighbor_offsets = buffers.host_neighbor_offsets
-            neighbor_indices = buffers.host_neighbor_indices
-            buffers = EnsureCudaNeighborBuffers!(SimMetaData, Position, Density, Pressure, Velocity,
-                                                 SimParticles.GravityFactor, MotionLimiter,
-                                                 neighbor_offsets, neighbor_indices, dρdtI,
-                                                 Acceleration; sync_state = false,
-                                                 sync_neighbors = true)
-            if !buffers.state_initialized
-                SyncCudaStateToDevice!(buffers, Position, Density, Pressure, Velocity,
-                                       SimParticles.GravityFactor, MotionLimiter, dρdtI,
-                                       Acceleration, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺)
-            end
-            buffers.active = true
-            dt = Δt(buffers.position, buffers.velocity, buffers.acceleration, SimConstants, SimKernel)
-        else
-            if buffers !== nothing
-                buffers.active = false
-            end
-            # This code here is to initialize the first time step for each simulation loop
-            dt = Δt(Position, Velocity, Acceleration, SimConstants, SimKernel)
-        end
+        # This code here is to initialize the first time step for each simulation loop
+        dt = Δt(Position, Velocity, Acceleration, SimConstants, SimKernel)
 
         @no_escape begin
             dt₂ = dt * 0.5
 
             while SimMetaData.TotalTime <= next_output_time(SimMetaData)
                 @timeit SimMetaData.HourGlass "01 Calculate IndexCounter"  begin
-
-                    if UseCudaLoop
-                        SimMetaData.Δx = UpdateΔx!(SimMetaData.Δx, buffers.position_half, buffers.position)
-                    else
-                        SimMetaData.Δx = UpdateΔx!(SimMetaData.Δx, Positionₙ⁺, SimParticles.Position)
-                    end
+                    SimMetaData.Δx = UpdateΔx!(SimMetaData.Δx, Positionₙ⁺, SimParticles.Position)
                     ShouldRebuild = SimMetaData.Δx >= SimKernel.h
 
                     # println("Δx: ", Δx, "h: ", SimKernel.h," dt: ", SimMetaData.CurrentTimeStep, " Iteration: ", SimMetaData.Iteration, " TotalTime: ", SimMetaData.TotalTime, " OutputIterationCounter: ", SimMetaData.OutputIterationCounter)
@@ -1591,133 +1286,51 @@ using LinearAlgebra
                     # Remove if statement logic if you want to update each iteration
                     # if mod(SimMetaData.Iteration, ceil(Int, SimKernel.H / (SimConstants.c₀ * dt * (1/SimConstants.CFL)) )) == 0 || SimMetaData.Iteration == 1
                     if ShouldRebuild
-                        if UseCudaLoop
-                            SyncCudaPositionsToHost!(buffers, Position)
-                        end
                         @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellDict)
                         SimMetaData.Δx    = zero(eltype(dρdtI))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
                         BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellDict)
-                        if SimMetaData.UseCuda
-                            UpdateCudaNeighborPairList!(SimMetaData, SimParticles, CellDict,
-                                                        ParticleRanges, NeighborCellLists)
-                            if UseCudaLoop
-                                neighbor_offsets = SimMetaData.CudaBuffers.host_neighbor_offsets
-                                neighbor_indices = SimMetaData.CudaBuffers.host_neighbor_indices
-                                buffers = EnsureCudaNeighborBuffers!(
-                                    SimMetaData, Position, Density, Pressure, Velocity,
-                                    SimParticles.GravityFactor, MotionLimiter, neighbor_offsets,
-                                    neighbor_indices, dρdtI, Acceleration; sync_state = false,
-                                    sync_neighbors = true,
-                                )
-                            end
-                        end
                     end
                 end
 
                 @timeit SimMetaData.HourGlass "Motion" ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
 
-                @timeit SimMetaData.HourGlass "02 Pressure" begin
-                    if UseCudaLoop
-                        Pressure!(buffers.pressure, buffers.density, SimConstants)
-                    else
-                        Pressure!(SimParticles.Pressure, SimParticles.Density, SimConstants)
-                    end
-                end
-                @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep" ApplyMDBCBeforeHalf!(
-                    SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
-                    Position, Density, GhostPoints, GhostNormals, ParticleType,
+                @timeit SimMetaData.HourGlass "02 Pressure" Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
+                @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep" ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType)
+
+                @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoop!(
+                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    NeighborCellLists, Position, Density, Pressure, Velocity,
+                    MotionLimiter, dρdtI, Acceleration, Kernel,
+                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
                 )
 
-                @timeit SimMetaData.HourGlass "04 First NeighborLoop" begin
-                    if UseCudaLoop
-                        NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel, SimConstants)
-                    else
-                        NeighborLoop!(
-                            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                            SimConstants, SimParticles, ParticleRanges, CellDict,
-                            NeighborCellLists, Position, Density, Pressure, Velocity,
-                            MotionLimiter, dρdtI, Acceleration, Kernel,
-                            KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                        )
-                    end
-                end
+                @timeit SimMetaData.HourGlass "05 Update To Half TimeStep" HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
 
-                @timeit SimMetaData.HourGlass "05 Update To Half TimeStep" begin
-                    if UseCudaLoop
-                        HalfTimeStepCuda!(SimConstants, buffers, dt₂)
-                    else
-                        HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
-                    end
-                end
-
-                @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary" begin
-                    if UseCudaLoop
-                        LimitDensityAtBoundary!(buffers.rho_half, SimConstants.ρ₀, buffers.motion_limiter)
-                    else
-                        LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, MotionLimiter)
-                    end
-                end
-
+                @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary" LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, MotionLimiter)
+            
                 @timeit SimMetaData.HourGlass "Motion" ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
+            
+                @timeit SimMetaData.HourGlass "07 Pressure" Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
+                @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoop!(
+                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    NeighborCellLists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
+                    MotionLimiter, dρdtI, Acceleration, Kernel,
+                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
+                )
 
-                @timeit SimMetaData.HourGlass "07 Pressure" begin
-                    if UseCudaLoop
-                        Pressure!(buffers.pressure, buffers.rho_half, SimConstants)
-                    else
-                        Pressure!(SimParticles.Pressure, ρₙ⁺, SimConstants)
-                    end
-                end
-                @timeit SimMetaData.HourGlass "08 Second NeighborLoop" begin
-                    if UseCudaLoop
-                        NeighborLoopCuda!(
-                            buffers, SimDensityDiffusion, SimViscosity, SimKernel, SimConstants;
-                            position=buffers.position_half, density=buffers.rho_half,
-                            pressure=buffers.pressure, velocity=buffers.velocity_half,
-                        )
-                    else
-                        NeighborLoop!(
-                            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                            SimConstants, SimParticles, ParticleRanges, CellDict,
-                            NeighborCellLists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
-                            MotionLimiter, dρdtI, Acceleration, Kernel,
-                            KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                        )
-                    end
-                end
-
-                @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary" begin
-                    if UseCudaLoop
-                        LimitDensityAtBoundary!(buffers.density, SimConstants.ρ₀, buffers.motion_limiter)
-                    else
-                        LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
-                    end
-                end
-
-                @timeit SimMetaData.HourGlass "10 Final Density" begin
-                    if UseCudaLoop
-                        DensityEpsi!(buffers.density, buffers.dρdtI, buffers.rho_half, dt)
-                    else
-                        DensityEpsi!(Density, dρdtI, ρₙ⁺, dt)
-                    end
-                end
-
-                @timeit SimMetaData.HourGlass "11 Update To Final TimeStep" begin
-                    if UseCudaLoop
-                        FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
-                    else
-                        FullTimeStep(SimMetaData, SimKernel, SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt)
-                    end
-                end
-
+                @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary" LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
+            
+                @timeit SimMetaData.HourGlass "10 Final Density" DensityEpsi!(Density, dρdtI, ρₙ⁺, dt)
+            
+                @timeit SimMetaData.HourGlass "11 Update To Final TimeStep" FullTimeStep(SimMetaData, SimKernel, SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt)
+            
                 @timeit SimMetaData.HourGlass "12 Update MetaData" UpdateMetaData!(SimMetaData, dt)
 
                 @timeit SimMetaData.HourGlass "13 Update TimeStep" begin
-                    if UseCudaLoop
-                        dt = FinalizeTimeStep(buffers.max_visc, buffers.min_dt_force, SimConstants, SimKernel)
-                    else
-                        dt = Δt(Position, Velocity, Acceleration, SimConstants, SimKernel)
-                    end
+                    dt = Δt(Position, Velocity, Acceleration, SimConstants, SimKernel)
                 end
             end
         end
@@ -1725,6 +1338,8 @@ using LinearAlgebra
         return nothing
     end
     
+    include("SPHCellListGPU.jl")
+
     ###===
     function RunSimulation(;SimGeometry::Vector{Geometry{Dimensions, FloatType}}, #Don't further specify type for now
         SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
@@ -1801,20 +1416,19 @@ using LinearAlgebra
             MotionDefinition = nothing
         end
 
+        backend = SelectBackend(Val(SimMetaData.UseCuda), SimMetaData, MotionDefinition,
+                                SimDensityDiffusion, SimViscosity)
+
         @inbounds while true
 
             @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
-                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                backend, SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                 SimConstants, SimParticles, FullStencil, ParticleRanges,
                 UniqueCells, CellDict, SortingScratchSpace,
                 NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
                 ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
             )
-            if SimMetaData.UseCuda &&
-               SimMetaData.CudaBuffers !== nothing &&
-               SimMetaData.CudaBuffers.active
-                SyncCudaStateToHost!(SimMetaData.CudaBuffers, SimParticles)
-            end
+            SyncBackendState!(backend, SimParticles, SimMetaData)
             push!(SimMetaData.TimeSteps, SimMetaData.CurrentTimeStep)
 
             LogStep!(SimMetaData, SimLogger)

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -79,9 +79,6 @@ using LinearAlgebra
     """
     # Replace unsafe_trunc with trunc if this ever errors
     @inline function map_floor(x, InverseCutOff)
-        if !isfinite(x)
-            return zero(Int)
-        end
         # This is different than just doing muladd(x,InverseCutOff,0.5) because it rounds towards zero.
         # Consider -1.7 + 0.5, this would give -1.2 and then trunced 1, but we want -2, therefore absolute addition before hand
         # We add 0.5 instead of 1, to ensure proper rounding behavior when restoring the sign for negative numbers.

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -79,6 +79,9 @@ using LinearAlgebra
     """
     # Replace unsafe_trunc with trunc if this ever errors
     @inline function map_floor(x, InverseCutOff)
+        if !isfinite(x)
+            return zero(Int)
+        end
         # This is different than just doing muladd(x,InverseCutOff,0.5) because it rounds towards zero.
         # Consider -1.7 + 0.5, this would give -1.2 and then trunced 1, but we want -2, therefore absolute addition before hand
         # We add 0.5 instead of 1, to ensure proper rounding behavior when restoring the sign for negative numbers.

--- a/src/SPHCellListGPU.jl
+++ b/src/SPHCellListGPU.jl
@@ -193,7 +193,8 @@ end
 
 function NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel,
                            SimConstants; position = buffers.position,
-                           density = buffers.density, velocity = buffers.velocity)
+                           density = buffers.density, pressure = buffers.pressure,
+                           velocity = buffers.velocity)
     n_particles = buffers.n_particles
     threads, blocks = CudaLaunchConfig(n_particles)
     CUDA.@sync CUDA.@cuda threads=threads blocks=blocks NeighborLoopCudaKernel!(
@@ -201,6 +202,7 @@ function NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel
         buffers.acceleration,
         position,
         density,
+        pressure,
         velocity,
         buffers.motion_limiter,
         buffers.neighbor_offsets,
@@ -223,18 +225,14 @@ end
 end
 
 function HalfTimeStepCudaKernel!(Position, Density, Velocity, Acceleration, GravityFactor,
-                                 MotionLimiter, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂, g, ρ₀)
+                                 MotionLimiter, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂, g)
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     if i <= length(Position)
         acc = Acceleration[i] + ConstructGravitySVector(Acceleration[i], g * GravityFactor[i])
         Acceleration[i] = acc
         Positionₙ⁺[i] = Position[i] + Velocity[i] * dt₂ * MotionLimiter[i]
         Velocityₙ⁺[i] = Velocity[i] + acc * dt₂ * MotionLimiter[i]
-        ρ_new = Density[i] + dρdtI[i] * dt₂
-        if (ρ_new < ρ₀) * !Bool(MotionLimiter[i])
-            ρ_new = ρ₀
-        end
-        ρₙ⁺[i] = ρ_new
+        ρₙ⁺[i] = Density[i] + dρdtI[i] * dt₂
     end
     return nothing
 end
@@ -254,22 +252,14 @@ function HalfTimeStepCuda!(SimConstants, buffers, dt₂)
         buffers.dρdtI,
         dt₂,
         SimConstants.g,
-        SimConstants.ρ₀,
     )
     return nothing
 end
 
-function PostStepCudaKernel!(Position, Density, Velocity, Acceleration, GravityFactor,
-                             MotionLimiter, dρdtI, ρₙ⁺, dt, g, h, η², ρ₀, max_visc,
-                             min_dt_force)
+function FullTimeStepCudaKernel!(Position, Velocity, Acceleration, GravityFactor,
+                                 MotionLimiter, dt, g, h, η², max_visc, min_dt_force)
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     if i <= length(Position)
-        if (Density[i] < ρ₀) * !Bool(MotionLimiter[i])
-            Density[i] = ρ₀
-        end
-        epsi = - (dρdtI[i] / ρₙ⁺[i]) * dt
-        Density[i] *= (2 - epsi) / (2 + epsi)
-
         acc = Acceleration[i] + ConstructGravitySVector(Acceleration[i], g * GravityFactor[i])
         Acceleration[i] = acc
         limiter = MotionLimiter[i]
@@ -287,22 +277,18 @@ function PostStepCudaKernel!(Position, Density, Velocity, Acceleration, GravityF
     return nothing
 end
 
-function PostStepCuda!(SimKernel, SimConstants, buffers, dt)
+function FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
     threads, blocks = CudaLaunchConfig(buffers.n_particles)
-    CUDA.@sync CUDA.@cuda threads=threads blocks=blocks PostStepCudaKernel!(
+    CUDA.@sync CUDA.@cuda threads=threads blocks=blocks FullTimeStepCudaKernel!(
         buffers.position,
-        buffers.density,
         buffers.velocity,
         buffers.acceleration,
         buffers.gravity_factor,
         buffers.motion_limiter,
-        buffers.dρdtI,
-        buffers.rho_half,
         dt,
         SimConstants.g,
         SimKernel.h,
         SimKernel.η²,
-        SimConstants.ρ₀,
         buffers.max_visc,
         buffers.min_dt_force,
     )
@@ -385,6 +371,7 @@ end
 
             @timeit SimMetaData.HourGlass "Motion" ProgressMotion(SimParticles, dt₂, nothing, SimMetaData)
 
+            @timeit SimMetaData.HourGlass "02 Pressure" Pressure!(buffers.pressure, buffers.density, SimConstants)
             @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep" ApplyMDBCBeforeHalf!(
                 SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
                 Position, Density, SimParticles.GhostPoints, SimParticles.GhostNormals, SimParticles.Type,
@@ -396,15 +383,28 @@ end
 
             @timeit SimMetaData.HourGlass "05 Update To Half TimeStep" HalfTimeStepCuda!(SimConstants, buffers, dt₂)
 
+            @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary" LimitDensityAtBoundary!(
+                buffers.rho_half, SimConstants.ρ₀, buffers.motion_limiter,
+            )
+
             @timeit SimMetaData.HourGlass "Motion" ProgressMotion(SimParticles, dt₂, nothing, SimMetaData)
 
+            @timeit SimMetaData.HourGlass "07 Pressure" Pressure!(buffers.pressure, buffers.rho_half, SimConstants)
             @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopCuda!(
                 buffers, SimDensityDiffusion, SimViscosity, SimKernel, SimConstants;
                 position=buffers.position_half, density=buffers.rho_half,
-                velocity=buffers.velocity_half,
+                pressure=buffers.pressure, velocity=buffers.velocity_half,
             )
 
-            @timeit SimMetaData.HourGlass "11 Update To Final TimeStep" PostStepCuda!(SimKernel, SimConstants, buffers, dt)
+            @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary" LimitDensityAtBoundary!(
+                buffers.density, SimConstants.ρ₀, buffers.motion_limiter,
+            )
+
+            @timeit SimMetaData.HourGlass "10 Final Density" DensityEpsi!(
+                buffers.density, buffers.dρdtI, buffers.rho_half, dt,
+            )
+
+            @timeit SimMetaData.HourGlass "11 Update To Final TimeStep" FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
 
             @timeit SimMetaData.HourGlass "12 Update MetaData" UpdateMetaData!(SimMetaData, dt)
 

--- a/src/SPHCellListGPU.jl
+++ b/src/SPHCellListGPU.jl
@@ -196,8 +196,7 @@ function NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel
                            density = buffers.density, pressure = buffers.pressure,
                            velocity = buffers.velocity)
     n_particles = buffers.n_particles
-    threads = 256
-    blocks = cld(n_particles, threads)
+    threads, blocks = CudaLaunchConfig(n_particles)
     CUDA.@sync CUDA.@cuda threads=threads blocks=blocks NeighborLoopCudaKernel!(
         buffers.dρdtI,
         buffers.acceleration,
@@ -216,6 +215,15 @@ function NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel
     return nothing
 end
 
+@inline function CudaLaunchConfig(n_particles::Integer)
+    if n_particles <= 0
+        return 1, 1
+    end
+    threads = min(256, max(32, 1 << floor(Int, log2(min(n_particles, 256)))))
+    blocks = cld(n_particles, threads)
+    return threads, blocks
+end
+
 function HalfTimeStepCudaKernel!(Position, Density, Velocity, Acceleration, GravityFactor,
                                  MotionLimiter, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂, g)
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
@@ -230,8 +238,7 @@ function HalfTimeStepCudaKernel!(Position, Density, Velocity, Acceleration, Grav
 end
 
 function HalfTimeStepCuda!(SimConstants, buffers, dt₂)
-    threads = 256
-    blocks = cld(buffers.n_particles, threads)
+    threads, blocks = CudaLaunchConfig(buffers.n_particles)
     CUDA.@sync CUDA.@cuda threads=threads blocks=blocks HalfTimeStepCudaKernel!(
         buffers.position,
         buffers.density,
@@ -271,8 +278,7 @@ function FullTimeStepCudaKernel!(Position, Velocity, Acceleration, GravityFactor
 end
 
 function FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
-    threads = 256
-    blocks = cld(buffers.n_particles, threads)
+    threads, blocks = CudaLaunchConfig(buffers.n_particles)
     CUDA.@sync CUDA.@cuda threads=threads blocks=blocks FullTimeStepCudaKernel!(
         buffers.position,
         buffers.velocity,

--- a/src/SPHCellListGPU.jl
+++ b/src/SPHCellListGPU.jl
@@ -193,8 +193,7 @@ end
 
 function NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel,
                            SimConstants; position = buffers.position,
-                           density = buffers.density, pressure = buffers.pressure,
-                           velocity = buffers.velocity)
+                           density = buffers.density, velocity = buffers.velocity)
     n_particles = buffers.n_particles
     threads, blocks = CudaLaunchConfig(n_particles)
     CUDA.@sync CUDA.@cuda threads=threads blocks=blocks NeighborLoopCudaKernel!(
@@ -202,7 +201,6 @@ function NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel
         buffers.acceleration,
         position,
         density,
-        pressure,
         velocity,
         buffers.motion_limiter,
         buffers.neighbor_offsets,
@@ -225,14 +223,18 @@ end
 end
 
 function HalfTimeStepCudaKernel!(Position, Density, Velocity, Acceleration, GravityFactor,
-                                 MotionLimiter, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂, g)
+                                 MotionLimiter, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂, g, ρ₀)
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     if i <= length(Position)
         acc = Acceleration[i] + ConstructGravitySVector(Acceleration[i], g * GravityFactor[i])
         Acceleration[i] = acc
         Positionₙ⁺[i] = Position[i] + Velocity[i] * dt₂ * MotionLimiter[i]
         Velocityₙ⁺[i] = Velocity[i] + acc * dt₂ * MotionLimiter[i]
-        ρₙ⁺[i] = Density[i] + dρdtI[i] * dt₂
+        ρ_new = Density[i] + dρdtI[i] * dt₂
+        if (ρ_new < ρ₀) * !Bool(MotionLimiter[i])
+            ρ_new = ρ₀
+        end
+        ρₙ⁺[i] = ρ_new
     end
     return nothing
 end
@@ -252,14 +254,22 @@ function HalfTimeStepCuda!(SimConstants, buffers, dt₂)
         buffers.dρdtI,
         dt₂,
         SimConstants.g,
+        SimConstants.ρ₀,
     )
     return nothing
 end
 
-function FullTimeStepCudaKernel!(Position, Velocity, Acceleration, GravityFactor,
-                                 MotionLimiter, dt, g, h, η², max_visc, min_dt_force)
+function PostStepCudaKernel!(Position, Density, Velocity, Acceleration, GravityFactor,
+                             MotionLimiter, dρdtI, ρₙ⁺, dt, g, h, η², ρ₀, max_visc,
+                             min_dt_force)
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     if i <= length(Position)
+        if (Density[i] < ρ₀) * !Bool(MotionLimiter[i])
+            Density[i] = ρ₀
+        end
+        epsi = - (dρdtI[i] / ρₙ⁺[i]) * dt
+        Density[i] *= (2 - epsi) / (2 + epsi)
+
         acc = Acceleration[i] + ConstructGravitySVector(Acceleration[i], g * GravityFactor[i])
         Acceleration[i] = acc
         limiter = MotionLimiter[i]
@@ -277,18 +287,22 @@ function FullTimeStepCudaKernel!(Position, Velocity, Acceleration, GravityFactor
     return nothing
 end
 
-function FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
+function PostStepCuda!(SimKernel, SimConstants, buffers, dt)
     threads, blocks = CudaLaunchConfig(buffers.n_particles)
-    CUDA.@sync CUDA.@cuda threads=threads blocks=blocks FullTimeStepCudaKernel!(
+    CUDA.@sync CUDA.@cuda threads=threads blocks=blocks PostStepCudaKernel!(
         buffers.position,
+        buffers.density,
         buffers.velocity,
         buffers.acceleration,
         buffers.gravity_factor,
         buffers.motion_limiter,
+        buffers.dρdtI,
+        buffers.rho_half,
         dt,
         SimConstants.g,
         SimKernel.h,
         SimKernel.η²,
+        SimConstants.ρ₀,
         buffers.max_visc,
         buffers.min_dt_force,
     )
@@ -371,7 +385,6 @@ end
 
             @timeit SimMetaData.HourGlass "Motion" ProgressMotion(SimParticles, dt₂, nothing, SimMetaData)
 
-            @timeit SimMetaData.HourGlass "02 Pressure" Pressure!(buffers.pressure, buffers.density, SimConstants)
             @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep" ApplyMDBCBeforeHalf!(
                 SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
                 Position, Density, SimParticles.GhostPoints, SimParticles.GhostNormals, SimParticles.Type,
@@ -383,28 +396,15 @@ end
 
             @timeit SimMetaData.HourGlass "05 Update To Half TimeStep" HalfTimeStepCuda!(SimConstants, buffers, dt₂)
 
-            @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary" LimitDensityAtBoundary!(
-                buffers.rho_half, SimConstants.ρ₀, buffers.motion_limiter,
-            )
-
             @timeit SimMetaData.HourGlass "Motion" ProgressMotion(SimParticles, dt₂, nothing, SimMetaData)
 
-            @timeit SimMetaData.HourGlass "07 Pressure" Pressure!(buffers.pressure, buffers.rho_half, SimConstants)
             @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopCuda!(
                 buffers, SimDensityDiffusion, SimViscosity, SimKernel, SimConstants;
                 position=buffers.position_half, density=buffers.rho_half,
-                pressure=buffers.pressure, velocity=buffers.velocity_half,
+                velocity=buffers.velocity_half,
             )
 
-            @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary" LimitDensityAtBoundary!(
-                buffers.density, SimConstants.ρ₀, buffers.motion_limiter,
-            )
-
-            @timeit SimMetaData.HourGlass "10 Final Density" DensityEpsi!(
-                buffers.density, buffers.dρdtI, buffers.rho_half, dt,
-            )
-
-            @timeit SimMetaData.HourGlass "11 Update To Final TimeStep" FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
+            @timeit SimMetaData.HourGlass "11 Update To Final TimeStep" PostStepCuda!(SimKernel, SimConstants, buffers, dt)
 
             @timeit SimMetaData.HourGlass "12 Update MetaData" UpdateMetaData!(SimMetaData, dt)
 

--- a/src/SPHCellListGPU.jl
+++ b/src/SPHCellListGPU.jl
@@ -1,0 +1,412 @@
+# CUDA-specialized neighbor loop and simulation backend.
+
+function SelectCudaBackend(::SimulationMetaData{D,T,NoShifting,NoKernelOutput,NoMDBC,L},
+                           ::Nothing, ::LinearDensityDiffusion, ::ArtificialViscosity) where {D,T,L}
+    if !CUDA.functional()
+        @warn "CUDA requested but not functional; falling back to CPU simulation loop."
+        return CPUBackend()
+    end
+    return GPUBackend()
+end
+
+SelectCudaBackend(_SimMetaData, _MotionDefinition, _SimDensityDiffusion, _SimViscosity) = CPUBackend()
+
+function SyncBackendState!(::GPUBackend, SimParticles, SimMetaData)
+    buffers = SimMetaData.CudaBuffers
+    if buffers !== nothing && buffers.active
+        SyncCudaStateToHost!(buffers, SimParticles)
+    end
+    return nothing
+end
+
+mutable struct CudaNeighborBuffers
+    n_particles::Int
+    host_neighbor_offsets::Vector{Int}
+    host_neighbor_indices::Vector{Int}
+    position
+    density
+    pressure
+    velocity
+    gravity_factor
+    motion_limiter
+    neighbor_offsets
+    neighbor_indices
+    dρdtI
+    acceleration
+    position_half
+    velocity_half
+    rho_half
+    max_visc
+    min_dt_force
+    neighbor_dirty::Bool
+    state_initialized::Bool
+    active::Bool
+end
+
+function EmptyCudaNeighborBuffers()
+    return CudaNeighborBuffers(
+        0,
+        Int[],
+        Int[],
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        Int[],
+        Int[],
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        nothing,
+        true,
+        false,
+        false,
+    )
+end
+
+function EnsureCudaNeighborBuffers!(SimMetaData, Position, Density, Pressure, Velocity,
+                                    GravityFactor, MotionLimiter, neighbor_offsets,
+                                    neighbor_indices, dρdtI, Acceleration; sync_state = true,
+                                    sync_neighbors = true)
+    n_particles = length(Position)
+    offsets_len = length(neighbor_offsets)
+    indices_len = length(neighbor_indices)
+    buffers = SimMetaData.CudaBuffers
+    needs_alloc = buffers === nothing ||
+                  buffers.n_particles != n_particles ||
+                  length(buffers.neighbor_offsets) != offsets_len ||
+                  length(buffers.neighbor_indices) != indices_len
+    if needs_alloc
+        buffers = CudaNeighborBuffers(
+            n_particles,
+            neighbor_offsets,
+            neighbor_indices,
+            CuArray(Position),
+            CuArray(Density),
+            CuArray(Pressure),
+            CuArray(Velocity),
+            CuArray(GravityFactor),
+            CuArray(MotionLimiter),
+            CuArray(neighbor_offsets),
+            CuArray(neighbor_indices),
+            similar(CuArray(dρdtI)),
+            similar(CuArray(Acceleration)),
+            similar(CuArray(Position)),
+            similar(CuArray(Velocity)),
+            similar(CuArray(Density)),
+            similar(CuArray(Density)),
+            similar(CuArray(Density)),
+            true,
+            false,
+            false,
+        )
+        SimMetaData.CudaBuffers = buffers
+    end
+    buffers.n_particles = n_particles
+    buffers.host_neighbor_offsets = neighbor_offsets
+    buffers.host_neighbor_indices = neighbor_indices
+
+    if sync_state
+        copyto!(buffers.position, Position)
+        copyto!(buffers.density, Density)
+        copyto!(buffers.pressure, Pressure)
+        copyto!(buffers.velocity, Velocity)
+        copyto!(buffers.gravity_factor, GravityFactor)
+        copyto!(buffers.motion_limiter, MotionLimiter)
+    end
+
+    if sync_neighbors && (needs_alloc || buffers.neighbor_dirty)
+        copyto!(buffers.neighbor_offsets, neighbor_offsets)
+        copyto!(buffers.neighbor_indices, neighbor_indices)
+        buffers.neighbor_dirty = false
+    end
+
+    return buffers
+end
+
+function SyncCudaStateToDevice!(buffers, Position, Density, Pressure, Velocity,
+                                GravityFactor, MotionLimiter, dρdtI, Acceleration,
+                                Positionₙ⁺, Velocityₙ⁺, ρₙ⁺)
+    copyto!(buffers.position, Position)
+    copyto!(buffers.density, Density)
+    copyto!(buffers.pressure, Pressure)
+    copyto!(buffers.velocity, Velocity)
+    copyto!(buffers.gravity_factor, GravityFactor)
+    copyto!(buffers.motion_limiter, MotionLimiter)
+    copyto!(buffers.dρdtI, dρdtI)
+    copyto!(buffers.acceleration, Acceleration)
+    copyto!(buffers.position_half, Positionₙ⁺)
+    copyto!(buffers.velocity_half, Velocityₙ⁺)
+    copyto!(buffers.rho_half, ρₙ⁺)
+    buffers.state_initialized = true
+    return nothing
+end
+
+function SyncCudaStateToHost!(buffers, SimParticles)
+    copyto!(SimParticles.Position, buffers.position)
+    copyto!(SimParticles.Density, buffers.density)
+    copyto!(SimParticles.Pressure, buffers.pressure)
+    copyto!(SimParticles.Velocity, buffers.velocity)
+    copyto!(SimParticles.Acceleration, buffers.acceleration)
+    return nothing
+end
+
+function SyncCudaPositionsToHost!(buffers, Position)
+    copyto!(Position, buffers.position)
+    return nothing
+end
+
+function UpdateΔx!(Δx::T, posₙ⁺::CUDA.AbstractGPUArray{SVector{D, T}},
+                   pos::CUDA.AbstractGPUArray{SVector{D, T}}) where {D, T<:Real}
+    maxd = CUDA.mapreduce(
+        (pₙ⁺, p) -> begin
+            diff = pₙ⁺ - p
+            sqrt(dot(diff, diff))
+        end,
+        max,
+        posₙ⁺,
+        pos,
+    )
+    return Δx + 4 * maxd
+end
+
+function UpdateCudaNeighborPairList!(SimMetaData, SimParticles, CellDict, ParticleRanges,
+                                     NeighborCellLists)
+    buffers = SimMetaData.CudaBuffers
+    if buffers === nothing
+        buffers = EmptyCudaNeighborBuffers()
+        SimMetaData.CudaBuffers = buffers
+    end
+
+    neighbor_offsets = buffers.host_neighbor_offsets
+    neighbor_indices = buffers.host_neighbor_indices
+    BuildNeighborPairList!(neighbor_offsets, neighbor_indices, SimParticles.Cells,
+                           CellDict, ParticleRanges, NeighborCellLists)
+    buffers.neighbor_dirty = true
+    return nothing
+end
+
+function NeighborLoopCuda!(buffers, SimDensityDiffusion, SimViscosity, SimKernel,
+                           SimConstants; position = buffers.position,
+                           density = buffers.density, pressure = buffers.pressure,
+                           velocity = buffers.velocity)
+    n_particles = buffers.n_particles
+    threads = 256
+    blocks = cld(n_particles, threads)
+    CUDA.@sync CUDA.@cuda threads=threads blocks=blocks NeighborLoopCudaKernel!(
+        buffers.dρdtI,
+        buffers.acceleration,
+        position,
+        density,
+        pressure,
+        velocity,
+        buffers.motion_limiter,
+        buffers.neighbor_offsets,
+        buffers.neighbor_indices,
+        SimKernel,
+        SimConstants,
+        SimDensityDiffusion,
+        SimViscosity,
+    )
+    return nothing
+end
+
+function HalfTimeStepCudaKernel!(Position, Density, Velocity, Acceleration, GravityFactor,
+                                 MotionLimiter, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂, g)
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if i <= length(Position)
+        acc = Acceleration[i] + ConstructGravitySVector(Acceleration[i], g * GravityFactor[i])
+        Acceleration[i] = acc
+        Positionₙ⁺[i] = Position[i] + Velocity[i] * dt₂ * MotionLimiter[i]
+        Velocityₙ⁺[i] = Velocity[i] + acc * dt₂ * MotionLimiter[i]
+        ρₙ⁺[i] = Density[i] + dρdtI[i] * dt₂
+    end
+    return nothing
+end
+
+function HalfTimeStepCuda!(SimConstants, buffers, dt₂)
+    threads = 256
+    blocks = cld(buffers.n_particles, threads)
+    CUDA.@sync CUDA.@cuda threads=threads blocks=blocks HalfTimeStepCudaKernel!(
+        buffers.position,
+        buffers.density,
+        buffers.velocity,
+        buffers.acceleration,
+        buffers.gravity_factor,
+        buffers.motion_limiter,
+        buffers.position_half,
+        buffers.velocity_half,
+        buffers.rho_half,
+        buffers.dρdtI,
+        dt₂,
+        SimConstants.g,
+    )
+    return nothing
+end
+
+function FullTimeStepCudaKernel!(Position, Velocity, Acceleration, GravityFactor,
+                                 MotionLimiter, dt, g, h, η², max_visc, min_dt_force)
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if i <= length(Position)
+        acc = Acceleration[i] + ConstructGravitySVector(Acceleration[i], g * GravityFactor[i])
+        Acceleration[i] = acc
+        limiter = MotionLimiter[i]
+        vel = Velocity[i] + acc * dt * limiter
+        Velocity[i] = vel
+        Position[i] = Position[i] + (((vel + (vel - acc * dt * limiter)) / 2) * dt) * limiter
+
+        r = Position[i]
+        r_sq = sqrt(dot(r, r))^2
+        max_visc[i] = abs(h * dot(vel, r) / (r_sq + η²))
+
+        a_mag = norm(acc)
+        min_dt_force[i] = a_mag > 0 ? sqrt(h / a_mag) : typemax(eltype(min_dt_force))
+    end
+    return nothing
+end
+
+function FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
+    threads = 256
+    blocks = cld(buffers.n_particles, threads)
+    CUDA.@sync CUDA.@cuda threads=threads blocks=blocks FullTimeStepCudaKernel!(
+        buffers.position,
+        buffers.velocity,
+        buffers.acceleration,
+        buffers.gravity_factor,
+        buffers.motion_limiter,
+        dt,
+        SimConstants.g,
+        SimKernel.h,
+        SimKernel.η²,
+        buffers.max_visc,
+        buffers.min_dt_force,
+    )
+    return nothing
+end
+
+@inbounds function SimulationLoop(::GPUBackend, SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
+                                  SimMetaData::SimulationMetaData{Dimensions, FloatType, NoShifting, NoKernelOutput, NoMDBC, LMode},
+                                  SimConstants, SimParticles, FullStencil,
+                                  ParticleRanges, UniqueCells, CellDict,
+                                  SortingScratchSpace,
+                                  NeighborCellLists, dρdtI, Velocityₙ⁺,
+                                  Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
+                                  ::Nothing) where {
+                                            Dimensions, FloatType, LMode,
+                                            SDD<:SPHDensityDiffusion,
+                                            SV<:SPHViscosity}
+    @unpack Position, Density, Pressure, Velocity, Acceleration, MotionLimiter = SimParticles
+
+    if SimMetaData.IndexCounter == 0
+        SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,
+                                                    ParticleRanges, UniqueCells, CellDict)
+        UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
+        BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView,
+                                ParticleRanges, CellDict)
+    end
+
+    UpdateCudaNeighborPairList!(SimMetaData, SimParticles, CellDict, ParticleRanges,
+                                NeighborCellLists)
+
+    buffers = SimMetaData.CudaBuffers
+    neighbor_offsets = buffers.host_neighbor_offsets
+    neighbor_indices = buffers.host_neighbor_indices
+    buffers = EnsureCudaNeighborBuffers!(SimMetaData, Position, Density, Pressure, Velocity,
+                                         SimParticles.GravityFactor, MotionLimiter,
+                                         neighbor_offsets, neighbor_indices, dρdtI,
+                                         Acceleration; sync_state = false,
+                                         sync_neighbors = true)
+    if !buffers.state_initialized
+        SyncCudaStateToDevice!(buffers, Position, Density, Pressure, Velocity,
+                               SimParticles.GravityFactor, MotionLimiter, dρdtI,
+                               Acceleration, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺)
+    end
+    buffers.active = true
+
+    UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
+    dt = Δt(buffers.position, buffers.velocity, buffers.acceleration, SimConstants, SimKernel)
+
+    @no_escape begin
+        dt₂ = dt * 0.5
+
+        while SimMetaData.TotalTime <= next_output_time(SimMetaData)
+            @timeit SimMetaData.HourGlass "01 Calculate IndexCounter" begin
+                SimMetaData.Δx = UpdateΔx!(SimMetaData.Δx, buffers.position_half, buffers.position)
+                ShouldRebuild = SimMetaData.Δx >= SimKernel.h
+
+                if ShouldRebuild
+                    SyncCudaPositionsToHost!(buffers, Position)
+                    @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" begin
+                        SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹,
+                                                                    SortingScratchSpace, ParticleRanges,
+                                                                    UniqueCells, CellDict)
+                    end
+                    SimMetaData.Δx    = zero(eltype(dρdtI))
+                    UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
+                    BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView,
+                                            ParticleRanges, CellDict)
+                    UpdateCudaNeighborPairList!(SimMetaData, SimParticles, CellDict,
+                                                ParticleRanges, NeighborCellLists)
+                    neighbor_offsets = SimMetaData.CudaBuffers.host_neighbor_offsets
+                    neighbor_indices = SimMetaData.CudaBuffers.host_neighbor_indices
+                    buffers = EnsureCudaNeighborBuffers!(
+                        SimMetaData, Position, Density, Pressure, Velocity,
+                        SimParticles.GravityFactor, MotionLimiter, neighbor_offsets,
+                        neighbor_indices, dρdtI, Acceleration; sync_state = false,
+                        sync_neighbors = true,
+                    )
+                end
+            end
+
+            @timeit SimMetaData.HourGlass "Motion" ProgressMotion(SimParticles, dt₂, nothing, SimMetaData)
+
+            @timeit SimMetaData.HourGlass "02 Pressure" Pressure!(buffers.pressure, buffers.density, SimConstants)
+            @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep" ApplyMDBCBeforeHalf!(
+                SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
+                Position, Density, SimParticles.GhostPoints, SimParticles.GhostNormals, SimParticles.Type,
+            )
+
+            @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopCuda!(
+                buffers, SimDensityDiffusion, SimViscosity, SimKernel, SimConstants,
+            )
+
+            @timeit SimMetaData.HourGlass "05 Update To Half TimeStep" HalfTimeStepCuda!(SimConstants, buffers, dt₂)
+
+            @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary" LimitDensityAtBoundary!(
+                buffers.rho_half, SimConstants.ρ₀, buffers.motion_limiter,
+            )
+
+            @timeit SimMetaData.HourGlass "Motion" ProgressMotion(SimParticles, dt₂, nothing, SimMetaData)
+
+            @timeit SimMetaData.HourGlass "07 Pressure" Pressure!(buffers.pressure, buffers.rho_half, SimConstants)
+            @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopCuda!(
+                buffers, SimDensityDiffusion, SimViscosity, SimKernel, SimConstants;
+                position=buffers.position_half, density=buffers.rho_half,
+                pressure=buffers.pressure, velocity=buffers.velocity_half,
+            )
+
+            @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary" LimitDensityAtBoundary!(
+                buffers.density, SimConstants.ρ₀, buffers.motion_limiter,
+            )
+
+            @timeit SimMetaData.HourGlass "10 Final Density" DensityEpsi!(
+                buffers.density, buffers.dρdtI, buffers.rho_half, dt,
+            )
+
+            @timeit SimMetaData.HourGlass "11 Update To Final TimeStep" FullTimeStepCuda!(SimKernel, SimConstants, buffers, dt)
+
+            @timeit SimMetaData.HourGlass "12 Update MetaData" UpdateMetaData!(SimMetaData, dt)
+
+            @timeit SimMetaData.HourGlass "13 Update TimeStep" begin
+                dt = FinalizeTimeStep(buffers.max_visc, buffers.min_dt_force, SimConstants, SimKernel)
+            end
+        end
+    end
+
+    return nothing
+end

--- a/src/SimulationEquations.jl
+++ b/src/SimulationEquations.jl
@@ -5,6 +5,7 @@ export EquationOfState, EquationOfStateGamma7, Pressure!, DensityEpsi!, LimitDen
 using StaticArrays
 using Parameters
 using FastPow
+using CUDA
 
 @inline function EquationOfStateGamma7(ρ,c₀,ρ₀)
     return @fastpow ((c₀^2*ρ₀)/7) * ((ρ/ρ₀)^7 - 1)
@@ -23,6 +24,24 @@ end
     end
 end
 
+function PressureCudaKernel!(Press, Density, c₀, ρ₀)
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if i <= length(Press)
+        Press[i] = EquationOfStateGamma7(Density[i], c₀, ρ₀)
+    end
+    return nothing
+end
+
+function Pressure!(Press::CUDA.AbstractGPUArray, Density::CUDA.AbstractGPUArray,
+                   SimulationConstants)
+    c₀ = SimulationConstants.c₀
+    ρ₀ = SimulationConstants.ρ₀
+    threads = 256
+    blocks = cld(length(Press), threads)
+    CUDA.@sync CUDA.@cuda threads=threads blocks=blocks PressureCudaKernel!(Press, Density, c₀, ρ₀)
+    return nothing
+end
+
 # This is to handle the special factor multiplied on density in the time stepping procedure, when
 # using symplectic time stepping
 @inline function DensityEpsi!(Density, dρdtIₙ⁺,ρₙ⁺,Δt)
@@ -32,6 +51,23 @@ end
     end
 end
 
+function DensityEpsiCudaKernel!(Density, dρdtIₙ⁺, ρₙ⁺, Δt)
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if i <= length(Density)
+        epsi = - (dρdtIₙ⁺[i] / ρₙ⁺[i]) * Δt
+        Density[i] *= (2 - epsi) / (2 + epsi)
+    end
+    return nothing
+end
+
+function DensityEpsi!(Density::CUDA.AbstractGPUArray, dρdtIₙ⁺::CUDA.AbstractGPUArray,
+                      ρₙ⁺::CUDA.AbstractGPUArray, Δt)
+    threads = 256
+    blocks = cld(length(Density), threads)
+    CUDA.@sync CUDA.@cuda threads=threads blocks=blocks DensityEpsiCudaKernel!(Density, dρdtIₙ⁺, ρₙ⁺, Δt)
+    return nothing
+end
+
 # This version of the function using !Bool(MotionLimiter) instead of BoundaryBool
 @inline function LimitDensityAtBoundary!(Density,ρ₀, MotionLimiter)
     @inbounds for i in eachindex(Density)
@@ -39,6 +75,24 @@ end
             Density[i] = ρ₀
         end
     end
+end
+
+function LimitDensityAtBoundaryCudaKernel!(Density, ρ₀, MotionLimiter)
+    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+    if i <= length(Density)
+        if (Density[i] < ρ₀) * !Bool(MotionLimiter[i])
+            Density[i] = ρ₀
+        end
+    end
+    return nothing
+end
+
+function LimitDensityAtBoundary!(Density::CUDA.AbstractGPUArray, ρ₀,
+                                 MotionLimiter::CUDA.AbstractGPUArray)
+    threads = 256
+    blocks = cld(length(Density), threads)
+    CUDA.@sync CUDA.@cuda threads=threads blocks=blocks LimitDensityAtBoundaryCudaKernel!(Density, ρ₀, MotionLimiter)
+    return nothing
 end
 
 @inline function ConstructGravitySVector(_::SVector{N, T}, value) where {N, T}

--- a/src/SimulationEquations.jl
+++ b/src/SimulationEquations.jl
@@ -7,6 +7,15 @@ using Parameters
 using FastPow
 using CUDA
 
+@inline function CudaLaunchConfig(n::Integer)
+    if n <= 0
+        return 1, 1
+    end
+    threads = min(256, max(32, 1 << floor(Int, log2(min(n, 256)))))
+    blocks = cld(n, threads)
+    return threads, blocks
+end
+
 @inline function EquationOfStateGamma7(ρ,c₀,ρ₀)
     return @fastpow ((c₀^2*ρ₀)/7) * ((ρ/ρ₀)^7 - 1)
 end
@@ -36,8 +45,7 @@ function Pressure!(Press::CUDA.AbstractGPUArray, Density::CUDA.AbstractGPUArray,
                    SimulationConstants)
     c₀ = SimulationConstants.c₀
     ρ₀ = SimulationConstants.ρ₀
-    threads = 256
-    blocks = cld(length(Press), threads)
+    threads, blocks = CudaLaunchConfig(length(Press))
     CUDA.@sync CUDA.@cuda threads=threads blocks=blocks PressureCudaKernel!(Press, Density, c₀, ρ₀)
     return nothing
 end
@@ -62,8 +70,7 @@ end
 
 function DensityEpsi!(Density::CUDA.AbstractGPUArray, dρdtIₙ⁺::CUDA.AbstractGPUArray,
                       ρₙ⁺::CUDA.AbstractGPUArray, Δt)
-    threads = 256
-    blocks = cld(length(Density), threads)
+    threads, blocks = CudaLaunchConfig(length(Density))
     CUDA.@sync CUDA.@cuda threads=threads blocks=blocks DensityEpsiCudaKernel!(Density, dρdtIₙ⁺, ρₙ⁺, Δt)
     return nothing
 end
@@ -89,8 +96,7 @@ end
 
 function LimitDensityAtBoundary!(Density::CUDA.AbstractGPUArray, ρ₀,
                                  MotionLimiter::CUDA.AbstractGPUArray)
-    threads = 256
-    blocks = cld(length(Density), threads)
+    threads, blocks = CudaLaunchConfig(length(Density))
     CUDA.@sync CUDA.@cuda threads=threads blocks=blocks LimitDensityAtBoundaryCudaKernel!(Density, ρ₀, MotionLimiter)
     return nothing
 end


### PR DESCRIPTION
### Motivation
- Move the heavy neighbor-loop work and time-step math onto the GPU and reduce host↔device overhead by keeping simulation state resident on the device and making the CUDA path a dispatchable option.
- Avoid rebuilding or re-uploading the flattened neighbor pairlist and large per-particle buffers every sub-step to improve throughput for cases like DamBreak3D.
- Provide CUDA-friendly kernels and helpers so per-particle interactions and timestep updates can run without dynamic dispatch or repeated allocations on the device.

### Description
- Added and expanded `CudaNeighborBuffers` and `EnsureCudaNeighborBuffers!` to allocate and persist GPU buffers and neighbor pairlists, plus `neighbor_dirty`, `state_initialized`, and `active` flags to control syncs.
- Implemented GPU kernels and helpers including `NeighborLoopCuda!`, `NeighborLoopCudaKernel!`, `HalfTimeStepCuda!`/`HalfTimeStepCudaKernel!`, `FullTimeStepCuda!`/`FullTimeStepCudaKernel!`, and CUDA variants of `Pressure!`, `DensityEpsi!`, and `LimitDensityAtBoundary!` to keep per-step work on-device.
- Added sync utilities `SyncCudaStateToDevice!`, `SyncCudaStateToHost!`, and `SyncCudaPositionsToHost!` and updated the simulation loop to select a `UseCudaLoop` path that reuses cached pairlists and minimizes transfers.
- Rewrote timestep handling to use device-side buffers where possible and compute time-step reductions on GPU using `FinalizeTimeStep`/device reductions instead of extra host passes.

### Testing
- No automated unit tests were executed for this change.
- Local package precompilation completed successfully during development (package precompilation finished as shown in the rollout logs).
- I ran focused code-inspection commands to validate call sites and wireups, and iterated until compilation issues were resolved.
- Commands executed during inspection included `rg -n "NeighborLoopCudaKernel|NeighborLoop!::Val{true}|CudaNeighborBuffers|EnsureCudaNeighborBuffers|UpdateCudaNeighborPairList|copyto!|Δt" src/SPHCellList.jl src/TimeStepping.jl`, `sed -n '500,820p' src/SPHCellList.jl`, `sed -n '1,140p' src/SimulationEquations.jl`, and the final commit `git commit -m "Keep CUDA loop data on GPU"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3a95cee88323a278f1bdec26486a)