### PR TITLE
Use summed viscosity for timestep buffers

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -50,6 +50,7 @@ using LinearAlgebra
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
+            visc_acc = zero(eltype(dρdtI))
             CellIndex = Cells[i]
             CellListIndex = get(CellDict, CellIndex, 1)
             SameCellStart = ParticleRanges[CellListIndex]
@@ -57,34 +58,34 @@ using LinearAlgebra
             NeighborCellIndices = NeighborCellLists[CellListIndex]
 
             @inbounds for j in SameCellStart:(i - 1)
-                dρdt_acc, acc_acc = ComputeInteractionsPerParticleNoKernel!(
+                dρdt_acc, acc_acc, visc_acc = ComputeInteractionsPerParticleNoKernel!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, Position, Density, Pressure,
-                    Velocity, MotionLimiter, dρdt_acc, acc_acc, i, j,
+                    Velocity, MotionLimiter, dρdt_acc, acc_acc, visc_acc, i, j,
                 )
             end
             @inbounds for j in (i + 1):SameCellEnd
-                dρdt_acc, acc_acc = ComputeInteractionsPerParticleNoKernel!(
+                dρdt_acc, acc_acc, visc_acc = ComputeInteractionsPerParticleNoKernel!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, Position, Density, Pressure,
-                    Velocity, MotionLimiter, dρdt_acc, acc_acc, i, j,
+                    Velocity, MotionLimiter, dρdt_acc, acc_acc, visc_acc, i, j,
                 )
             end
             for NeighborIdx in NeighborCellIndices
                 StartIndex_ = ParticleRanges[NeighborIdx]
                 EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
                 @inbounds for j in StartIndex_:EndIndex_
-                    dρdt_acc, acc_acc = ComputeInteractionsPerParticleNoKernel!(
+                    dρdt_acc, acc_acc, visc_acc = ComputeInteractionsPerParticleNoKernel!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
-                        Velocity, MotionLimiter, dρdt_acc, acc_acc, i, j,
+                        Velocity, MotionLimiter, dρdt_acc, acc_acc, visc_acc, i, j,
                     )
                 end
             end
 
             dρdtI[i] = dρdt_acc
             Acceleration[i] = acc_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, Position[i], Velocity[i], acc_acc, SimKernel)
+            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, visc_acc, Position[i], Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -111,6 +112,7 @@ using LinearAlgebra
             acc_acc = zero(Acceleration[i])
             kernel_acc = zero(Kernel[i])
             kernel_grad_acc = zero(KernelGradient[i])
+            visc_acc = zero(eltype(dρdtI))
             CellIndex = Cells[i]
             CellListIndex = get(CellDict, CellIndex, 1)
             SameCellStart = ParticleRanges[CellListIndex]
@@ -118,33 +120,33 @@ using LinearAlgebra
             NeighborCellIndices = NeighborCellLists[CellListIndex]
 
             @inbounds for j in SameCellStart:(i - 1)
-                dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc =
+                dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, visc_acc =
                     ComputeInteractionsPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
                         Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
-                        kernel_grad_acc, i, j,
+                        kernel_grad_acc, visc_acc, i, j,
                     )
             end
             @inbounds for j in (i + 1):SameCellEnd
-                dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc =
+                dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, visc_acc =
                     ComputeInteractionsPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
                         Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
-                        kernel_grad_acc, i, j,
+                        kernel_grad_acc, visc_acc, i, j,
                     )
             end
             for NeighborIdx in NeighborCellIndices
                 StartIndex_ = ParticleRanges[NeighborIdx]
                 EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
                 @inbounds for j in StartIndex_:EndIndex_
-                    dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc =
+                    dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, visc_acc =
                         ComputeInteractionsPerParticle!(
                             SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                             SimConstants, SimParticles, Position, Density, Pressure,
                             Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
-                            kernel_grad_acc, i, j,
+                            kernel_grad_acc, visc_acc, i, j,
                         )
                 end
             end
