### PR TITLE
Fix module include order for TimeStepping

### DIFF
--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -4,8 +4,8 @@ module SPHExample
     include("SPHKernels.jl")
     include("SPHViscosityModels.jl")      
     include("ProduceHDFVTK.jl")    
-    include("TimeStepping.jl");       
     include("SimulationEquations.jl");
+    include("TimeStepping.jl");       
     include("SimulationGeometry.jl")
     include("SimulationMetaDataConfiguration.jl");
     include("SimulationConstantsConfiguration.jl");
@@ -62,4 +62,3 @@ module SPHExample
     export AutoOpenLogFile, AutoOpenParaview
 
 end
-


### PR DESCRIPTION
### Motivation
- Package precompilation failed with `UndefVarError: SimulationEquations not defined` raised from `src/TimeStepping.jl`, so the symbols expected by the time-stepping module were not available at load time.
- The intent is to make the package compile again by ensuring required modules are included before modules that reference them.
- The change is minimal and focused on include ordering to avoid touching APIs or exports.

### Description
- Reordered includes in `src/SPHExample.jl` so `include("SimulationEquations.jl")` appears before `include("TimeStepping.jl")` to ensure dependencies are defined when `TimeStepping.jl` is parsed.
- This makes names exported from `SimulationEquations` (e.g. `ConstructGravitySVector`) available to `TimeStepping` during precompilation.
- The change was committed with message `Fix module include order`.
- Commands executed during investigation and fix: `ls`, `cat AGENTS.md`, `sed -n '1,200p' src/SPHExample.jl`, `sed -n '1,200p' src/TimeStepping.jl`, applied patch, `git status -sb`, `git add src/SPHExample.jl`, and `git commit -m "Fix module include order"`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656d7aeca48323aa1ae38500288a97)