### PR TITLE
Gate optional kernel/ghost fields by metadata and validate output variables

### DIFF
--- a/example/Dambreak2dMDBC.jl
+++ b/example/Dambreak2dMDBC.jl
@@ -6,6 +6,18 @@ let
 
     SimConstantsDambreak = SimulationConstants{FloatType}(dx=0.02,c₀=88.14487860902641, δᵩ = 0.1, CFL=0.2, α = 0.02)
 
+    SimMetaDataDambreak  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,NoMDBC,StoreLog}(
+        SimulationName="DamBreak2D",
+        SaveLocation="E:/SecondApproach/DamBreak2D_MDBC/",
+        SimulationTime=2.0,
+        OutputTimes=collect(0.01:0.01:2.0),
+        VisualizeInParaview=true,
+        ExportSingleVTKHDF=true,
+        ExportGridCells=true,
+        ExportGridCellParticleCounts=true,
+        OpenLogFile=true
+    )
+
     # Create Geometry instances
     FixedBoundary = Geometry{Dimensions, FloatType}(
         CSVFile     = "./input/dam_break_2d/DamBreak2d_Dp0.02_MDBC_Bound_ThreeLayers.csv",
@@ -25,19 +37,7 @@ let
     SimulationGeometry = [FixedBoundary; Water]
 
     # Load in particles
-    SimParticles = AllocateDataStructures(SimulationGeometry)
-
-    SimMetaDataDambreak  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,NoMDBC,StoreLog}(
-        SimulationName="DamBreak2D",
-        SaveLocation="E:/SecondApproach/DamBreak2D_MDBC/",
-        SimulationTime=2.0,
-        OutputTimes=collect(0.01:0.01:2.0),
-        VisualizeInParaview=true,
-        ExportSingleVTKHDF=true,
-        ExportGridCells=true,
-        ExportGridCellParticleCounts=true,
-        OpenLogFile=true
-    )
+    SimParticles = AllocateDataStructures(SimulationGeometry, SimMetaDataDambreak)
 
     # If save directory is not already made, make it
     if !isdir(SimMetaDataDambreak.SaveLocation)

--- a/example/Dambreak3d.jl
+++ b/example/Dambreak3d.jl
@@ -14,6 +14,18 @@ let
         CFL = 0.2
     )
 
+    # --- Simulation metadata & logging ---
+    SimMetaDataDambreak3D = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,NoMDBC,StoreLog}(
+        SimulationName         = "DamBreak3D_Test",
+        SaveLocation           = "E:/SecondApproach/TESTING_CPU_3DDambreak",
+        SimulationTime         = 1.6,
+        OutputTimes            = 0.01,
+        VisualizeInParaview    = true,
+        ExportSingleVTKHDF     = true,
+        ExportGridCells        = true,
+        OpenLogFile            = true
+    )
+
     # --- Geometry ---
     FixedBoundary = Geometry{Dimensions, FloatType}(
         CSVFile     = "./input/dam_break_3d/DamBreak3d_Dp$(dx)_Bound.csv",
@@ -30,19 +42,7 @@ let
     SimulationGeometry = [FixedBoundary; Water]
 
     # --- Allocate particles ---
-    SimParticles = AllocateDataStructures(SimulationGeometry)
-
-    # --- Simulation metadata & logging ---
-    SimMetaDataDambreak3D = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,NoMDBC,StoreLog}(
-        SimulationName         = "DamBreak3D_Test",
-        SaveLocation           = "E:/SecondApproach/TESTING_CPU_3DDambreak",
-        SimulationTime         = 1.6,
-        OutputTimes            = 0.01,
-        VisualizeInParaview    = true,
-        ExportSingleVTKHDF     = true,
-        ExportGridCells        = true,
-        OpenLogFile            = true
-    )
+    SimParticles = AllocateDataStructures(SimulationGeometry, SimMetaDataDambreak3D)
 
     SimLogger = SimulationLogger(SimMetaDataDambreak3D.SaveLocation)
 

--- a/example/DucklingMDBC.jl
+++ b/example/DucklingMDBC.jl
@@ -6,6 +6,17 @@ let
     
     SimConstantsWedge = SimulationConstants{FloatType}(dx=0.01,c₀=23.43842998154953, δᵩ = 0.1, CFL=0.2, α=0.02, m₀=0.001)
 
