### PR TITLE
Replace dict-based cell lookup with dense CellIndexLookup grid

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -18,7 +18,9 @@ using ..OpenExternalPrograms
 using ..SPHKernels
 using ..SPHViscosityModels
 using ..SPHDensityDiffusionModels
-using ..SPHNeighborList: BuildNeighborCellLists!, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, MapFloor, UpdateNeighbors!, UpdateΔx!
+using ..SPHNeighborList: BuildNeighborCellLists!, CellLookupIndex, ComputeCellNeighborCounts,
+                         ComputeCellParticleCounts, ConstructStencil, ExtractCells!, InitializeCellIndexLookup,
+                         MapFloor, UpdateNeighbors!, UpdateΔx!
 
 using StaticArrays
 using StructArrays: StructArray, foreachfield
@@ -35,7 +37,7 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, dρdtI,
+                                      CellLookup, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
                                       min_dt_force = nothing;
@@ -52,7 +54,7 @@ using LinearAlgebra
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
             CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
+            CellListIndex = CellLookupIndex(CellLookup, CellIndex, 1)
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
             NeighborCellIndices = NeighborCellLists[CellListIndex]
@@ -91,7 +93,7 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, dρdtI,
+                                      CellLookup, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
                                       min_dt_force = nothing;
@@ -111,7 +113,7 @@ using LinearAlgebra
             kernel_acc = zero(Kernel[i])
             kernel_grad_acc = zero(KernelGradient[i])
             CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
+            CellListIndex = CellLookupIndex(CellLookup, CellIndex, 1)
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
             NeighborCellIndices = NeighborCellLists[CellListIndex]
@@ -156,7 +158,7 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, dρdtI,
+                                      CellLookup, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
                                       min_dt_force = nothing;
@@ -175,7 +177,7 @@ using LinearAlgebra
             shift_c_acc = zero(∇Cᵢ[i])
             shift_r_acc = zero(∇◌rᵢ[i])
             CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
+            CellListIndex = CellLookupIndex(CellLookup, CellIndex, 1)
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
             NeighborCellIndices = NeighborCellLists[CellListIndex]
@@ -220,7 +222,7 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, dρdtI,
+                                      CellLookup, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
                                       min_dt_force = nothing;
@@ -243,7 +245,7 @@ using LinearAlgebra
             shift_c_acc = zero(∇Cᵢ[i])
             shift_r_acc = zero(∇◌rᵢ[i])
             CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
+            CellListIndex = CellLookupIndex(CellLookup, CellIndex, 1)
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
             NeighborCellIndices = NeighborCellLists[CellListIndex]
@@ -291,7 +293,7 @@ using LinearAlgebra
     f(SimKernel, GhostPoint) = CartesianIndex(map(x -> MapFloor(x, SimKernel.H⁻¹), Tuple(GhostPoint)))
     function NeighborLoopMDBC!(SimKernel,
                                SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
-                               SimConstants, ParticleRanges, CellDict, Position,
+                               SimConstants, ParticleRanges, CellLookup, Position,
                                Density, GhostPoints, GhostNormals, ParticleType,
                                bᵧ, Aᵧ;
                                ParticleOrder) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}
@@ -314,7 +316,7 @@ using LinearAlgebra
                     # Returns a range, x>:x for exact match and x=:x for no match
                     # utilizes that it is a sorted array and requires no isequal constructor,
                     # so I prefer this for now
-                    NeighborIdx = get(CellDict, SCellIndex, 1)
+                    NeighborIdx = CellLookupIndex(CellLookup, SCellIndex, 1)
 
                     StartIndex_       = ParticleRanges[NeighborIdx] 
                     EndIndex_         = ParticleRanges[NeighborIdx + 1] - 1
@@ -632,7 +634,7 @@ using LinearAlgebra
 
     function ApplyMDBCBeforeHalf!(SimMetaData::SimulationMetaData{D,T,S,K,SimpleMDBC,L},
                                   SimKernel, SimConstants, SimParticles,
-                                  ParticleRanges, CellDict, Position, Density,
+                                  ParticleRanges, CellLookup, Position, Density,
                                   GhostPoints, GhostNormals, ParticleType;
                                   ParticleOrder
                                  ) where {D,T,S<:ShiftingMode,K<:KernelOutputMode,L<:LogMode}
