### PR TITLE
Fix viscous timestep accumulation

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -422,7 +422,8 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
-            visc_acc += abs(h * dot(vᵢ, Position[i])) / (dᵢⱼ^2 + η²)
+            visc_term_dt = abs(h * dot(vᵢⱼ, xᵢⱼ)) / (dᵢⱼ^2 + η²)
+            visc_acc = max(visc_acc, visc_term_dt)
 
             kernel_acc, kernel_grad_acc =
                 compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc,
@@ -475,7 +476,8 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
-            visc_acc += abs(h * dot(vᵢ, Position[i])) / (dᵢⱼ^2 + η²)
+            visc_term_dt = abs(h * dot(vᵢⱼ, xᵢⱼ)) / (dᵢⱼ^2 + η²)
+            visc_acc = max(visc_acc, visc_term_dt)
         end
 
         return dρdt_acc, acc_acc, visc_acc
@@ -528,7 +530,8 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
-            visc_acc += abs(h * dot(vᵢ, Position[i])) / (dᵢⱼ^2 + η²)
+            visc_term_dt = abs(h * dot(vᵢⱼ, xᵢⱼ)) / (dᵢⱼ^2 + η²)
+            visc_acc = max(visc_acc, visc_term_dt)
 
             kernel_acc, kernel_grad_acc =
                 compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc,
@@ -588,7 +591,8 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
-            visc_acc += abs(h * dot(vᵢ, Position[i])) / (dᵢⱼ^2 + η²)
+            visc_term_dt = abs(h * dot(vᵢⱼ, xᵢⱼ)) / (dᵢⱼ^2 + η²)
+            visc_acc = max(visc_acc, visc_term_dt)
 
             MLcond = MotionLimiter[i] * MotionLimiter[j]
             shift_c_acc += (m₀ / ρᵢ) * ∇ᵢWᵢⱼ


### PR DESCRIPTION
### Motivation
- The global time step was becoming excessively small due to an incorrect viscous contribution being accumulated per neighbor pair and the wrong dot product being used when forming the viscous timestep limiter.
- The change aims to follow the expected SPH formulation by computing the viscous timestep contribution from relative velocity and separation, and by taking the per-particle maximum contribution instead of summing them.

### Description
- Replace `visc_acc += ...` with `visc_acc = max(visc_acc, visc_term_dt)` so the viscous contribution per particle is the maximum of per-pair terms instead of a sum.
- Compute `visc_term_dt` as `abs(h * dot(vᵢⱼ, xᵢⱼ)) / (dᵢⱼ^2 + η²)` using relative velocity `vᵢⱼ` and separation `xᵢⱼ` rather than `dot(vᵢ, Position[i])`.
- Applied the fix in all interaction variants within `src/SPHCellList.jl` where the viscous timestep term was computed.

### Testing
- No automated tests were run for this change.
- Commands executed while preparing the change: `ls`, `cat AGENTS.md`, `rg -n "time step|timestep|Δt|dt" src`, inspected `src/TimeStepping.jl` and `src/SPHCellList.jl` with `sed`/`nl`, and applied the patch to `src/SPHCellList.jl`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac21010d48323a3a8e55c93e829b8)