### PR TITLE
Refactor NeighborLoopPerParticle! to use SimParticles fields

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -185,8 +185,7 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        Cells = SimParticles.Cells
-        MotionLimiter = SimParticles.MotionLimiter
+        @unpack Cells, MotionLimiter = SimParticles
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -245,10 +244,7 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        Cells = SimParticles.Cells
-        MotionLimiter = SimParticles.MotionLimiter
-        Kernel = SimParticles.Kernel
-        KernelGradient = SimParticles.KernelGradient
+        @unpack Cells, MotionLimiter, Kernel, KernelGradient = SimParticles
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -316,8 +312,7 @@ using LinearAlgebra
                                                   S<:ShiftingMode,B<:MDBCMode,
                                                   L<:LogMode,SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        Cells = SimParticles.Cells
-        MotionLimiter = SimParticles.MotionLimiter
+        @unpack Cells, MotionLimiter = SimParticles
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -387,10 +382,7 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        Cells = SimParticles.Cells
-        MotionLimiter = SimParticles.MotionLimiter
-        Kernel = SimParticles.Kernel
-        KernelGradient = SimParticles.KernelGradient
+        @unpack Cells, MotionLimiter, Kernel, KernelGradient = SimParticles
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -174,15 +174,19 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, Position, Density,
-                                      Pressure, Velocity, MotionLimiter, dρdtI,
+                                      CellDict, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
-                                      min_dt_force = nothing) where {D,T,
+                                      min_dt_force = nothing;
+                                      Position = SimParticles.Position,
+                                      Density = SimParticles.Density,
+                                      Pressure = SimParticles.Pressure,
+                                      Velocity = SimParticles.Velocity) where {D,T,
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
         Cells = SimParticles.Cells
+        MotionLimiter = SimParticles.MotionLimiter
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -229,16 +233,22 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, Position, Density,
-                                      Pressure, Velocity, MotionLimiter, dρdtI,
-                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
+                                      CellDict, NeighborCellLists, dρdtI,
+                                      Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
-                                      min_dt_force = nothing) where {D,T,
+                                      min_dt_force = nothing;
+                                      Position = SimParticles.Position,
+                                      Density = SimParticles.Density,
+                                      Pressure = SimParticles.Pressure,
+                                      Velocity = SimParticles.Velocity) where {D,T,
                                                   K<:KernelOutputMode,
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
         Cells = SimParticles.Cells
+        MotionLimiter = SimParticles.MotionLimiter
+        Kernel = SimParticles.Kernel
+        KernelGradient = SimParticles.KernelGradient
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -295,15 +305,19 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, Position, Density,
-                                      Pressure, Velocity, MotionLimiter, dρdtI,
+                                      CellDict, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
-                                      min_dt_force = nothing) where {D,T,
+                                      min_dt_force = nothing;
+                                      Position = SimParticles.Position,
+                                      Density = SimParticles.Density,
+                                      Pressure = SimParticles.Pressure,
+                                      Velocity = SimParticles.Velocity) where {D,T,
                                                   S<:ShiftingMode,B<:MDBCMode,
                                                   L<:LogMode,SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
         Cells = SimParticles.Cells
+        MotionLimiter = SimParticles.MotionLimiter
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -360,17 +374,23 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, Position, Density,
-                                      Pressure, Velocity, MotionLimiter, dρdtI,
-                                      Acceleration, Kernel, KernelGradient, ∇Cᵢ,
+                                      CellDict, NeighborCellLists, dρdtI,
+                                      Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
-                                      min_dt_force = nothing) where {D,T,
+                                      min_dt_force = nothing;
+                                      Position = SimParticles.Position,
+                                      Density = SimParticles.Density,
+                                      Pressure = SimParticles.Pressure,
+                                      Velocity = SimParticles.Velocity) where {D,T,
                                                   S<:ShiftingMode,
                                                   K<:KernelOutputMode,
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
         Cells = SimParticles.Cells
+        MotionLimiter = SimParticles.MotionLimiter
+        Kernel = SimParticles.Kernel
+        KernelGradient = SimParticles.KernelGradient
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -1044,8 +1064,6 @@ using LinearAlgebra
                 GroupMarker = SimParticles
         ParticleType   = SimParticles.Type
         ParticleMarker = GroupMarker
-        Kernel = hasproperty(SimParticles, :Kernel) ? SimParticles.Kernel : nothing
-        KernelGradient = hasproperty(SimParticles, :KernelGradient) ? SimParticles.KernelGradient : nothing
         GhostPoints = hasproperty(SimParticles, :GhostPoints) ? SimParticles.GhostPoints : nothing
         GhostNormals = hasproperty(SimParticles, :GhostNormals) ? SimParticles.GhostNormals : nothing
 
@@ -1095,16 +1113,13 @@ using LinearAlgebra
                     @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, ParticleRanges, CellDict,
-                        NeighborCellLists, Position, Density, Pressure, Velocity,
-                        MotionLimiter, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
+                        NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
                     )
                 else
                     @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, ParticleRanges, CellDict,
-                        NeighborCellLists, Position, Density, Pressure, Velocity,
-                        MotionLimiter, dρdtI, Acceleration, Kernel, KernelGradient,
-                        ∇Cᵢ, ∇◌rᵢ,
+                        NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
                     )
                 end
 
@@ -1121,17 +1136,21 @@ using LinearAlgebra
                     @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, ParticleRanges, CellDict,
-                        NeighborCellLists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
-                        MotionLimiter, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
+                        NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
                         max_visc, min_dt_force,
+                        Position = Positionₙ⁺,
+                        Density = ρₙ⁺,
+                        Velocity = Velocityₙ⁺,
                     )
                 else
                     @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, ParticleRanges, CellDict,
-                        NeighborCellLists, Positionₙ⁺, ρₙ⁺, Pressure, Velocityₙ⁺,
-                        MotionLimiter, dρdtI, Acceleration, Kernel,
-                        KernelGradient, ∇Cᵢ, ∇◌rᵢ, max_visc, min_dt_force,
+                        NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
+                        max_visc, min_dt_force,
+                        Position = Positionₙ⁺,
+                        Density = ρₙ⁺,
+                        Velocity = Velocityₙ⁺,
                     )
                 end
 


### PR DESCRIPTION
### Motivation
- Reduce the number of positional arguments passed into `NeighborLoopPerParticle!` by using `SimParticles` fields where possible.
- Centralise particle data access to make the neighbor loop calls simpler and less error-prone.
- Allow explicit overrides for half-step arrays so the same neighbor loop implementation can operate on temporary state.
- Keep behaviour identical while simplifying call sites inside the main `SimulationLoop`.

### Description
- Updated all variants of `NeighborLoopPerParticle!` in `src/SPHCellList.jl` to remove `Position`, `Density`, `Pressure`, and `Velocity` from the positional argument list and accept them as keyword overrides (defaults are `SimParticles.Position`, `SimParticles.Density`, `SimParticles.Pressure`, `SimParticles.Velocity`).
- Internal per-loop locals such as `MotionLimiter`, and when present `Kernel`/`KernelGradient`, are now loaded from `SimParticles` inside the functions instead of being passed in.
- Simplified the `SimulationLoop` call sites to invoke `NeighborLoopPerParticle!` with the reduced argument list and pass half-step arrays via the new keyword overrides (e.g. `Position = Positionₙ⁺`, `Density = ρₙ⁺`, `Velocity = Velocityₙ⁺`).
- Code edits confined to `src/SPHCellList.jl`; no changes to other modules.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69637913fb848323b8b0af77750c8a78)