@@ -153,7 +155,7 @@ using LinearAlgebra
             Acceleration[i] = acc_acc
             Kernel[i] = kernel_acc
             KernelGradient[i] = kernel_grad_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, Position[i], Velocity[i], acc_acc, SimKernel)
+            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, visc_acc, Position[i], Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -179,6 +181,7 @@ using LinearAlgebra
             acc_acc = zero(Acceleration[i])
             shift_c_acc = zero(∇Cᵢ[i])
             shift_r_acc = zero(∇◌rᵢ[i])
+            visc_acc = zero(eltype(dρdtI))
             CellIndex = Cells[i]
             CellListIndex = get(CellDict, CellIndex, 1)
             SameCellStart = ParticleRanges[CellListIndex]
@@ -186,33 +189,33 @@ using LinearAlgebra
             NeighborCellIndices = NeighborCellLists[CellListIndex]
 
             @inbounds for j in SameCellStart:(i - 1)
-                dρdt_acc, acc_acc, shift_c_acc, shift_r_acc =
+                dρdt_acc, acc_acc, shift_c_acc, shift_r_acc, visc_acc =
                     ComputeInteractionsPerParticleNoKernel!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
                         Velocity, MotionLimiter, dρdt_acc, acc_acc, shift_c_acc,
-                        shift_r_acc, i, j,
+                        shift_r_acc, visc_acc, i, j,
                     )
             end
             @inbounds for j in (i + 1):SameCellEnd
-                dρdt_acc, acc_acc, shift_c_acc, shift_r_acc =
+                dρdt_acc, acc_acc, shift_c_acc, shift_r_acc, visc_acc =
                     ComputeInteractionsPerParticleNoKernel!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
                         Velocity, MotionLimiter, dρdt_acc, acc_acc, shift_c_acc,
-                        shift_r_acc, i, j,
+                        shift_r_acc, visc_acc, i, j,
                     )
             end
             for NeighborIdx in NeighborCellIndices
                 StartIndex_ = ParticleRanges[NeighborIdx]
                 EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
                 @inbounds for j in StartIndex_:EndIndex_
-                    dρdt_acc, acc_acc, shift_c_acc, shift_r_acc =
+                    dρdt_acc, acc_acc, shift_c_acc, shift_r_acc, visc_acc =
                         ComputeInteractionsPerParticleNoKernel!(
                             SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                             SimConstants, SimParticles, Position, Density, Pressure,
                             Velocity, MotionLimiter, dρdt_acc, acc_acc, shift_c_acc,
-                            shift_r_acc, i, j,
+                            shift_r_acc, visc_acc, i, j,
                         )
                 end
             end
@@ -221,7 +224,7 @@ using LinearAlgebra
             Acceleration[i] = acc_acc
             ∇Cᵢ[i] = shift_c_acc
             ∇◌rᵢ[i] = shift_r_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, Position[i], Velocity[i], acc_acc, SimKernel)
+            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, visc_acc, Position[i], Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -251,6 +254,7 @@ using LinearAlgebra
             kernel_grad_acc = zero(KernelGradient[i])
             shift_c_acc = zero(∇Cᵢ[i])
             shift_r_acc = zero(∇◌rᵢ[i])
+            visc_acc = zero(eltype(dρdtI))
             CellIndex = Cells[i]
             CellListIndex = get(CellDict, CellIndex, 1)
             SameCellStart = ParticleRanges[CellListIndex]
@@ -259,20 +263,20 @@ using LinearAlgebra
 
             @inbounds for j in SameCellStart:(i - 1)
                 dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
-                shift_r_acc = ComputeInteractionsPerParticle!(
+                shift_r_acc, visc_acc = ComputeInteractionsPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, Position, Density, Pressure,
                     Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
-                    kernel_grad_acc, shift_c_acc, shift_r_acc, i, j,
+                    kernel_grad_acc, shift_c_acc, shift_r_acc, visc_acc, i, j,
                 )
             end
             @inbounds for j in (i + 1):SameCellEnd
                 dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