+    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC,StoreLog}(
+        SimulationName="CaseDuckling",
+        SaveLocation="E:/SecondApproach/TESTING_CPU_Duckling",
+        SimulationTime=1,
+        OutputTimes=0.02,
+        VisualizeInParaview=true,
+        ExportSingleVTKHDF=true,
+        ExportGridCells= true,
+        OpenLogFile=true
+    )
+
     # Assuming SimConstantsWedge is defined somewhere else with the field `dx`
     FixedBoundary = Geometry{Dimensions, FloatType}(
         CSVFile     = "./input/case_duckling_mdbc/CaseDuckling_Dp$(SimConstantsWedge.dx)_Bound_MDBC.csv",
@@ -24,18 +35,7 @@ let
     SimulationGeometry = [FixedBoundary;Water]
     
     # Load in particles
-    SimParticles = AllocateDataStructures(SimulationGeometry)
-
-    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC,StoreLog}(
-        SimulationName="CaseDuckling",
-        SaveLocation="E:/SecondApproach/TESTING_CPU_Duckling",
-        SimulationTime=1,
-        OutputTimes=0.02,
-        VisualizeInParaview=true,
-        ExportSingleVTKHDF=true,
-        ExportGridCells= true,
-        OpenLogFile=true
-    )
+    SimParticles = AllocateDataStructures(SimulationGeometry, SimMetaDataWedge)
 
     SimKernel           = SPHKernelInstance{Dimensions, FloatType}(WendlandC2(); dx = SimConstantsWedge.dx, k = 1.5)
     SimViscosity        = ArtificialViscosity()
@@ -60,6 +60,4 @@ let
 
     return SimParticles
 end
-
-
 

--- a/example/MovingSquare2d.jl
+++ b/example/MovingSquare2d.jl
@@ -53,7 +53,7 @@ let
     SimulationGeometry = [FixedBoundary;Water;MovingSquare]
 
     # Load in particles
-    SimParticles = AllocateDataStructures(SimulationGeometry)
+    SimParticles = AllocateDataStructures(SimulationGeometry, SimMetaDataMovingSquare)
     
     # Collect Geometry instances into a vector
     SimulationGeometry = [FixedBoundary, Water, MovingSquare]

--- a/example/StillWedgeMDBC.jl
+++ b/example/StillWedgeMDBC.jl
@@ -7,26 +7,6 @@ let
     SimConstantsWedge = SimulationConstants{FloatType}(dx=0.02,c₀=42.48576250492629, δᵩ = 0.1, CFL=0.5)
     # SimConstantsWedge = SimulationConstants{FloatType}(dx=0.01,c₀=43.4, δᵩ = 0.1, CFL=0.2)
 # 
-    # Assuming SimConstantsWedge is defined somewhere else with the field `dx`
-    FixedBoundary = Geometry{Dimensions, FloatType}(
-        CSVFile     = "./input/still_wedge/StillWedge_Dp$(SimConstantsWedge.dx)_Bound.csv",
-        GroupMarker = 1,
-        Type        = Fixed,   # Using the enum value Fixed
-        Motion      = nothing
-    )
-
-    Water = Geometry{Dimensions, FloatType}(
-        CSVFile     = "./input/still_wedge/StillWedge_Dp$(SimConstantsWedge.dx)_Fluid.csv",
-        GroupMarker = 2,
-        Type        = Fluid,   # Using the enum value Fluid
-        Motion      = nothing
-    )
-
-    SimulationGeometry = [FixedBoundary;Water]
-    
-    # Load in particles
-    SimParticles = AllocateDataStructures(SimulationGeometry)
-
     SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC,StoreLog}(
         SimulationName="StillWedge", 
         SaveLocation="W:/Simulations/StillWedge2D_MDBC",
@@ -51,6 +31,26 @@ let
         #     # "GhostNormals",
         # ]
     )
