### PR TITLE
Move neighbor-list helpers into SPHNeighborList module

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -1,6 +1,6 @@
 module SPHCellList
 
-export ConstructStencil, ExtractCells!, UpdateNeighbors!, NeighborLoop!, ComputeInteractions!, RunSimulation
+export NeighborLoop!, ComputeInteractions!, RunSimulation
 
 using Parameters, FastPow, StaticArrays, Base.Threads
 import LinearAlgebra: dot
@@ -18,6 +18,7 @@ using ..OpenExternalPrograms
 using ..SPHKernels
 using ..SPHViscosityModels
 using ..SPHDensityDiffusionModels
+using ..SPHNeighborList: BuildNeighborCellLists!, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, MapFloor, UpdateNeighbors!
 
 using StaticArrays
 using StructArrays: StructArray, foreachfield
@@ -30,59 +31,6 @@ using HDF5
 using Base.Threads
 using LinearAlgebra
     using Bumper
-
-    function ConstructFullStencil(v::Val{d}) where d
-        return CartesianIndices(ntuple(_->-1:1, v))
-    end
-
-    function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellDict)
-        target_len   = length(UniqueCellsView)
-        original_len = length(NeighborCellLists)
-        resize!(NeighborCellLists, target_len)
-
-        if target_len > original_len
-            @inbounds for idx in (original_len + 1):target_len
-                NeighborCellLists[idx] = Int[]
-            end
-        end
-        
-        @inbounds for cell_idx in eachindex(UniqueCellsView)
-            neighbors = NeighborCellLists[cell_idx]
-            empty!(neighbors)
-            cell = UniqueCellsView[cell_idx]
-            for offset in FullStencil
-                neighbor_cell = cell + offset
-                neighbor_idx = get(CellDict, neighbor_cell, 1)
-                start_idx = ParticleRanges[neighbor_idx]
-                end_idx = ParticleRanges[neighbor_idx + 1] - 1
-                if start_idx <= end_idx && neighbor_idx != cell_idx
-                    push!(neighbors, neighbor_idx)
-                end
-            end
-        end
-
-        return nothing
-    end
-
-    """
-    Extracts the cells for each particle based on their positions and the inverse cutoff value.
-
-    # Arguments
-    - `Particles`: The particles whose cells are to be extracted.
-    - `::Val{InverseCutOff}`: The inverse cutoff value used for cell extraction.
-
-    # Returns
-    - `nothing`: This function modifies the `Particles` in place.
-    """
-    # Replace unsafe_trunc with trunc if this ever errors
-    @inline function map_floor(x, InverseCutOff)
-        # This is different than just doing muladd(x,InverseCutOff,0.5) because it rounds towards zero.
-        # Consider -1.7 + 0.5, this would give -1.2 and then truncated 1, but we want -2, therefore absolute addition beforehand
-        # We add 0.5 instead of 1, to ensure proper rounding behavior when restoring the sign for negative numbers.
-        Int(sign(x)) * unsafe_trunc(Int, muladd(abs(x),InverseCutOff,0.5))
-    end
-
-
 
     @inline function KernelOutputLocal!(::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
                                         kernel_acc, kernel_grad_acc, SimKernel,
@@ -101,74 +49,6 @@ using LinearAlgebra
         return kernel_acc + Wᵢⱼ, kernel_grad_acc + ∇ᵢWᵢⱼ
     end
    
-    @inline function ExtractCells!(Particles, InverseCutOff)
-        @inbounds @simd ivdep for i ∈ eachindex(Particles.Cells)
-            Particles.Cells[i] = CartesianIndex(map(x -> map_floor(x, InverseCutOff), Tuple(Particles.Position[i])))
-        end
-        return nothing
-    end
-
-    """
-    Updates the neighbor list and sorts particles by their cell indices.
-
-    # Arguments
-    - `Particles`: The particles whose neighbors are to be updated.
-    - `CutOff`: The cutoff value used for cell extraction.
-    - `SortingScratchSpace`: Scratch space for sorting.
-    - `ParticleRanges`: Array to store the ranges of particles in each cell.
-    - `UniqueCells`: Array to store the unique cells.
-
-    # Returns
-    - `IndexCounter`: The number of unique cells identified.
-    """
-    function UpdateNeighbors!(Particles, InverseCutOff, SortingScratchSpace,
-                              ParticleRanges, UniqueCells, CellDict)
-        ExtractCells!(Particles, InverseCutOff)
-
-        sort!(Particles, by = p -> p.Cells; scratch=SortingScratchSpace)
-        Cells = @views Particles.Cells
-        @. ParticleRanges             = zero(eltype(ParticleRanges))
-        ParticleRanges[1] = 1
-        IndexCounter                  = 2
-        ParticleRanges[IndexCounter]  = 1
-        UniqueCells[IndexCounter]     = Cells[1]
-        empty!(CellDict)
-        CellDict[Cells[1]] = IndexCounter
-
-        @inbounds @simd ivdep for i in eachindex(Cells)[2:end]
-            if Cells[i] != Cells[i-1] # Equivalent to diff(Cells) != 0
-                IndexCounter                 += 1
-                ParticleRanges[IndexCounter]  = i
-                UniqueCells[IndexCounter]     = Cells[i]
-                CellDict[Cells[i]]           = IndexCounter
-            end
-        end
-        ParticleRanges[IndexCounter + 1]  = length(ParticleRanges)
-
-        return IndexCounter 
-    end
-
-    function compute_cell_particle_counts(particle_ranges, n_cells)
-        counts = Vector{Int}(undef, n_cells)
-        @inbounds for i in 1:n_cells
-            counts[i] = particle_ranges[i + 1] - particle_ranges[i]
-        end
-        return counts
-    end
-
-    function compute_cell_neighbor_counts(particle_ranges, neighbor_cell_lists, n_cells)
-        counts = compute_cell_particle_counts(particle_ranges, n_cells)
-        neighbors = Vector{Int}(undef, n_cells)
-        @inbounds for i in 1:n_cells
-            neighbor_total = 0
-            for neighbor_idx in neighbor_cell_lists[i]
-                neighbor_total += counts[neighbor_idx]
-            end
-            neighbors[i] = max(counts[i] - 1, 0) + neighbor_total
-        end
-        return neighbors
-    end
-
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
@@ -439,14 +319,14 @@ using LinearAlgebra
         return nothing
     end
 
-    f(SimKernel, GhostPoint) = CartesianIndex(map(x->map_floor(x,SimKernel.H⁻¹), Tuple(GhostPoint)))
+    f(SimKernel, GhostPoint) = CartesianIndex(map(x -> MapFloor(x, SimKernel.H⁻¹), Tuple(GhostPoint)))
     function NeighborLoopMDBC!(SimKernel,
                                SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
                                SimConstants, ParticleRanges, CellDict, Position,
                                Density, GhostPoints, GhostNormals, ParticleType,
                                bᵧ, Aᵧ) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}
         