-                shift_r_acc = ComputeInteractionsPerParticle!(
+                shift_r_acc, visc_acc = ComputeInteractionsPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, Position, Density, Pressure,
                     Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
-                    kernel_grad_acc, shift_c_acc, shift_r_acc, i, j,
+                    kernel_grad_acc, shift_c_acc, shift_r_acc, visc_acc, i, j,
                 )
             end
             for NeighborIdx in NeighborCellIndices
@@ -280,11 +284,11 @@ using LinearAlgebra
                 EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
                 @inbounds for j in StartIndex_:EndIndex_
                     dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
-                    shift_r_acc = ComputeInteractionsPerParticle!(
+                    shift_r_acc, visc_acc = ComputeInteractionsPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
                         Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
-                        kernel_grad_acc, shift_c_acc, shift_r_acc, i, j,
+                        kernel_grad_acc, shift_c_acc, shift_r_acc, visc_acc, i, j,
                     )
                 end
             end
@@ -295,7 +299,7 @@ using LinearAlgebra
             KernelGradient[i] = kernel_grad_acc
             ∇Cᵢ[i] = shift_c_acc
             ∇◌rᵢ[i] = shift_r_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, Position[i],
+            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, visc_acc, Position[i],
                                       Velocity[i], acc_acc, SimKernel)
         end
 
@@ -376,12 +380,12 @@ using LinearAlgebra
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L}, SimConstants,
         SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
-        dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, i, j) where {D,T,
-                                                                     K<:KernelOutputMode,
-                                                                     B<:MDBCMode,
-                                                                     L<:LogMode,
-                                                                     SDD<:SPHDensityDiffusion,
-                                                                     SV<:SPHViscosity}
+        dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, visc_acc, i, j) where {D,T,
+                                                                      K<:KernelOutputMode,
+                                                                      B<:MDBCMode,
+                                                                      L<:LogMode,
+                                                                      SDD<:SPHDensityDiffusion,
+                                                                      SV<:SPHViscosity}
         @unpack m₀, dx = SimConstants
         @unpack h⁻¹, H² = SimKernel
 
@@ -418,20 +422,21 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
+            visc_acc += norm(visc_term)
 
             kernel_acc, kernel_grad_acc =
                 compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc,
                                             SimKernel, q, ∇ᵢWᵢⱼ)
         end
 
-        return dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc
+        return dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, visc_acc
     end
 
     Base.@propagate_inbounds function ComputeInteractionsPerParticleNoKernel!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L}, SimConstants,
         SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
-        dρdt_acc, acc_acc, i, j) where {D,T,B<:MDBCMode,L<:LogMode,
+        dρdt_acc, acc_acc, visc_acc, i, j) where {D,T,B<:MDBCMode,L<:LogMode,
                                         SDD<:SPHDensityDiffusion,
                                         SV<:SPHViscosity}
         @unpack m₀, dx = SimConstants
@@ -470,9 +475,10 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
+            visc_acc += norm(visc_term)
         end
 
-        return dρdt_acc, acc_acc
+        return dρdt_acc, acc_acc, visc_acc
     end
 
     Base.@propagate_inbounds function ComputeInteractionsPerParticle!(
@@ -480,7 +486,7 @@ using LinearAlgebra
         SimMetaData::SimulationMetaData{D,T,S,K,B,L}, SimConstants,
         SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
         dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
-        shift_r_acc, i, j) where {D,T,S<:ShiftingMode,
+        shift_r_acc, visc_acc, i, j) where {D,T,S<:ShiftingMode,
                                   K<:KernelOutputMode,
                                   B<:MDBCMode,
                                   L<:LogMode,
@@ -522,6 +528,7 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
+            visc_acc += norm(visc_term)
 
             kernel_acc, kernel_grad_acc =
                 compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc,
@@ -532,14 +539,14 @@ using LinearAlgebra
             shift_r_acc += (m₀ / ρⱼ) * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
         end
 
-        return dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc, shift_r_acc
+        return dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc, shift_r_acc, visc_acc
     end
 
     Base.@propagate_inbounds function ComputeInteractionsPerParticleNoKernel!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,S,NoKernelOutput,B,L}, SimConstants,
         SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
