### PR TITLE
Move logging helpers into SimulationLoggerConfiguration

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -26,10 +26,8 @@ using Parameters: @unpack
 using FastPow: @fastpow
 using Format
 using TimerOutputs
-using Logging, LoggingExtras
 using HDF5
 using Base.Threads
-using UnicodePlots
 using LinearAlgebra
     using Bumper
 
@@ -795,63 +793,6 @@ using LinearAlgebra
         return nothing
     end
 
-    function InitializeLog!(::SimulationMetaData{D,T,S,K,B,NoLog}, _args...) where {D,T,S<:ShiftingMode,
-                                                                                      K<:KernelOutputMode,
-                                                                                      B<:MDBCMode}
-        return nothing
-    end
-    function InitializeLog!(SimMetaData::SimulationMetaData{D,T,S,K,B,StoreLog}, SimLogger,
-                             SimConstants, SimKernel, SimViscosity, SimDensityDiffusion,
-                             SimGeometry, SimParticles) where {D,T,S<:ShiftingMode,
-                                                              K<:KernelOutputMode,
-                                                              B<:MDBCMode}
-        InitializeLogger(SimLogger, SimConstants, SimMetaData, SimKernel,
-                         SimViscosity, SimDensityDiffusion, SimGeometry, SimParticles)
-        LogStep(SimLogger, SimMetaData, SimMetaData.HourGlass)
-        SimMetaData.StepsTakenForLastOutput = SimMetaData.Iteration
-        return nothing
-    end
-
-    function LogStep!(::SimulationMetaData{D,T,S,K,B,NoLog}, _...) where {D,T,S<:ShiftingMode,
-                                                                           K<:KernelOutputMode,
-                                                                           B<:MDBCMode}
-        return nothing
-    end
-
-    function LogStep!(SimMetaData::SimulationMetaData{D,T,S,K,B,StoreLog}, SimLogger) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, B<:MDBCMode}
-        LogStep(SimLogger, SimMetaData, SimMetaData.HourGlass)
-        SimMetaData.StepsTakenForLastOutput = SimMetaData.Iteration
-        return nothing
-    end
-
-    function FinalizeLog!(::SimulationMetaData{D,T,S,K,B,NoLog}, _...) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, B<:MDBCMode}
-        return nothing
-    end
-    
-    function FinalizeLog!(SimMetaData::SimulationMetaData{D,T,S,K,B,StoreLog}, SimLogger) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, B<:MDBCMode}
-        LogFinal(SimLogger, SimMetaData.HourGlass)
-        
-        # Time steps line plot
-        UnicodeTimeStepsGraph = lineplot(
-            1:length(SimMetaData.TimeSteps),
-            SimMetaData.TimeSteps,
-            title="Time Steps [s] as a function of iteration",
-            name="Time Steps",
-            xlabel="Iterations [-]",
-            ylabel="Time Step Size [s]",
-        )
-
-        with_logger(SimLogger.Logger) do
-            @info ""
-            show(SimLogger.LoggerIo, UnicodeTimeStepsGraph)
-        end
-        
-        close(SimLogger.LoggerIo)
-        
-        AutoOpenLogFile(SimLogger, SimMetaData)
-        return nothing
-    end
-
     function ProgressMotion(_SimParticles, _dt₂, ::Nothing, _SimMetaData)
         return nothing
     end
@@ -1267,6 +1208,7 @@ using LinearAlgebra
                 AutoOpenParaview(SimMetaData, output.variable_names)
 
                 FinalizeLog!(SimMetaData, SimLogger)
+                AutoOpenLogFile(SimLogger, SimMetaData)
 
                 break
             end

--- a/src/SimulationLoggerConfiguration.jl
+++ b/src/SimulationLoggerConfiguration.jl
@@ -10,9 +10,12 @@ module SimulationLoggerConfiguration
     using Base.Threads
     using InteractiveUtils
     using LibGit2
+    using UnicodePlots
     using ..SimulationGeometry
+    using ..SimulationMetaDataConfiguration
 
     export SimulationLogger, generate_format_string, InitializeLogger, LogSimulationDetails, LogStep, LogFinal