+
+    # Assuming SimConstantsWedge is defined somewhere else with the field `dx`
+    FixedBoundary = Geometry{Dimensions, FloatType}(
+        CSVFile     = "./input/still_wedge/StillWedge_Dp$(SimConstantsWedge.dx)_Bound.csv",
+        GroupMarker = 1,
+        Type        = Fixed,   # Using the enum value Fixed
+        Motion      = nothing
+    )
+
+    Water = Geometry{Dimensions, FloatType}(
+        CSVFile     = "./input/still_wedge/StillWedge_Dp$(SimConstantsWedge.dx)_Fluid.csv",
+        GroupMarker = 2,
+        Type        = Fluid,   # Using the enum value Fluid
+        Motion      = nothing
+    )
+
+    SimulationGeometry = [FixedBoundary;Water]
+    
+    # Load in particles
+    SimParticles = AllocateDataStructures(SimulationGeometry, SimMetaDataWedge)
 
     SimLogger = SimulationLogger(SimMetaDataWedge.SaveLocation)
 
@@ -105,7 +105,5 @@ let
     
     # display(plt)
 end
-
-
 
 

--- a/example/StillWedgeMiddleSquareMDBC.jl
+++ b/example/StillWedgeMiddleSquareMDBC.jl
@@ -7,6 +7,17 @@ let
     SimConstantsWedge = SimulationConstants{FloatType}(dx=0.02,c₀=42.48576250492629, δᵩ = 0.1, CFL=0.5)
     # SimConstantsWedge = SimulationConstants{FloatType}(dx=0.01,c₀=43.4, δᵩ = 0.1, CFL=0.2)
 
+    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC,StoreLog}(
+        SimulationName="StillWedge", 
+        SaveLocation="E:/SecondApproach/StillWedgeMiddleSquare2D_MDBC",
+        SimulationTime=4,
+        OutputTimes=0.01,
+        VisualizeInParaview=true,
+        ExportSingleVTKHDF=true,
+        ExportGridCells=true,
+        OpenLogFile=true
+    )
+
     # Assuming SimConstantsWedge is defined somewhere else with the field `dx`
     FixedBoundary = Geometry{Dimensions, FloatType}(
         CSVFile     = "./input/still_wedge_middle_square_mdbc/StillWedge_MiddleSquare_Dp$(SimConstantsWedge.dx)_Bound.csv",
@@ -25,18 +36,7 @@ let
     SimulationGeometry = [FixedBoundary;Water]
     
     # Load in particles
-    SimParticles = AllocateDataStructures(SimulationGeometry)
-
-    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,SimpleMDBC,StoreLog}(
-        SimulationName="StillWedge", 
-        SaveLocation="E:/SecondApproach/StillWedgeMiddleSquare2D_MDBC",
-        SimulationTime=4,
-        OutputTimes=0.01,
-        VisualizeInParaview=true,
-        ExportSingleVTKHDF=true,
-        ExportGridCells=true,
-        OpenLogFile=true
-    )
+    SimParticles = AllocateDataStructures(SimulationGeometry, SimMetaDataWedge)
 
     # If save directory is not already made, make it
     if !isdir(SimMetaDataWedge.SaveLocation)
@@ -96,7 +96,5 @@ let
     
     # display(plt)
 end
-
-
 
 

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -42,7 +42,7 @@ function LoadSpecificCSV(::Val{D}, ::Type{T}, particle_type::ParticleType, parti
     return points, density, types, group_marker, idp
 end
 
-function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, FloatType}}) where {Dimensions, FloatType}
+function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, FloatType}}; OutputVariables=String[], RequireMDBC::Bool=false, RequireKernelOutput::Bool=false) where {Dimensions, FloatType}
     Position    = Vector{SVector{Dimensions, FloatType}}()
     Density     = Vector{FloatType}()
     Types       = Vector{ParticleType}()
@@ -75,6 +75,13 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
     PositionType             = eltype(Position)
     PositionUnderlyingType   = eltype(PositionType)
 
+    sort_perm = sortperm(Idp)
+    Position = Position[sort_perm]
+    Density = Density[sort_perm]
+    Types = Types[sort_perm]
+    GroupMarker = GroupMarker[sort_perm]
+    Idp = Idp[sort_perm]
+
     GravityFactor = similar(Density)
     for i ∈ eachindex(GravityFactor)
         fac = 0
@@ -97,24 +104,58 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
         MotionLimiter[i] = fac
     end
 
-    BoundaryBool  = UInt8.(.!Bool.(MotionLimiter))
+    if !RequireKernelOutput && ("Kernel" in OutputVariables || "KernelGradient" in OutputVariables)
+        error("Kernel output requires StoreKernelOutput in SimulationMetaData.")
+    end
 
     Acceleration    = zeros(PositionType, NumberOfPoints)
     Velocity        = zeros(PositionType, NumberOfPoints)
