### PR TITLE
Move time step helpers into TimeStepping

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -804,61 +804,6 @@ using LinearAlgebra
         end
     end
     
-    function HalfTimeStep(::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
-                          SimConstants, SimParticles, Positionₙ⁺,
-                          Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}
-        @unpack Position, Density, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
-
-        @inbounds @simd ivdep for i in eachindex(Position)
-            Acceleration[i]  +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
-            Positionₙ⁺[i]     =  Position[i]   + Velocity[i]   * dt₂  * MotionLimiter[i]
-            Velocityₙ⁺[i]     =  Velocity[i]   + Acceleration[i]  *  dt₂ * MotionLimiter[i]
-            ρₙ⁺[i]            =  Density[i]    + dρdtI[i]       *  dt₂
-        end
-
-
-        return nothing
-    end
-
-    function FullTimeStep(::SimulationMetaData{D,T,NoShifting,K,B,L}, SimKernel,
-                          SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt) where {D,T,
-                                                                             K<:KernelOutputMode,
-                                                                             B<:MDBCMode,
-                                                                             L<:LogMode}
-        @unpack Position, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
-        @inbounds @simd ivdep for i in eachindex(Position)
-            Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
-            Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
-            Position[i]       +=  (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt) * MotionLimiter[i]
-        end
-        return nothing
-    end
-
-    function FullTimeStep(::SimulationMetaData{D,T,S,K,B,L}, SimKernel, SimConstants,
-                          SimParticles, ∇Cᵢ, ∇◌rᵢ, dt) where {D,T,S<:ShiftingMode,
-                                                             K<:KernelOutputMode,
-                                                             B<:MDBCMode,
-                                                             L<:LogMode}
-        @unpack Position, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
-        A     = 2# Value between 1 to 6 advised
-        A_FST = 0; # zero for internal flows
-        A_FSM = length(first(Position)); #2d, 3d val different
-        @inbounds @simd ivdep for i in eachindex(Position)
-            Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
-            Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
-
-            A_FSC                  = (∇◌rᵢ[i] - A_FST)/(A_FSM - A_FST)
-            if A_FSC < 0
-                δxᵢ = zero(eltype(Position))
-            else
-                δxᵢ = -A_FSC * A * SimKernel.h * norm(Velocity[i]) * dt * ∇Cᵢ[i]
-            end
-
-            Position[i]           += (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt + δxᵢ) * MotionLimiter[i]
-        end
-        return nothing
-    end
-
     function GenerateMotionDetails(SimParticles, SimGeometry, Dimensions, FloatType)
         # Assuming group markers are sequential
         MotionDefinition = Vector{Union{Nothing, MotionDetails{Dimensions, FloatType}}}(undef, maximum(SimParticles.GroupMarker))

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -1,11 +1,13 @@
 module TimeStepping
 
-export Δt, FinalizeTimeStep, UpdateTimeStepBuffers!, next_output_time, ProgressMotion
+export Δt, FinalizeTimeStep, UpdateTimeStepBuffers!, next_output_time, ProgressMotion, HalfTimeStep, FullTimeStep
 
 using LinearAlgebra
 using Parameters
 using Base.Threads
 using Bumper
+using ..SimulationEquations
+using ..SimulationMetaDataConfiguration
 
 @inline function UpdateTimeStepBuffers!(::Nothing, ::Nothing, index, position,
                                            velocity, acceleration, sim_kernel)
@@ -145,6 +147,60 @@ function ProgressMotion(SimParticles, dt₂, MotionsDefinition, SimMetaData)
         end
     end
 
+    return nothing
+end
+
+function HalfTimeStep(::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
+                          SimConstants, SimParticles, Positionₙ⁺,
+                          Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}
+    @unpack Position, Density, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
+
+    @inbounds @simd ivdep for i in eachindex(Position)
+        Acceleration[i]  +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
+        Positionₙ⁺[i]     =  Position[i]   + Velocity[i]   * dt₂  * MotionLimiter[i]
+        Velocityₙ⁺[i]     =  Velocity[i]   + Acceleration[i]  *  dt₂ * MotionLimiter[i]
+        ρₙ⁺[i]            =  Density[i]    + dρdtI[i]       *  dt₂
+    end
+
+    return nothing
+end
+
+function FullTimeStep(::SimulationMetaData{D,T,NoShifting,K,B,L}, SimKernel,
+                          SimConstants, SimParticles, ∇Cᵢ, ∇◌rᵢ, dt) where {D,T,
+                                                                             K<:KernelOutputMode,
+                                                                             B<:MDBCMode,
+                                                                             L<:LogMode}
+    @unpack Position, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
+    @inbounds @simd ivdep for i in eachindex(Position)
+        Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
+        Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
+        Position[i]       +=  (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt) * MotionLimiter[i]
+    end
+    return nothing
+end
+
+function FullTimeStep(::SimulationMetaData{D,T,S,K,B,L}, SimKernel, SimConstants,
+                          SimParticles, ∇Cᵢ, ∇◌rᵢ, dt) where {D,T,S<:ShiftingMode,
+                                                             K<:KernelOutputMode,
+                                                             B<:MDBCMode,
+                                                             L<:LogMode}
+    @unpack Position, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
+    A     = 2# Value between 1 to 6 advised
+    A_FST = 0; # zero for internal flows
+    A_FSM = length(first(Position)); #2d, 3d val different
+    @inbounds @simd ivdep for i in eachindex(Position)
+        Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
+        Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
+
+        A_FSC                  = (∇◌rᵢ[i] - A_FST)/(A_FSM - A_FST)
+        if A_FSC < 0
+            δxᵢ = zero(eltype(Position))
+        else
+            δxᵢ = -A_FSC * A * SimKernel.h * norm(Velocity[i]) * dt * ∇Cᵢ[i]
+        end
+
+        Position[i]           += (((Velocity[i] + (Velocity[i] - Acceleration[i] * dt * MotionLimiter[i])) / 2) * dt + δxᵢ) * MotionLimiter[i]
+    end
     return nothing
 end
 


### PR DESCRIPTION
### Motivation
- Centralize time-stepping logic by moving `HalfTimeStep` and `FullTimeStep` out of `SPHCellList` into the `TimeStepping` module to improve organization and reusability.
- Make the time-stepping helpers part of the public time-stepping API by exporting them from `TimeStepping`.
- Reduce duplication and keep particle update logic colocated with other adaptive time-step utilities.

### Description
- Moved `HalfTimeStep` and two overloads of `FullTimeStep` from `src/SPHCellList.jl` into `src/TimeStepping.jl` and exported them from the `TimeStepping` module.
- Added `using ..SimulationEquations` and `using ..SimulationMetaDataConfiguration` to `TimeStepping` so the helpers can call `ConstructGravitySVector` and use `SimulationMetaData` types.
- Removed the original implementations from `src/SPHCellList.jl` so there is a single canonical implementation in `TimeStepping`.
- Commands executed during the change included `ls`, `cat AGENTS.md`, repository searches with `rg`, file inspections with `sed`, patch application via the scripted `apply_patch`, and staging/commit operations (`git add`, `git commit`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656bf321588323add38af6e6c7f973)