@@ -640,7 +642,7 @@ using LinearAlgebra
             DimensionsPlus = D + 1
             bᵧ = @alloc(SVector{DimensionsPlus, T}, length(Position))
             Aᵧ = @alloc(SMatrix{DimensionsPlus, DimensionsPlus, T, DimensionsPlus*DimensionsPlus}, length(Position))
-            NeighborLoopMDBC!(SimKernel, SimMetaData, SimConstants, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType, bᵧ, Aᵧ; ParticleOrder = ParticleOrder)
+            NeighborLoopMDBC!(SimKernel, SimMetaData, SimConstants, ParticleRanges, CellLookup, Position, Density, GhostPoints, GhostNormals, ParticleType, bᵧ, Aᵧ; ParticleOrder = ParticleOrder)
             ApplyMDBCCorrection(SimConstants, SimParticles, bᵧ, Aᵧ)
         end
 
@@ -697,7 +699,7 @@ using LinearAlgebra
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
                                       SimConstants, SimParticles, FullStencil,
-                                      ParticleRanges, UniqueCells, CellDict,
+                                      ParticleRanges, UniqueCells, CellLookup,
                                       ParticleOrder, CellOffsets,
                                       NeighborCellLists, dρdtI, Velocityₙ⁺,
                                       Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
@@ -747,10 +749,10 @@ using LinearAlgebra
                     # Remove if statement logic if you want to update each iteration
                     # if mod(SimMetaData.Iteration, ceil(Int, SimKernel.H / (SimConstants.c₀ * dt * (1/SimConstants.CFL)) )) == 0 || SimMetaData.Iteration == 1
                     if ShouldRebuild
-                        @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, ParticleRanges, UniqueCells, CellDict, ParticleOrder, CellOffsets)
+                        @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, ParticleRanges, UniqueCells, CellLookup, ParticleOrder, CellOffsets)
                         SimMetaData.Δx    = zero(eltype(dρdtI))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
-                        BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellDict)
+                        BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellLookup)
                     end
                 end
 
@@ -760,20 +762,20 @@ using LinearAlgebra
                 if SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, KMode, NoMDBC, LMode} where {SMode, KMode, LMode}
                     @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData)
                 else
-                    @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType; ParticleOrder = ParticleOrder)
+                    @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellLookup, Position, Density, GhostPoints, GhostNormals, ParticleType; ParticleOrder = ParticleOrder)
                 end
 
                 if SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, NoKernelOutput, BMode, LMode} where {SMode, BMode, LMode}
                     @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        SimConstants, SimParticles, ParticleRanges, CellLookup,
                         NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
                         ParticleOrder = ParticleOrder,
                     )
                 else
                     @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        SimConstants, SimParticles, ParticleRanges, CellLookup,
                         NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
                         ParticleOrder = ParticleOrder,
                     )
@@ -791,7 +793,7 @@ using LinearAlgebra
                 if SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, NoKernelOutput, BMode, LMode} where {SMode, BMode, LMode}
                     @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        SimConstants, SimParticles, ParticleRanges, CellLookup,
                         NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
                         max_visc, min_dt_force,
                         ParticleOrder = ParticleOrder,
@@ -802,7 +804,7 @@ using LinearAlgebra
                 else
                     @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        SimConstants, SimParticles, ParticleRanges, CellLookup,
                         NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
                         max_visc, min_dt_force,
                         ParticleOrder = ParticleOrder,
@@ -867,7 +869,7 @@ using LinearAlgebra
         # Produce sorting related variables
         ParticleRanges         = zeros(Int, NumberOfPoints + 1 + 1) # +1 for the last particle, +1 for dummy entry
         UniqueCells            = zeros(CartesianIndex{Dimensions}, NumberOfPoints)
-        CellDict               = Dict{CartesianIndex{Dimensions}, Int}()
+        CellLookup             = InitializeCellIndexLookup(Val(Dimensions))
         FullStencil            = ConstructStencil(Val(Dimensions))
         NeighborCellLists      = [Int[] for _ in 1:length(UniqueCells)]
         ParticleOrder          = zeros(Int, NumberOfPoints)