-    Kernel          = zeros(PositionUnderlyingType, NumberOfPoints)
-    KernelGradient  = zeros(PositionType, NumberOfPoints)
-    GhostPoints     = zeros(PositionType, NumberOfPoints)
-    GhostNormals    = zeros(PositionType, NumberOfPoints)
-
     Pressureᵢ      = zeros(PositionUnderlyingType, NumberOfPoints)
     
     Cells          = fill(zero(CartesianIndex{Dimensions}), NumberOfPoints)
     
-    SimParticles = StructArray((Cells = Cells, Kernel = Kernel, KernelGradient = KernelGradient, Position=Position, Acceleration=Acceleration, Velocity=Velocity, Density=Density, Pressure=Pressureᵢ, GravityFactor=GravityFactor, MotionLimiter=MotionLimiter, BoundaryBool = BoundaryBool, ID = Idp , Type = Types, GroupMarker = GroupMarker, GhostPoints = GhostPoints, GhostNormals=GhostNormals))
+    ParticleFields = (;
+        Cells = Cells,
+        Position = Position,
+        Acceleration = Acceleration,
+        Velocity = Velocity,
+        Density = Density,
+        Pressure = Pressureᵢ,
+        GravityFactor = GravityFactor,
+        MotionLimiter = MotionLimiter,
+        Type = Types,
+        GroupMarker = GroupMarker,
+    )
+    if RequireKernelOutput
+        Kernel = zeros(PositionUnderlyingType, NumberOfPoints)
+        KernelGradient = zeros(PositionType, NumberOfPoints)
+        ParticleFields = merge(ParticleFields, (; Kernel = Kernel, KernelGradient = KernelGradient))
+    end
+    if RequireMDBC || "GhostPoints" in OutputVariables
+        GhostPoints = zeros(PositionType, NumberOfPoints)
+        ParticleFields = merge(ParticleFields, (; GhostPoints = GhostPoints))
+    end
+    if RequireMDBC || "GhostNormals" in OutputVariables
+        GhostNormals = zeros(PositionType, NumberOfPoints)
+        ParticleFields = merge(ParticleFields, (; GhostNormals = GhostNormals))
+    end
+    if "BoundaryBool" in OutputVariables
+        BoundaryBool = UInt8.(.!Bool.(MotionLimiter))
+        ParticleFields = merge(ParticleFields, (; BoundaryBool = BoundaryBool))
+    end
+    if "ID" in OutputVariables
+        ParticleFields = merge(ParticleFields, (; ID = Idp))
+    end
 
-    sort!(SimParticles, by = p -> p.ID)
+    SimParticles = StructArray(ParticleFields)
 
     return SimParticles