+    export InitializeLog!, LogStep!, FinalizeLog!
 
     """
         generate_format_string(values; padding=10)
@@ -220,6 +223,62 @@ module SimulationLoggerConfiguration
             @info "\n Sorted by time \n"
             show(SimLogger.LoggerIo, HourGlass)
         end
+    end
+
+    function InitializeLog!(::SimulationMetaData{D,T,S,K,B,NoLog}, _args...) where {D,T,S<:ShiftingMode,
+                                                                                      K<:KernelOutputMode,
+                                                                                      B<:MDBCMode}
+        return nothing
+    end
+    function InitializeLog!(SimMetaData::SimulationMetaData{D,T,S,K,B,StoreLog}, SimLogger,
+                             SimConstants, SimKernel, SimViscosity, SimDensityDiffusion,
+                             SimGeometry, SimParticles) where {D,T,S<:ShiftingMode,
+                                                              K<:KernelOutputMode,
+                                                              B<:MDBCMode}
+        InitializeLogger(SimLogger, SimConstants, SimMetaData, SimKernel,
+                         SimViscosity, SimDensityDiffusion, SimGeometry, SimParticles)
+        LogStep(SimLogger, SimMetaData, SimMetaData.HourGlass)
+        SimMetaData.StepsTakenForLastOutput = SimMetaData.Iteration
+        return nothing
+    end
+
+    function LogStep!(::SimulationMetaData{D,T,S,K,B,NoLog}, _...) where {D,T,S<:ShiftingMode,
+                                                                           K<:KernelOutputMode,
+                                                                           B<:MDBCMode}
+        return nothing
+    end
+
+    function LogStep!(SimMetaData::SimulationMetaData{D,T,S,K,B,StoreLog}, SimLogger) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, B<:MDBCMode}
+        LogStep(SimLogger, SimMetaData, SimMetaData.HourGlass)
+        SimMetaData.StepsTakenForLastOutput = SimMetaData.Iteration
+        return nothing
+    end
+
+    function FinalizeLog!(::SimulationMetaData{D,T,S,K,B,NoLog}, _...) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, B<:MDBCMode}
+        return nothing
+    end
+    
+    function FinalizeLog!(SimMetaData::SimulationMetaData{D,T,S,K,B,StoreLog}, SimLogger) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, B<:MDBCMode}
+        LogFinal(SimLogger, SimMetaData.HourGlass)
+        
+        # Time steps line plot
+        UnicodeTimeStepsGraph = lineplot(
+            1:length(SimMetaData.TimeSteps),
+            SimMetaData.TimeSteps,
+            title="Time Steps [s] as a function of iteration",
+            name="Time Steps",
+            xlabel="Iterations [-]",
+            ylabel="Time Step Size [s]",
+        )
+
+        with_logger(SimLogger.Logger) do
+            @info ""
+            show(SimLogger.LoggerIo, UnicodeTimeStepsGraph)
+        end
+        
+        close(SimLogger.LoggerIo)
+
+        return nothing
     end
 
 end


### PR DESCRIPTION
### Motivation
- Centralize logging behavior by relocating the log lifecycle helpers to the logger module so logging concerns are kept together.
- Remove duplicated imports and plotting responsibilities from the simulation loop module to keep `SPHCellList.jl` focused on simulation logic.
- Preserve the automatic opening of the log file at simulation end while avoiding tighter module coupling.

### Description
- Added `InitializeLog!`, `LogStep!`, and `FinalizeLog!` (and exported them) in `SimulationLoggerConfiguration.jl` and moved `UnicodePlots` import there to keep plotting/logging helpers colocated.
- Removed the corresponding helper implementations and `UnicodePlots` import from `SPHCellList.jl` and updated the simulation loop to call `FinalizeLog!` then `AutoOpenLogFile` to preserve behavior.
- Adjusted module imports/exports so `SimulationLoggerConfiguration` depends on `SimulationMetaDataConfiguration` and provides the new API to be used by the simulation loop.

### Testing
- No automated tests were run on this change.
- Changes compiled locally via normal edit/commit workflow (no test-suite executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a04a4bd08323b5996ac40f363720)