### PR TITLE
Cache per-particle cell list indices and remove redundant sqrt in time stepping

### DIFF
--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -108,9 +108,10 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
 
     Pressureᵢ      = zeros(PositionUnderlyingType, NumberOfPoints)
     
-    Cells          = fill(zero(CartesianIndex{Dimensions}), NumberOfPoints)
-    
-    SimParticles = StructArray((Cells = Cells, Kernel = Kernel, KernelGradient = KernelGradient, Position=Position, Acceleration=Acceleration, Velocity=Velocity, Density=Density, Pressure=Pressureᵢ, GravityFactor=GravityFactor, MotionLimiter=MotionLimiter, BoundaryBool = BoundaryBool, ID = Idp , Type = Types, GroupMarker = GroupMarker, GhostPoints = GhostPoints, GhostNormals=GhostNormals))
+    Cells         = fill(zero(CartesianIndex{Dimensions}), NumberOfPoints)
+    CellListIndex = zeros(Int, NumberOfPoints)
+
+    SimParticles = StructArray((Cells = Cells, CellListIndex = CellListIndex, Kernel = Kernel, KernelGradient = KernelGradient, Position=Position, Acceleration=Acceleration, Velocity=Velocity, Density=Density, Pressure=Pressureᵢ, GravityFactor=GravityFactor, MotionLimiter=MotionLimiter, BoundaryBool = BoundaryBool, ID = Idp , Type = Types, GroupMarker = GroupMarker, GhostPoints = GhostPoints, GhostNormals=GhostNormals))
 
     sort!(SimParticles, by = p -> p.ID)
 

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -129,6 +129,7 @@ using LinearAlgebra
 
         sort!(Particles, by = p -> p.Cells; scratch=SortingScratchSpace)
         Cells = @views Particles.Cells
+        CellListIndex = Particles.CellListIndex
         @. ParticleRanges             = zero(eltype(ParticleRanges))
         ParticleRanges[1] = 1
         IndexCounter                  = 2
@@ -136,6 +137,7 @@ using LinearAlgebra
         UniqueCells[IndexCounter]     = Cells[1]
         empty!(CellDict)
         CellDict[Cells[1]] = IndexCounter
+        CellListIndex[1] = IndexCounter
 
         @inbounds @simd ivdep for i in eachindex(Cells)[2:end]
             if Cells[i] != Cells[i-1] # Equivalent to diff(Cells) != 0
@@ -144,6 +146,7 @@ using LinearAlgebra
                 UniqueCells[IndexCounter]     = Cells[i]
                 CellDict[Cells[i]]           = IndexCounter
             end
+            CellListIndex[i] = IndexCounter
         end
         ParticleRanges[IndexCounter + 1]  = length(ParticleRanges)
 