@@ -909,7 +911,7 @@ using LinearAlgebra
             @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
                 SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                 SimConstants, SimParticles, FullStencil, ParticleRanges,
-                UniqueCells, CellDict, ParticleOrder, CellOffsets,
+                UniqueCells, CellLookup, ParticleOrder, CellOffsets,
                 NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
                 ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
             )

--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -58,7 +58,8 @@ module SPHExample
 
     using .SPHNeighborList
     export ConstructStencil, ExtractCells!, UpdateNeighbors!,
-           BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts
+           BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts,
+           CellIndexLookup, InitializeCellIndexLookup
 
     using .SPHCellList
     export NeighborLoop!, ComputeInteractions!, RunSimulation

--- a/src/SPHNeighborList.jl
+++ b/src/SPHNeighborList.jl
@@ -1,15 +1,63 @@
 module SPHNeighborList
 
 export ConstructStencil, ExtractCells!, UpdateNeighbors!,
-       BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts, UpdateΔx!
+       BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts, UpdateΔx!,
+       CellIndexLookup, InitializeCellIndexLookup, CellLookupIndex
 
 using StaticArrays
+
+mutable struct CellIndexLookup{D}
+    Grid::Vector{Int}
+    MinCell::MVector{D, Int}
+    MaxCell::MVector{D, Int}
+    Strides::MVector{D, Int}
+end
+
+function InitializeCellIndexLookup(::Val{D}) where D
+    zeros_tuple = ntuple(_ -> 0, D)
+    return CellIndexLookup{D}(
+        Int[],
+        MVector{D, Int}(zeros_tuple),
+        MVector{D, Int}(zeros_tuple),
+        MVector{D, Int}(zeros_tuple),
+    )
+end
+
+@inline function PrepareCellLookup!(CellLookup::CellIndexLookup{D}) where D
+    total = 1
+    @inbounds for d in 1:D
+        dim = CellLookup.MaxCell[d] - CellLookup.MinCell[d] + 1
+        CellLookup.Strides[d] = total
+        total *= dim
+    end
+    resize!(CellLookup.Grid, total)
+    fill!(CellLookup.Grid, 0)
+    return nothing
+end
+
+@inline function CellLinearIndex(CellLookup::CellIndexLookup{D}, Cell::CartesianIndex{D}) where D
+    idx = 1
+    @inbounds for d in 1:D
+        idx += (Cell[d] - CellLookup.MinCell[d]) * CellLookup.Strides[d]
+    end
+    return idx
+end
+
+@inline function CellLookupIndex(CellLookup::CellIndexLookup{D}, Cell::CartesianIndex{D}, Default) where D
+    @inbounds for d in 1:D
+        value = Cell[d]
+        if value < CellLookup.MinCell[d] || value > CellLookup.MaxCell[d]
+            return Default
+        end
+    end
+    return CellLookup.Grid[CellLinearIndex(CellLookup, Cell)]
+end
 
 function ConstructStencil(V::Val{d}) where d
     return CartesianIndices(ntuple(_ -> -1:1, V))
 end
 
-function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellDict)
+function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellLookup)
     TargetLen   = length(UniqueCellsView)
     OriginalLen = length(NeighborCellLists)
     resize!(NeighborCellLists, TargetLen)
@@ -27,7 +75,7 @@ function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView
         Cell = UniqueCellsView[CellIndex]
         for Offset in FullStencil
             NeighborCell = Cell + Offset
-            NeighborIndex = get(CellDict, NeighborCell, 0)
+            NeighborIndex = CellLookupIndex(CellLookup, NeighborCell, 0)
             if NeighborIndex != 0 && NeighborIndex != CellIndex
                 StartIndex = ParticleRanges[NeighborIndex]
                 EndIndex = ParticleRanges[NeighborIndex + 1] - 1
@@ -66,6 +114,38 @@ end
     return nothing
 end
 
