### PR TITLE
Move metadata timing helpers

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -904,27 +904,6 @@ using LinearAlgebra
         return nothing
     end
 
-    function UpdateMetaData!(SimMetaData, dt)
-        SimMetaData.Iteration      += 1
-        SimMetaData.CurrentTimeStep = dt
-        SimMetaData.TotalTime      += dt
-
-        return nothing
-    end
-
-    @inline next_output_time(SimMetaData) = next_output_time(SimMetaData.OutputTimes, SimMetaData)
-
-    @inline next_output_time(interval::Real, SimMetaData) = interval * SimMetaData.OutputIterationCounter
-
-    @inline function next_output_time(times::AbstractVector, SimMetaData)
-        idx = SimMetaData.OutputIterationCounter
-        if idx < length(times)
-            return times[idx]
-        else
-            return SimMetaData.SimulationTime
-        end
-    end
-
     function GenerateMotionDetails(SimParticles, SimGeometry, Dimensions, FloatType)
         # Assuming group markers are sequential
         MotionDefinition = Vector{Union{Nothing, MotionDetails{Dimensions, FloatType}}}(undef, maximum(SimParticles.GroupMarker))

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -4,7 +4,7 @@ using Parameters
 using TimerOutputs
 
 
-export SimulationMetaData, ShiftingMode, NoShifting, PlanarShifting,
+export SimulationMetaData, UpdateMetaData!, ShiftingMode, NoShifting, PlanarShifting,
        KernelOutputMode, NoKernelOutput, StoreKernelOutput,
        MDBCMode, NoMDBC, SimpleMDBC,
        LogMode, NoLog, StoreLog
@@ -67,5 +67,13 @@ SimulationMetaData{D,T,S}(; kwargs...) where {D,T,S<:ShiftingMode} =
     SimulationMetaData{D,T,S,NoKernelOutput,NoMDBC,NoLog}(; kwargs...)
 SimulationMetaData{D,T}(; kwargs...) where {D,T} =
     SimulationMetaData{D,T,NoShifting,NoKernelOutput,NoMDBC,NoLog}(; kwargs...)
+
+function UpdateMetaData!(SimMetaData, dt)
+    SimMetaData.Iteration      += 1
+    SimMetaData.CurrentTimeStep = dt
+    SimMetaData.TotalTime      += dt
+
+    return nothing
+end
 
 end

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -1,6 +1,6 @@
 module TimeStepping
 
-export Δt, FinalizeTimeStep, UpdateTimeStepBuffers!
+export Δt, FinalizeTimeStep, UpdateTimeStepBuffers!, next_output_time
 
 using LinearAlgebra
 using Parameters
@@ -102,6 +102,19 @@ function Δt(Position, Velocity, Acceleration, SimulationConstants, SPHKernel)
         end
 
         CFL * min(minimum(d_buffer), h / (c₀ + maximum(v_buffer)))
+    end
+end
+
+@inline next_output_time(SimMetaData) = next_output_time(SimMetaData.OutputTimes, SimMetaData)
+
+@inline next_output_time(interval::Real, SimMetaData) = interval * SimMetaData.OutputIterationCounter
+
+@inline function next_output_time(times::AbstractVector, SimMetaData)
+    idx = SimMetaData.OutputIterationCounter
+    if idx < length(times)
+        return times[idx]
+    else
+        return SimMetaData.SimulationTime
     end
 end
 


### PR DESCRIPTION
### Motivation
- Centralize small helper functions related to simulation timing and metadata to improve code organization and reduce duplication.
- Keep metadata mutation logic inside the metadata configuration module for clearer ownership.
- Move output scheduling helpers into the time-stepping module where time logic lives.

### Description
- Move `UpdateMetaData!` from `src/SPHCellList.jl` into `src/SimulationMetaDataConfiguration.jl` and add it to the module export list.
- Move `next_output_time` helper overloads from `src/SPHCellList.jl` into `src/TimeStepping.jl` and export `next_output_time` from that module.
- Remove duplicate definitions from `src/SPHCellList.jl` so the helpers are defined only in their new modules.
- Commands executed during the change include `rg -n "UpdateMetaData!|next_output_time" -S src`, `nl -ba src/TimeStepping.jl`, `nl -ba src/SimulationMetaDataConfiguration.jl`, `git status -sb`, and `git commit -m "Move metadata timing helpers"`.

### Testing
- No automated tests were executed for this PR (no test commands were run).
- A local commit was created successfully and the modified files staged and committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655719eb3883238bba381c7f41eafa)