@@ -182,15 +185,14 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        Cells = SimParticles.Cells
+        CellListIndex = SimParticles.CellListIndex
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
-            CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
-            SameCellStart = ParticleRanges[CellListIndex]
-            SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
-            NeighborCellIndices = NeighborCellLists[CellListIndex]
+            CellListIndexI = CellListIndex[i]
+            SameCellStart = ParticleRanges[CellListIndexI]
+            SameCellEnd = ParticleRanges[CellListIndexI + 1] - 1
+            NeighborCellIndices = NeighborCellLists[CellListIndexI]
 
             @inbounds for j in SameCellStart:(i - 1)
                 dρdt_acc, acc_acc = ComputeInteractionsPerParticleNoKernel!(
@@ -238,17 +240,16 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        Cells = SimParticles.Cells
+        CellListIndex = SimParticles.CellListIndex
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
             kernel_acc = zero(Kernel[i])
             kernel_grad_acc = zero(KernelGradient[i])
-            CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
-            SameCellStart = ParticleRanges[CellListIndex]
-            SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
-            NeighborCellIndices = NeighborCellLists[CellListIndex]
+            CellListIndexI = CellListIndex[i]
+            SameCellStart = ParticleRanges[CellListIndexI]
+            SameCellEnd = ParticleRanges[CellListIndexI + 1] - 1
+            NeighborCellIndices = NeighborCellLists[CellListIndexI]
 
             @inbounds for j in SameCellStart:(i - 1)
                 dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc =
@@ -303,17 +304,16 @@ using LinearAlgebra
                                                   S<:ShiftingMode,B<:MDBCMode,
                                                   L<:LogMode,SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        Cells = SimParticles.Cells
+        CellListIndex = SimParticles.CellListIndex
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
             shift_c_acc = zero(∇Cᵢ[i])
             shift_r_acc = zero(∇◌rᵢ[i])
-            CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
-            SameCellStart = ParticleRanges[CellListIndex]
-            SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
-            NeighborCellIndices = NeighborCellLists[CellListIndex]
+            CellListIndexI = CellListIndex[i]
+            SameCellStart = ParticleRanges[CellListIndexI]
+            SameCellEnd = ParticleRanges[CellListIndexI + 1] - 1
+            NeighborCellIndices = NeighborCellLists[CellListIndexI]
 
             @inbounds for j in SameCellStart:(i - 1)
                 dρdt_acc, acc_acc, shift_c_acc, shift_r_acc =
@@ -370,7 +370,7 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        Cells = SimParticles.Cells
+        CellListIndex = SimParticles.CellListIndex
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -378,11 +378,10 @@ using LinearAlgebra
             kernel_grad_acc = zero(KernelGradient[i])
             shift_c_acc = zero(∇Cᵢ[i])
             shift_r_acc = zero(∇◌rᵢ[i])
-            CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
-            SameCellStart = ParticleRanges[CellListIndex]
-            SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
-            NeighborCellIndices = NeighborCellLists[CellListIndex]
+            CellListIndexI = CellListIndex[i]
+            SameCellStart = ParticleRanges[CellListIndexI]
+            SameCellEnd = ParticleRanges[CellListIndexI + 1] - 1
+            NeighborCellIndices = NeighborCellLists[CellListIndexI]
 
             @inbounds for j in SameCellStart:(i - 1)
                 dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -16,7 +16,7 @@ end
                                            velocity, acceleration, sim_kernel)
     h = sim_kernel.h
     η² = sim_kernel.η²
-    r_sq = sqrt(dot(position, position))^2
+    r_sq = dot(position, position)
     curr_visc = abs(h * dot(velocity, position) / (r_sq + η²))
     a_mag = norm(acceleration)
     curr_dt_force = a_mag > 0 ? sqrt(h / a_mag) : typemax(eltype(min_dt_force))
@@ -85,7 +85,7 @@ function Δt(Position, Velocity, Acceleration, SimulationConstants, SPHKernel)
                         v = Velocity[j]
                         a = Acceleration[j]
 
-                        r_sq = sqrt(dot(r, r))^2
+                        r_sq = dot(r, r)
                         curr_visc = abs(h * dot(v, r) / (r_sq + η²))
                         t_visc = max(t_visc, curr_visc)
 


### PR DESCRIPTION
### Motivation
- Reduce repeated dictionary lookups inside tight neighbor loops by caching the computed cell-list index per particle.  
- Avoid recomputing the mapping from particle cell to cell-list index during neighbor traversal to cut CPU cost in hot loops.  
- Remove an unnecessary `sqrt` operation in timestep/viscosity calculations to reduce work in per-particle time stepping routines.  

### Description
- Add a `CellListIndex` integer array to the particle `StructArray` in `AllocateDataStructures` (`src/PreProcess.jl`) and initialize it alongside `Cells`.  
- Populate `CellListIndex` in `UpdateNeighbors!` (`src/SPHCellList.jl`) while building `ParticleRanges`/`UniqueCells` so each particle stores its cell-list index.  
- Replace per-particle `get(CellDict, CellIndex, 1)` lookups in all `NeighborLoopPerParticle!` variants to use the cached `CellListIndex[i]` for same-cell and neighbor range access (`src/SPHCellList.jl`).  
- Remove redundant square-root usage by replacing `r_sq = sqrt(dot(r, r))^2` with `r_sq = dot(r, r)` in `UpdateTimeStepBuffers!` and `Δt` (`src/TimeStepping.jl`).  

### Testing
- No automated tests were run for these changes.  
- No CI or unit test results were produced as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a55e949608323ba45d0ef60476cb1)