+@inline function ExtractCellsAndBounds!(Particles, InverseCutOff, MinCell, MaxCell)
+    Cells = Particles.Cells
+    Positions = Particles.Position
+    if isempty(Cells)
+        return false
+    end
+
+    FirstCell = CartesianIndex(map(X -> MapFloor(X, InverseCutOff), Tuple(Positions[1])))
+    Cells[1] = FirstCell
+    @inbounds for d in eachindex(MinCell)
+        MinCell[d] = FirstCell[d]
+        MaxCell[d] = FirstCell[d]
+    end
+
+    if length(Cells) > 1
+        @inbounds @simd ivdep for Index in 2:length(Cells)
+            Cell = CartesianIndex(map(X -> MapFloor(X, InverseCutOff), Tuple(Positions[Index])))
+            Cells[Index] = Cell
+            @inbounds for d in eachindex(MinCell)
+                value = Cell[d]
+                if value < MinCell[d]
+                    MinCell[d] = value
+                elseif value > MaxCell[d]
+                    MaxCell[d] = value
+                end
+            end
+        end
+    end
+
+    return true
+end
+
 """
 Updates the neighbor list without sorting particle storage.
 
@@ -73,22 +153,26 @@ This builds a per-cell particle ordering buffer so cell ranges can be iterated
 without reordering the particle arrays.
 """
 function UpdateNeighbors!(Particles, InverseCutOff, ParticleRanges,
-                          UniqueCells, CellDict, ParticleOrder, CellOffsets)
-    ExtractCells!(Particles, InverseCutOff)
+                          UniqueCells, CellLookup, ParticleOrder, CellOffsets)
+    HasParticles = ExtractCellsAndBounds!(Particles, InverseCutOff, CellLookup.MinCell, CellLookup.MaxCell)
+    if !HasParticles
+        return 0
+    end
+    PrepareCellLookup!(CellLookup)
 
     Cells = @views Particles.Cells
     ParticleRanges[1] = 1
     IndexCounter = 1
-    empty!(CellDict)
     fill!(CellOffsets, zero(eltype(CellOffsets)))
 
     @inbounds for Index in eachindex(Cells)
         Cell = Cells[Index]
-        CellIndex = get(CellDict, Cell, 0)
+        LinearIndex = CellLinearIndex(CellLookup, Cell)
+        CellIndex = CellLookup.Grid[LinearIndex]
         if CellIndex == 0
             IndexCounter += 1
             CellIndex = IndexCounter
-            CellDict[Cell] = CellIndex
+            CellLookup.Grid[LinearIndex] = CellIndex
             UniqueCells[CellIndex] = Cell
         end
         CellOffsets[CellIndex] += 1
@@ -104,7 +188,7 @@ function UpdateNeighbors!(Particles, InverseCutOff, ParticleRanges,
     ParticleRanges[IndexCounter + 1] = RunningIndex
 
     @inbounds for Index in eachindex(Cells)
-        CellIndex = CellDict[Cells[Index]]
+        CellIndex = CellLookup.Grid[CellLinearIndex(CellLookup, Cells[Index])]
         TargetIndex = CellOffsets[CellIndex]
         ParticleOrder[TargetIndex] = Index
         CellOffsets[CellIndex] = TargetIndex + 1


### PR DESCRIPTION
### Motivation

- Replace the runtime `Dict{CartesianIndex,Int}` cell→index mapping with a dense, bounds-tracked grid to reduce hashing overhead and improve locality when building neighbor lists.
- Compute a compact linear index for cells within observed min/max bounds so lookups become fast array accesses instead of dictionary queries.

### Description

- Added an array-backed lookup type `CellIndexLookup{D}` and initializer `InitializeCellIndexLookup`, plus helpers `PrepareCellLookup!`, `CellLinearIndex` and `CellLookupIndex` in `src/SPHNeighborList.jl` to manage min/max cell bounds and a dense `Grid::Vector{Int}` mapping. 
- Added `ExtractCellsAndBounds!` to compute particle cell positions and global min/max per-dimension for the lookup grid. 
- Replaced usages of the `CellDict` `Dict` with the new `CellLookup` in `UpdateNeighbors!`, `BuildNeighborCellLists!`, `NeighborLoopMDBC!` and all neighbor-loop entry points in `src/SPHCellList.jl`, and adapted `SimulationLoop` wiring to pass `CellLookup` through. 
- Re-exported the lookup initializer from the top-level module via updates to `src/SPHExample.jl` so callers can create the new mapping. 

### Testing

- No automated tests were executed as part of this change.
- No runtime or unit test results are reported here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696957ba9d508323a5651aa615bfa2b0)