### PR TITLE
Move MDBC normals loader and motion helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ It may evolve over time, in shaa Allah.
 - `Project.toml`/`Manifest.toml`: dependency declarations
   (do not modify without instruction)
 - `README.md`: high level project overview and instructions
+- A future `Motions`-related file is planned for upcoming motion utilities, in shaa Allah.
 
 ## Common Code Patterns in This Repository
 - Each file in `/src` typically defines a `module` with the same name as the file

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -1,6 +1,6 @@
 module PreProcess
 
-export LoadBoundaryNormals, AllocateDataStructures, AllocateSupportDataStructures, AllocateThreadedArrays
+export LoadBoundaryNormals, LoadMDBCNormals!, AllocateDataStructures, AllocateSupportDataStructures, AllocateThreadedArrays
 
 using CSV
 using StaticArrays
@@ -223,6 +223,22 @@ function LoadBoundaryNormals(::Val{D}, ::Type{T}, path_mdbc) where {D, T}
     end
 
     return points, ghost_points, normals
+end
+
+function LoadMDBCNormals!(::SimulationMetaData{D,T,S,K,NoMDBC,L}, SimParticles, path) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, L<:LogMode}
+    return nothing
+end
+
+function LoadMDBCNormals!(::SimulationMetaData{D,T,S,K,SimpleMDBC,L}, SimParticles, path) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, L<:LogMode}
+    if isnothing(path)
+        return nothing
+    end
+    _, GhostPoints, GhostNormals = LoadBoundaryNormals(Val(D), T, path)
+    for gi ∈ eachindex(GhostPoints)
+        SimParticles.GhostPoints[gi]  = GhostPoints[gi]
+        SimParticles.GhostNormals[gi] = GhostNormals[gi]
+    end
+    return nothing
 end
 
 end

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -778,51 +778,6 @@ using LinearAlgebra
         return nothing
     end
 
-    function LoadMDBCNormals!(::SimulationMetaData{D,T,S,K,NoMDBC,L}, SimParticles, path) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, L<:LogMode}
-        return nothing
-    end
-    function LoadMDBCNormals!(::SimulationMetaData{D,T,S,K,SimpleMDBC,L}, SimParticles, path) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, L<:LogMode}
-        if isnothing(path)
-            return nothing
-        end
-        _, GhostPoints, GhostNormals = LoadBoundaryNormals(Val(D), T, path)
-        for gi ∈ eachindex(GhostPoints)
-            SimParticles.GhostPoints[gi]  = GhostPoints[gi]
-            SimParticles.GhostNormals[gi] = GhostNormals[gi]
-        end
-        return nothing
-    end
-
-    function ProgressMotion(_SimParticles, _dt₂, ::Nothing, _SimMetaData)
-        return nothing
-    end
-
-    function ProgressMotion(SimParticles, dt₂, MotionsDefinition, SimMetaData)
-        @unpack Position, Velocity = SimParticles
-        ParticleMarker  = SimParticles.GroupMarker
-        ParticleType    = SimParticles.Type
-        @inbounds @simd ivdep for i in eachindex(Position)
-            if ParticleType[i] == Moving
-                motion = MotionsDefinition[ParticleMarker[i]]
-    
-                if motion !== nothing
-                    ShouldMove = (motion.StartTime <= SimMetaData.TotalTime) &&
-                                 (SimMetaData.TotalTime <= (motion.StartTime + motion.Duration))
-    
-                    # Retrieve motion parameters
-                    MotionVel = motion.Velocity
-                    MotionDir = motion.Direction
-    
-                    # Update Velocity and Position
-                    Velocity[i] = MotionVel * MotionDir * ShouldMove
-                    Position[i] += Velocity[i] * dt₂
-                end
-            end
-        end
-
-        return nothing
-    end
-
     function ApplyMDBCCorrection(SimConstants, SimParticles, bᵧ, Aᵧ)
 
         Position    = SimParticles.Position

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -1,6 +1,6 @@
 module TimeStepping
 
-export Δt, FinalizeTimeStep, UpdateTimeStepBuffers!, next_output_time
+export Δt, FinalizeTimeStep, UpdateTimeStepBuffers!, next_output_time, ProgressMotion
 
 using LinearAlgebra
 using Parameters
@@ -116,6 +116,36 @@ end
     else
         return SimMetaData.SimulationTime
     end
+end
+
+function ProgressMotion(_SimParticles, _dt₂, ::Nothing, _SimMetaData)
+    return nothing
+end
+
+function ProgressMotion(SimParticles, dt₂, MotionsDefinition, SimMetaData)
+    @unpack Position, Velocity = SimParticles
+    ParticleMarker  = SimParticles.GroupMarker
+    ParticleType    = SimParticles.Type
+    @inbounds @simd ivdep for i in eachindex(Position)
+        if ParticleType[i] == Moving
+            motion = MotionsDefinition[ParticleMarker[i]]
+
+            if motion !== nothing
+                ShouldMove = (motion.StartTime <= SimMetaData.TotalTime) &&
+                             (SimMetaData.TotalTime <= (motion.StartTime + motion.Duration))
+
+                # Retrieve motion parameters
+                MotionVel = motion.Velocity
+                MotionDir = motion.Direction
+
+                # Update Velocity and Position
+                Velocity[i] = MotionVel * MotionDir * ShouldMove
+                Position[i] += Velocity[i] * dt₂
+            end
+        end
+    end
+
+    return nothing
 end
 
 end


### PR DESCRIPTION
### Motivation
- Consolidate boundary-normal loading into the preprocessing step so MDBC ghost data is provided by the PreProcess module.
- Centralize motion progression logic with other timestep utilities by moving it into the TimeStepping module.
- Avoid duplication of helper implementations across modules and make the relevant helpers exportable for reuse.
- Document planned future `Motions` utilities in the project guidance for clarity.

### Description
- Exported and implemented `LoadMDBCNormals!` in `src/PreProcess.jl` with two dispatches: a no-op for `NoMDBC` and a loader for `SimpleMDBC` that calls `LoadBoundaryNormals` and populates `SimParticles` ghost fields.
- Removed the `LoadMDBCNormals!` implementations and the `ProgressMotion` helpers from `src/SPHCellList.jl` to eliminate duplication.
- Added and exported `ProgressMotion` (no-op and active-motion variants) to `src/TimeStepping.jl` to handle particle motion updates during time stepping.
- Updated `AGENTS.md` to note a planned future `Motions`-related file for motion utilities.

### Testing
- No automated tests were run for this change.
- Commands executed during the change include: `ls`, `cat AGENTS.md`, `rg -n "LoadMDBCNormals|ProgressMotion" src`, `sed -n '740,860p' src/SPHCellList.jl`, `sed -n '1,200p' src/TimeStepping.jl`, `nl -ba src/PreProcess.jl | sed -n '200,320p'`, `nl -ba src/TimeStepping.jl | sed -n '1,220p'`, `nl -ba AGENTS.md | sed -n '1,60p'`, `git status -sb`, `git add AGENTS.md src/PreProcess.jl src/TimeStepping.jl src/SPHCellList.jl`, and `git commit -m "Move MDBC and motion helpers"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656b3f9e388323b7b06188310ff6a6)