### PR TITLE
Use Base UV errno codes for ParaView state-file warning

### DIFF
--- a/src/OpenExternalPrograms.jl
+++ b/src/OpenExternalPrograms.jl
@@ -79,8 +79,6 @@ function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames;
     ExtractDimensionalityMetaData(::SimulationMetaData{N, FloatType, SMode, KMode, BMode, LMode}) where {N, FloatType, SMode, KMode, BMode, LMode} = N
     ViewDimension = ExtractDimensionalityMetaData(SimMetaData) == 2 ? "2D" : "3D"
 
-    ParaViewStateFile     = open(ParaViewStateFileName, "w")
-
     ParaViewConfig    = 
                             """
                             # import regex library
@@ -169,9 +167,19 @@ function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames;
                             Render()
                             """
 
-    write(ParaViewStateFile, ParaViewConfig) 
-
-    close(ParaViewStateFile)
+    try
+        open(ParaViewStateFileName, "w") do ParaViewStateFile
+            write(ParaViewStateFile, ParaViewConfig)
+        end
+    catch e
+        if e isa SystemError && (e.errno == Base.UV_EACCES || e.errno == Base.UV_EBUSY)
+            @warn("ParaView state file is already open; close it to regenerate.",
+                  file=ParaViewStateFileName)
+        else
+            rethrow()
+        end
+        return nothing
+    end
 
     if SimMetaData.VisualizeInParaview && paraview_cmd !== nothing
         try


### PR DESCRIPTION
### Motivation
- Avoid adding a `Libc` dependency just to detect file-in-use errors when writing the ParaView state file. 
- Emit a clear, actionable warning instead of crashing when the state file cannot be written due to OS-level file access errors. 
- Address the inline suggestion to use a smarter approach than importing `Libc`.

### Description
- Remove the `Libc` dependency and switch errno checks to `Base.UV_EACCES` and `Base.UV_EBUSY` when handling `SystemError` during state-file writes. 
- Write the state file using `open(... do)` and catch `SystemError` to `@warn("ParaView state file is already open; close it to regenerate.", file=ParaViewStateFileName)` for the relevant errno cases while rethrowing other errors. 
- Changes were applied to `src/OpenExternalPrograms.jl` and committed with the message `Use Base errno codes for ParaView warning`.

### Testing
- No automated tests were run for this change.
- Local inspection of `src/OpenExternalPrograms.jl` and standard VCS operations (`git add`/`git commit`) were performed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696424c61a6c8323ba4a5c0801678f83)