-        dρdt_acc, acc_acc, shift_c_acc, shift_r_acc, i, j) where {D,T,
+        dρdt_acc, acc_acc, shift_c_acc, shift_r_acc, visc_acc, i, j) where {D,T,
                                                                   S<:ShiftingMode,
                                                                   B<:MDBCMode,
                                                                   L<:LogMode,
@@ -581,13 +588,14 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
+            visc_acc += norm(visc_term)
 
             MLcond = MotionLimiter[i] * MotionLimiter[j]
             shift_c_acc += (m₀ / ρᵢ) * ∇ᵢWᵢⱼ
             shift_r_acc += (m₀ / ρⱼ) * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
         end
 
-        return dρdt_acc, acc_acc, shift_c_acc, shift_r_acc
+        return dρdt_acc, acc_acc, shift_c_acc, shift_r_acc, visc_acc
     end
 
     Base.@propagate_inbounds function ComputeInteractionsMDBC!(SimKernel, SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode}, SimConstants, Position, Density, ParticleType, GhostPoints, i, j) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -10,21 +10,18 @@ using ..SimulationEquations
 using ..SimulationGeometry
 using ..SimulationMetaDataConfiguration
 
-@inline function UpdateTimeStepBuffers!(::Nothing, ::Nothing, index, position,
-                                           velocity, acceleration, sim_kernel)
+@inline function UpdateTimeStepBuffers!(::Nothing, ::Nothing, index, visc_sum,
+                                           position, velocity, acceleration, sim_kernel)
     return nothing
 end
 
-@inline function UpdateTimeStepBuffers!(max_visc, min_dt_force, index, position,
-                                           velocity, acceleration, sim_kernel)
+@inline function UpdateTimeStepBuffers!(max_visc, min_dt_force, index, visc_sum,
+                                           position, velocity, acceleration, sim_kernel)
     h = sim_kernel.h
-    η² = sim_kernel.η²
-    r_sq = sqrt(dot(position, position))^2
-    curr_visc = abs(h * dot(velocity, position) / (r_sq + η²))
     a_mag = norm(acceleration)
     curr_dt_force = a_mag > 0 ? sqrt(h / a_mag) : typemax(eltype(min_dt_force))
     @inbounds begin
-        max_visc[index] = curr_visc
+        max_visc[index] = visc_sum
         min_dt_force[index] = curr_dt_force
     end
     return nothing


### PR DESCRIPTION
### Motivation
- Improve timestep estimation by accumulating per-particle viscous contributions during neighbor interactions and using the summed viscosity in the CFL/viscous limiter instead of a single-pair estimate.
- Make the viscous contribution explicit and pre-aggregated per particle so `FinalizeTimeStep` sees a more representative `global_visc` for time stepping.

### Description
- Added a per-particle `visc_acc` accumulator in the neighbor loops and passed it through the interaction helpers so each neighbor-viscosity contribution is summed (`src/SPHCellList.jl`).
- Extended the `ComputeInteractionsPerParticle!` / `ComputeInteractionsPerParticleNoKernel!` variants to return the running per-particle viscosity sum and increment it with `norm(visc_term)` where viscosity contributions are computed (`src/SPHCellList.jl`).
- Changed `UpdateTimeStepBuffers!` signature to accept a `visc_sum` argument and store it into the `max_visc` buffer instead of computing a single-pair `curr_visc` locally (`src/TimeStepping.jl`).
- Kept the existing force-based timestep buffer (`min_dt_force`) behavior unchanged, so both viscous and force criteria remain available to `FinalizeTimeStep`.

### Testing
- No automated unit/integration tests were executed against the modified code; behavior change was implemented and validated only by static inspection in this rollout.
- Commands run during the change and inspection: `ls`, `cat AGENTS.md`, `rg -n "NeighborLoopPerParticle!" -S src`, multiple `sed`/`nl` calls to inspect files, and `rg` searches to confirm call sites and symbol usage (all completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a99c849a88323bfeea12eb184d795)