+end
+
+function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, FloatType}}, SimMetaData::SimulationMetaData{Dimensions, FloatType}) where {Dimensions, FloatType}
+    RequireMDBC = !(SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, KMode, NoMDBC, LMode} where {SMode, KMode, LMode})
+    RequireKernelOutput = !(SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, NoKernelOutput, BMode, LMode} where {SMode, BMode, LMode})
+    return AllocateDataStructures(SimGeometry; OutputVariables = SimMetaData.OutputVariables, RequireMDBC = RequireMDBC, RequireKernelOutput = RequireKernelOutput)
 end
 
 function AllocateSupportDataStructures(::SimulationMetaData{D,T,NoShifting,K,B,L}, Position) where {D,T,K<:KernelOutputMode,

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -566,21 +566,32 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             OutputVTKHDF = h5open("$(particle_savepath).vtkhdf", "w")
             root = HDF5.create_group(OutputVTKHDF, "VTKHDF")
             
-            available_init = Dict(
-                "Kernel" => SimParticles.Kernel,
-                "KernelGradient" => SimParticles.KernelGradient,
-                "Density" => SimParticles.Density,
-                "Pressure" => SimParticles.Pressure,
-                "Velocity" => SimParticles.Velocity,
-                "Acceleration" => SimParticles.Acceleration,
-                "BoundaryBool" => SimParticles.BoundaryBool,
-                "ID" => SimParticles.ID,
-                "Type" => Int8.(SimParticles.Type),
-                "GroupMarker" => SimParticles.GroupMarker,
-                "GhostPoints" => SimParticles.GhostPoints,
-                "GhostNormals" => SimParticles.GhostNormals,
+            field_map = Dict(
+                "Kernel" => :Kernel,
+                "KernelGradient" => :KernelGradient,
+                "Density" => :Density,
+                "Pressure" => :Pressure,
+                "Velocity" => :Velocity,
+                "Acceleration" => :Acceleration,
+                "BoundaryBool" => :BoundaryBool,
+                "ID" => :ID,
+                "Type" => :Type,
+                "GroupMarker" => :GroupMarker,
+                "GhostPoints" => :GhostPoints,
+                "GhostNormals" => :GhostNormals,
             )
-            output_data_init = [available_init[name] for name in output_vars]
+            output_data_init = Vector{Any}(undef, length(output_vars))
+            for (i, name) in pairs(output_vars)
+                prop = get(field_map, name, nothing)
+                if prop === nothing || !hasproperty(SimParticles, prop)
+                    error("OutputVariables includes $(name) but SimParticles has no field $(name).")
+                end
+                if name == "Type"
+                    output_data_init[i] = Int8.(getproperty(SimParticles, prop))
+                else
+                    output_data_init[i] = getproperty(SimParticles, prop)
+                end
+            end
 
             GenerateGeometryStructure(root, output_vars, output_data_init...; chunk_size=1024)
             GenerateStepStructure(root, output_vars, output_data_init...)
@@ -644,7 +655,11 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                 elseif name == "Type"
                     output_data[i] = Vector{Int8}(undef, n)
                 else
-                    src = getproperty(SimParticles, field_map[name])
+                    prop = field_map[name]
+                    if !hasproperty(SimParticles, prop)
+                        error("OutputVariables includes $(name) but SimParticles has no field $(name).")
+                    end
+                    src = getproperty(SimParticles, prop)
                     output_data[i] = similar(src, n)
                 end
             end
@@ -666,14 +681,22 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                         buf[j] = Int8(src[j])
                     end
                 elseif name in vector_fields
-                    src = getproperty(SimParticles, field_map[name])
+                    prop = field_map[name]
+                    if !hasproperty(SimParticles, prop)
+                        error("OutputVariables includes $(name) but SimParticles has no field $(name).")
+                    end
+                    src = getproperty(SimParticles, prop)
                     if Dimensions == 2
                         to_3d!(buf, src)
                     else
                         copy!(buf, src)
                     end
                 else
-                    src = getproperty(SimParticles, field_map[name])
+                    prop = field_map[name]
+                    if !hasproperty(SimParticles, prop)
+                        error("OutputVariables includes $(name) but SimParticles has no field $(name).")
+                    end
+                    src = getproperty(SimParticles, prop)
                     copy!(buf, src)
                 end
             end

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -176,7 +176,7 @@ using LinearAlgebra
                                       SimConstants, SimParticles, ParticleRanges,
                                       CellDict, NeighborCellLists, Position, Density,
                                       Pressure, Velocity, MotionLimiter, dρdtI,
-                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
+                                      Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
                                       min_dt_force = nothing) where {D,T,
                                                   B<:MDBCMode,L<:LogMode,
@@ -297,7 +297,7 @@ using LinearAlgebra
                                       SimConstants, SimParticles, ParticleRanges,
                                       CellDict, NeighborCellLists, Position, Density,
                                       Pressure, Velocity, MotionLimiter, dρdtI,
-                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
+                                      Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
                                       min_dt_force = nothing) where {D,T,
                                                   S<:ShiftingMode,B<:MDBCMode,
@@ -1041,10 +1041,13 @@ using LinearAlgebra
                                                 SDD<:SPHDensityDiffusion,
                                                 SV<:SPHViscosity}
         @unpack Position, Density, Pressure, Velocity, Acceleration, MotionLimiter,
-                GroupMarker, Kernel, KernelGradient, GhostPoints,
-                GhostNormals = SimParticles
+                GroupMarker = SimParticles
         ParticleType   = SimParticles.Type
         ParticleMarker = GroupMarker
+        Kernel = hasproperty(SimParticles, :Kernel) ? SimParticles.Kernel : nothing
+        KernelGradient = hasproperty(SimParticles, :KernelGradient) ? SimParticles.KernelGradient : nothing
+        GhostPoints = hasproperty(SimParticles, :GhostPoints) ? SimParticles.GhostPoints : nothing
+        GhostNormals = hasproperty(SimParticles, :GhostNormals) ? SimParticles.GhostNormals : nothing
 
         ###
         UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
@@ -1082,15 +1085,28 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "02 Pressure"                              Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
-                @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType)
+                if SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, KMode, NoMDBC, LMode} where {SMode, KMode, LMode}
+                    @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData)
+                else
+                    @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType)
+                end
 
