### PR TITLE
Move UpdateΔx! into SPHNeighborList

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -18,7 +18,7 @@ using ..OpenExternalPrograms
 using ..SPHKernels
 using ..SPHViscosityModels
 using ..SPHDensityDiffusionModels
-using ..SPHNeighborList: BuildNeighborCellLists!, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, MapFloor, UpdateNeighbors!
+using ..SPHNeighborList: BuildNeighborCellLists!, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, MapFloor, UpdateNeighbors!, UpdateΔx!
 
 using StaticArrays
 using StructArrays: StructArray, foreachfield
@@ -703,35 +703,8 @@ using LinearAlgebra
     end
 
 
-    """
-        UpdateΔx!(Δx, posₙ⁺, pos)
-
-    Increment Δx by twice the maximum ‖posₙ⁺[i] – pos[i]‖, without ever allocating.
-    Returns the new Δx.
-    """
-    @inline function UpdateΔx!(Δx::T,
-                                    posₙ⁺::AbstractVector{SVector{D, T}},
-                                    pos   ::AbstractVector{SVector{D, T}}) where {D, T<:Real}
-        maxd = zero(T)
-        @inbounds for i in eachindex(posₙ⁺, pos)
-            # compute squared norm manually
-            sumsq = zero(T)
-            @inbounds for j in 1:D
-                d = posₙ⁺[i][j] - pos[i][j]
-                sumsq += d*d
-            end
-            # sqrt/T is allocation-free on scalars
-            nrm = sqrt(sumsq)
-            if nrm > maxd
-                maxd = nrm
-            end
-        end
-        return Δx + 4*maxd
-    end
-
     # Per-particle local Δx removed: use single scalar `SimMetaData.Δx`.
 
-    
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
                                       SimConstants, SimParticles, FullStencil,

--- a/src/SPHNeighborList.jl
+++ b/src/SPHNeighborList.jl
@@ -1,6 +1,6 @@
 module SPHNeighborList
 
-export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts
+export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts, UpdateΔx!
 
 function ConstructStencil(V::Val{d}) where d
     return CartesianIndices(ntuple(_ -> -1:1, V))
@@ -119,6 +119,32 @@ function ComputeCellNeighborCounts(ParticleRanges, NeighborCellLists, CellCount)
         Neighbors[Index] = max(Counts[Index] - 1, 0) + NeighborTotal
     end
     return Neighbors
+end
+
+"""
+    UpdateΔx!(Δx, posₙ⁺, pos)
+
+Increment Δx by twice the maximum ‖posₙ⁺[i] – pos[i]‖, without ever allocating.
+Returns the new Δx.
+"""
+@inline function UpdateΔx!(Δx::T,
+                           posₙ⁺::AbstractVector{SVector{D, T}},
+                           pos   ::AbstractVector{SVector{D, T}}) where {D, T<:Real}
+    maxd = zero(T)
+    @inbounds for i in eachindex(posₙ⁺, pos)
+        # compute squared norm manually
+        sumsq = zero(T)
+        @inbounds for j in 1:D
+            d = posₙ⁺[i][j] - pos[i][j]
+            sumsq += d*d
+        end
+        # sqrt/T is allocation-free on scalars
+        nrm = sqrt(sumsq)
+        if nrm > maxd
+            maxd = nrm
+        end
+    end
+    return Δx + 4 * maxd
 end
 
 end


### PR DESCRIPTION
### Motivation
- Consolidate the `UpdateΔx!` utility into the neighbor-list utilities so it can be reused and maintained in a single place.
- Remove duplicated implementation from `SPHCellList` and make `SPHCellList` import the shared routine instead.

### Description
- Added `UpdateΔx!` to `src/SPHNeighborList.jl` and exported it as part of the module API.
- Removed the local `UpdateΔx!` implementation from `src/SPHCellList.jl` and updated its `using ..SPHNeighborList` import list to include `UpdateΔx!`.
- Kept the existing comment about using a single scalar `SimMetaData.Δx` (per-particle local Δx removed).
- Updated code references so `SimulationLoop` now calls the relocated `UpdateΔx!`.

### Testing
- No automated tests were run for this change.
- Commands used to inspect and apply the change include `rg -n "UpdateΔx" -S src`, `sed`/`nl` to view files, and `git commit -m "Move UpdateΔx! to neighbor list"` to record the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696573e0fc0c83239eb5e661402f9daa)