### PR TITLE
Import SimulationGeometry in TimeStepping to resolve Moving UndefVarError

### DIFF
--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -7,6 +7,7 @@ using Parameters
 using Base.Threads
 using Bumper
 using ..SimulationEquations
+using ..SimulationGeometry
 using ..SimulationMetaDataConfiguration
 
 @inline function UpdateTimeStepBuffers!(::Nothing, ::Nothing, index, position,


### PR DESCRIPTION
### Motivation
- `ProgressMotion` in `TimeStepping` referenced the `Moving` particle type but `SimulationGeometry` was not imported, causing an `UndefVarError` when running examples that use moving particles.

### Description
- Add `using ..SimulationGeometry` to `src/TimeStepping.jl` so `Moving` and related geometry symbols are in scope for motion updates.

### Testing
- No automated tests were run for this trivial import fix; change committed locally using `git add src/TimeStepping.jl` and `git commit -m "Import Moving type in TimeStepping"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967fb17053c83239ebacfbf851b3998)