-                @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
-                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, CellDict,
-                    NeighborCellLists, Position, Density, Pressure, Velocity,
-                    MotionLimiter, dρdtI, Acceleration, Kernel,
-                    KernelGradient, ∇Cᵢ, ∇◌rᵢ,
-                )
+                if SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, NoKernelOutput, BMode, LMode} where {SMode, BMode, LMode}
+                    @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
+                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        NeighborCellLists, Position, Density, Pressure, Velocity,
+                        MotionLimiter, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
+                    )
+                else
+                    @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
+                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        NeighborCellLists, Position, Density, Pressure, Velocity,
+                        MotionLimiter, dρdtI, Acceleration, Kernel, KernelGradient,
+                        ∇Cᵢ, ∇◌rᵢ,
+                    )
+                end
 
 
                 @timeit SimMetaData.HourGlass "05 Update To Half TimeStep"               HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
@@ -1101,13 +1117,23 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "07 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
-                @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
-                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, CellDict,
-                    NeighborCellLists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
-                    MotionLimiter, dρdtI, Acceleration, Kernel,
-                    KernelGradient, ∇Cᵢ, ∇◌rᵢ, max_visc, min_dt_force,
-                )
+                if SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, NoKernelOutput, BMode, LMode} where {SMode, BMode, LMode}
+                    @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
+                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        NeighborCellLists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
+                        MotionLimiter, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
+                        max_visc, min_dt_force,
+                    )
+                else
+                    @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
+                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        NeighborCellLists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
+                        MotionLimiter, dρdtI, Acceleration, Kernel,
+                        KernelGradient, ∇Cᵢ, ∇◌rᵢ, max_visc, min_dt_force,
+                    )
+                end
 
                 @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
             

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -49,18 +49,12 @@ struct StoreLog <: LogMode end
     ExportGridCells::Bool                   = false
     ExportGridCellParticleCounts::Bool      = false
     OutputVariables::Vector{String}         = [
-        "Kernel",
-        "KernelGradient",
         "Density",
         "Pressure",
         "Velocity",
         "Acceleration",
-        "BoundaryBool",
-        "ID",
         "Type",
         "GroupMarker",
-        "GhostPoints",
-        "GhostNormals",
     ]
     OpenLogFile::Bool                       = true
     Δx::FloatType                           = zero(FloatType)


### PR DESCRIPTION
### Motivation
- Reduce memory use by allocating optional per-particle fields (kernel outputs and MDBC ghost arrays) only when required by simulation metadata or explicit `OutputVariables`.
- Prevent runtime errors when exporters request unavailable fields by validating `OutputVariables` against the actual `SimParticles` fields.
- Ensure MDBC-required ghost arrays are present when MDBC is enabled and produce stable particle ordering by sorting by `Idp` before allocation.

### Description
- Add optional gating to `AllocateDataStructures` via `RequireMDBC` and `RequireKernelOutput`, and add an overload `AllocateDataStructures(..., SimMetaData)` that derives those flags from metadata.
- Reorder input arrays with `sortperm(Idp)` and build `ParticleFields` as a named-tuple, conditionally `merge`ing `Kernel`, `KernelGradient`, `GhostPoints`, `GhostNormals`, `BoundaryBool`, and `ID` only when requested, then create `SimParticles = StructArray(ParticleFields)`.
- Guard runtime access to optional fields in the simulation by using `hasproperty(SimParticles, ...)` and `SimMetaData isa ...` checks, and only call `ApplyMDBCBeforeHalf!` or pass kernel arrays when enabled.
- Update `ProduceHDFVTK.jl` to map field names to symbols with `field_map`, validate that each `OutputVariables` entry exists on `SimParticles`, cast `Type` to `Int8` for output, and avoid accessing missing optional fields; also trim default `OutputVariables` and update example scripts to call `AllocateDataStructures(SimGeometry, SimMetaData)`.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69622cd9e8e48323a99c0b776109ada1)