### PR TITLE
Initial particle sort by cell ID to improve locality

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -339,6 +339,23 @@ using LinearAlgebra
         return nothing
     end
 
+    """
+    Sort particle storage by the cell ordering recorded in `ParticleOrder`.
+
+    This is intended to be used once at the start of a simulation to improve
+    locality. After sorting, `ParticleOrder` is reset to the identity mapping.
+    """
+    function SortParticlesByCellID!(SimParticles::StructArray, ParticleOrder)
+        foreachfield(SimParticles) do Field
+            FieldSorted = Field[ParticleOrder]
+            copyto!(Field, FieldSorted)
+        end
+        @inbounds for Index in eachindex(ParticleOrder)
+            ParticleOrder[Index] = Index
+        end
+        return nothing
+    end
+
     # The previous generic `ComputeInteractions!` implementation was unused
     # in favour of the per-particle variants (ComputeInteractionsPerParticle! etc.).
     # It has been removed to reduce code size and avoid dead code.
@@ -748,6 +765,9 @@ using LinearAlgebra
                     # if mod(SimMetaData.Iteration, ceil(Int, SimKernel.H / (SimConstants.c₀ * dt * (1/SimConstants.CFL)) )) == 0 || SimMetaData.Iteration == 1
                     if ShouldRebuild
                         @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, ParticleRanges, UniqueCells, CellDict, ParticleOrder, CellOffsets)
+                        if SimMetaData.Iteration == 0
+                            @timeit SimMetaData.HourGlass "01b Initial Sort By CellID" SortParticlesByCellID!(SimParticles, ParticleOrder)
+                        end
                         SimMetaData.Δx    = zero(eltype(dρdtI))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
                         BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellDict)


### PR DESCRIPTION
### Motivation
- Improve memory locality and (potentially) runtime performance by reordering particle storage according to initial cell assignment before the main simulation loop.

### Description
- Add `SortParticlesByCellID!(SimParticles::StructArray, ParticleOrder)` which permutes every particle field using `foreachfield` and then resets `ParticleOrder` to the identity mapping.
- Invoke the one-time sort immediately after the first `UpdateNeighbors!` call when `SimMetaData.Iteration == 0` and record timing under the label "01b Initial Sort By CellID".
- Leave all other neighbor-list and per-iteration logic unchanged so subsequent neighbor rebuilds continue to use the existing non-sorting update path.

### Testing
- No automated tests were run for this change.
- Commands inspected or used while developing the change include `rg -n ...`, `sed -n ...`, and `nl -ba ...`, and the patch was applied to `src/SPHCellList.jl`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69682c6895cc8323953a3a0a13caabce)