### PR TITLE
Fix map_floor comment spelling

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -77,7 +77,7 @@ using LinearAlgebra
     # Replace unsafe_trunc with trunc if this ever errors
     @inline function map_floor(x, InverseCutOff)
         # This is different than just doing muladd(x,InverseCutOff,0.5) because it rounds towards zero.
-        # Consider -1.7 + 0.5, this would give -1.2 and then trunced 1, but we want -2, therefore absolute addition before hand
+        # Consider -1.7 + 0.5, this would give -1.2 and then truncated 1, but we want -2, therefore absolute addition beforehand
         # We add 0.5 instead of 1, to ensure proper rounding behavior when restoring the sign for negative numbers.
         Int(sign(x)) * unsafe_trunc(Int, muladd(abs(x),InverseCutOff,0.5))
     end


### PR DESCRIPTION
### Motivation
- Fix a typo in the inline comment for the `map_floor` helper to improve code clarity and documentation.
- This is a non-functional documentation change that does not alter runtime behavior or APIs.

### Description
- Corrected wording in the inline comment of the `map_floor` function in `src/SPHCellList.jl`, changing "trunced" to "truncated" and "before hand" to "beforehand".
- No changes were made to executable code paths or public interfaces.

### Testing
- No automated tests were run for this change.
- Commands executed during the edit and verification include `ls`, `cat AGENTS.md`, `rg -n "map_floor" -n src/SPHCellList.jl`, `sed -n '60,120p' src/SPHCellList.jl`, `git status -sb`, `git add src/SPHCellList.jl`, `git commit -m "Fix map_floor comment spelling"`, and `nl -ba src/SPHCellList.jl | sed -n '72,90p'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963e973a49c832380eab54f66b38da7)