-        FullStencil = ConstructFullStencil(Val(Dimensions))
+        FullStencil = ConstructStencil(Val(Dimensions))
 
         @inbounds @threads for iter in eachindex(GhostPoints)
             GhostPoint = GhostPoints[iter]
@@ -1007,7 +887,7 @@ using LinearAlgebra
         ParticleRanges         = zeros(Int, NumberOfPoints + 1 + 1) # +1 for the last particle, +1 for dummy entry
         UniqueCells            = zeros(CartesianIndex{Dimensions}, NumberOfPoints)
         CellDict               = Dict{CartesianIndex{Dimensions}, Int}()
-        FullStencil            = ConstructFullStencil(Val(Dimensions))
+        FullStencil            = ConstructStencil(Val(Dimensions))
         NeighborCellLists      = [Int[] for _ in 1:length(UniqueCells)]
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
 
@@ -1021,11 +901,11 @@ using LinearAlgebra
             cell_particle_counts = nothing
             cell_neighbor_counts = nothing
             if SimMetaData.ExportGridCellParticleCounts
-                cell_particle_counts = compute_cell_particle_counts(
+                cell_particle_counts = ComputeCellParticleCounts(
                     ParticleRanges,
                     SimMetaData.IndexCounter,
                 )
-                cell_neighbor_counts = compute_cell_neighbor_counts(
+                cell_neighbor_counts = ComputeCellNeighborCounts(
                     ParticleRanges,
                     NeighborCellLists,
                     SimMetaData.IndexCounter,
@@ -1061,11 +941,11 @@ using LinearAlgebra
             cell_particle_counts = nothing
             cell_neighbor_counts = nothing
             if SimMetaData.ExportGridCellParticleCounts
-                cell_particle_counts = compute_cell_particle_counts(
+                cell_particle_counts = ComputeCellParticleCounts(
                     ParticleRanges,
                     length(UniqueCellsView),
                 )
-                cell_neighbor_counts = compute_cell_neighbor_counts(
+                cell_neighbor_counts = ComputeCellNeighborCounts(
                     ParticleRanges,
                     NeighborCellLists,
                     length(UniqueCellsView),

--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -13,6 +13,7 @@ module SPHExample
     include("PreProcess.jl");
     include("OpenExternalPrograms.jl")
     include("SPHDensityDiffusionModels.jl")  
+    include("SPHNeighborList.jl")
     include("SPHCellList.jl") #Must be last    
 
     # Re-export desired functions from each submodule
@@ -55,8 +56,11 @@ module SPHExample
     using .SimulationConstantsConfiguration
     export SimulationConstants
 
+    using .SPHNeighborList
+    export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts
+
     using .SPHCellList
-    export ConstructStencil, ExtractCells!, UpdateNeighbors!, NeighborLoop!, ComputeInteractions!, RunSimulation
+    export NeighborLoop!, ComputeInteractions!, RunSimulation
 
     using .OpenExternalPrograms
     export AutoOpenLogFile, AutoOpenParaview

--- a/src/SPHNeighborList.jl
+++ b/src/SPHNeighborList.jl
@@ -1,0 +1,124 @@
+module SPHNeighborList
+
+export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts
+
+function ConstructStencil(V::Val{d}) where d
+    return CartesianIndices(ntuple(_ -> -1:1, V))
+end
+
+function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellDict)
+    TargetLen   = length(UniqueCellsView)
+    OriginalLen = length(NeighborCellLists)
+    resize!(NeighborCellLists, TargetLen)
+
+    if TargetLen > OriginalLen
+        @inbounds for Index in (OriginalLen + 1):TargetLen
+            NeighborCellLists[Index] = Int[]
+        end
+    end
+
+    @inbounds for CellIndex in eachindex(UniqueCellsView)
+        Neighbors = NeighborCellLists[CellIndex]
+        empty!(Neighbors)
+        Cell = UniqueCellsView[CellIndex]
+        for Offset in FullStencil
+            NeighborCell = Cell + Offset
+            NeighborIndex = get(CellDict, NeighborCell, 1)
+            StartIndex = ParticleRanges[NeighborIndex]
+            EndIndex = ParticleRanges[NeighborIndex + 1] - 1
+            if StartIndex <= EndIndex && NeighborIndex != CellIndex
+                push!(Neighbors, NeighborIndex)
+            end
+        end
+    end
+
+    return nothing
+end
+
+"""
+Extracts the cells for each particle based on their positions and the inverse cutoff value.
+
+# Arguments
+- `Particles`: The particles whose cells are to be extracted.
+- `::Val{InverseCutOff}`: The inverse cutoff value used for cell extraction.
+
+# Returns
+- `nothing`: This function modifies the `Particles` in place.
+"""
+# Replace unsafe_trunc with trunc if this ever errors
+@inline function MapFloor(X, InverseCutOff)
+    # This is different than just doing muladd(x,InverseCutOff,0.5) because it rounds towards zero.
+    # Consider -1.7 + 0.5, this would give -1.2 and then truncated 1, but we want -2, therefore absolute addition beforehand
+    # We add 0.5 instead of 1, to ensure proper rounding behavior when restoring the sign for negative numbers.
+    Int(sign(X)) * unsafe_trunc(Int, muladd(abs(X), InverseCutOff, 0.5))
+end
+
+@inline function ExtractCells!(Particles, InverseCutOff)
+    @inbounds @simd ivdep for Index ∈ eachindex(Particles.Cells)
+        Particles.Cells[Index] = CartesianIndex(map(X -> MapFloor(X, InverseCutOff), Tuple(Particles.Position[Index])))
+    end
+    return nothing
+end
+
+"""
+Updates the neighbor list and sorts particles by their cell indices.
+
+# Arguments
+- `Particles`: The particles whose neighbors are to be updated.
+- `CutOff`: The cutoff value used for cell extraction.
+- `SortingScratchSpace`: Scratch space for sorting.
+- `ParticleRanges`: Array to store the ranges of particles in each cell.
+- `UniqueCells`: Array to store the unique cells.
+
+# Returns
+- `IndexCounter`: The number of unique cells identified.
+"""
+function UpdateNeighbors!(Particles, InverseCutOff, SortingScratchSpace,
+                          ParticleRanges, UniqueCells, CellDict)
+    ExtractCells!(Particles, InverseCutOff)
+
+    sort!(Particles, by = p -> p.Cells; scratch=SortingScratchSpace)
+    Cells = @views Particles.Cells
+    @. ParticleRanges             = zero(eltype(ParticleRanges))
+    ParticleRanges[1] = 1
+    IndexCounter                  = 2
+    ParticleRanges[IndexCounter]  = 1
+    UniqueCells[IndexCounter]     = Cells[1]
+    empty!(CellDict)
+    CellDict[Cells[1]] = IndexCounter
+
+    @inbounds @simd ivdep for Index in eachindex(Cells)[2:end]
+        if Cells[Index] != Cells[Index - 1] # Equivalent to diff(Cells) != 0
+            IndexCounter                 += 1
+            ParticleRanges[IndexCounter]  = Index
+            UniqueCells[IndexCounter]     = Cells[Index]
+            CellDict[Cells[Index]]       = IndexCounter
+        end
+    end
+    ParticleRanges[IndexCounter + 1]  = length(ParticleRanges)
+
+    return IndexCounter
+end
+
+function ComputeCellParticleCounts(ParticleRanges, CellCount)
+    Counts = Vector{Int}(undef, CellCount)
+    @inbounds for Index in 1:CellCount
+        Counts[Index] = ParticleRanges[Index + 1] - ParticleRanges[Index]
+    end
+    return Counts
+end
+
+function ComputeCellNeighborCounts(ParticleRanges, NeighborCellLists, CellCount)
+    Counts = ComputeCellParticleCounts(ParticleRanges, CellCount)
+    Neighbors = Vector{Int}(undef, CellCount)
+    @inbounds for Index in 1:CellCount
+        NeighborTotal = 0
+        for NeighborIndex in NeighborCellLists[Index]
+            NeighborTotal += Counts[NeighborIndex]
+        end
+        Neighbors[Index] = max(Counts[Index] - 1, 0) + NeighborTotal
+    end
+    return Neighbors
+end
+
+end


### PR DESCRIPTION
### Motivation
- Isolate functionality that is strictly used for neighbor lists into its own module to improve separation of concerns and follow the requested naming convention.
- Standardize helper names to project CapitalCase conventions (e.g. `MapFloor`, `ConstructStencil`, `ComputeCellParticleCounts`).
- Reduce the size and responsibilities of `SPHCellList` by removing neighbor-list helpers from it.

### Description
- Add new file `src/SPHNeighborList.jl` that implements neighbor-list utilities: `ConstructStencil`, `ExtractCells!`, `UpdateNeighbors!`, `BuildNeighborCellLists!`, `ComputeCellParticleCounts`, and `ComputeCellNeighborCounts`.
- Update `src/SPHCellList.jl` to import the neighbor-list helpers from `SPHNeighborList` and remove the duplicated implementations, and update call sites to the CapitalCase APIs (e.g. `ConstructStencil`, `MapFloor`, `ComputeCellParticleCounts`, `ComputeCellNeighborCounts`).
- Update `src/SPHExample.jl` to `include("SPHNeighborList.jl")` and re-export the neighbor-list helpers from the top-level module API.
- Make small internal renames and loop-index style changes in `SPHNeighborList.jl` to match naming conventions and improve readability.

### Testing
- No automated tests were executed as part of this change.
- Commands executed during the change (for review and wiring): `ls`, `cat AGENTS.md`, `rg -n <pattern> src`, `sed -n '...p' src/<file>.jl` (file inspections), `git status -sb`, `git add src/SPHCellList.jl src/SPHExample.jl src/SPHNeighborList.jl`, and `git commit -m "Move neighbor list helpers"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696570db30308323abd2de29e8c8fb08)