### PR TITLE
Fix TimeStepping include dependencies

### DIFF
--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -4,10 +4,10 @@ module SPHExample
     include("SPHKernels.jl")
     include("SPHViscosityModels.jl")      
     include("ProduceHDFVTK.jl")    
-    include("TimeStepping.jl");       
-    include("SimulationEquations.jl");
     include("SimulationGeometry.jl")
     include("SimulationMetaDataConfiguration.jl");
+    include("SimulationEquations.jl");
+    include("TimeStepping.jl");       
     include("SimulationConstantsConfiguration.jl");
     include("SimulationLoggerConfiguration.jl");
     include("PreProcess.jl");
@@ -62,4 +62,3 @@ module SPHExample
     export AutoOpenLogFile, AutoOpenParaview
 
 end
-


### PR DESCRIPTION
### Motivation
- Precompilation failed with `UndefVarError: SimulationMetaDataConfiguration not defined` when `TimeStepping.jl` was parsed because its dependencies were not yet included. 
- The intent is to ensure modules that define symbols referenced by `TimeStepping` are parsed before `TimeStepping.jl` to restore successful package load/precompilation. 

### Description
- Reordered includes in `src/SPHExample.jl` so `include("SimulationMetaDataConfiguration.jl")` and `include("SimulationEquations.jl")` appear before `include("TimeStepping.jl")`.
- This ensures symbols exported by `SimulationMetaDataConfiguration` and `SimulationEquations` (e.g. `SimulationMetaData`, `ConstructGravitySVector`) are available when `TimeStepping` is parsed.
- Modified file: `src/SPHExample.jl` (adjusted include order). 
- Changes were committed with `git add src/SPHExample.jl` and `git commit -m "Fix TimeStepping include deps"`.

### Testing
- No automated tests were run.
- Precompilation was not executed as part of this change. 
- No CI results are available for this patch.
- Manual load/run checks were not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69656d7aeca48323aa1ae38500288a97)