### PR TITLE
Fix SVector import in SPHNeighborList

### DIFF
--- a/src/SPHNeighborList.jl
+++ b/src/SPHNeighborList.jl
@@ -2,6 +2,8 @@ module SPHNeighborList
 
 export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts, UpdateΔx!
 
+using StaticArrays
+
 function ConstructStencil(V::Val{d}) where d
     return CartesianIndices(ntuple(_ -> -1:1, V))
 end


### PR DESCRIPTION
### Motivation
- Precompilation failed with `UndefVarError: SVector not defined` originating from `SPHNeighborList` because `SVector` is used but `StaticArrays` was not imported.
- Several functions and signatures in the project rely on `SVector` types in neighbor-list logic and geometry handling.
- Provide an explicit import to ensure `SVector` and related types are available when `SPHNeighborList` is loaded.

### Description
- Added `using StaticArrays` to `src/SPHNeighborList.jl` to expose `SVector` to the module.
- No other API or logic changes were made; exported symbols and function implementations remain unchanged.
- Change is small and focused to resolve the missing symbol during precompilation.

### Testing
- No automated tests were run for this change.
- Manual verification: the file was updated and committed; precompile error should be resolved when the package is next loaded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696574cb7fb08323a4e52653eda7c52e)