### PR TITLE
Align viscous timestep limiter and include per-particle max speed in CFL

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -38,6 +38,7 @@ using LinearAlgebra
                                       CellDict, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
+                                      max_speed = nothing,
                                       min_dt_force = nothing;
                                       Position = SimParticles.Position,
                                       Density = SimParticles.Density,
@@ -85,7 +86,7 @@ using LinearAlgebra
 
             dρdtI[i] = dρdt_acc
             Acceleration[i] = acc_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, visc_acc, Position[i], Velocity[i], acc_acc, SimKernel)
+            UpdateTimeStepBuffers!(max_visc, max_speed, min_dt_force, i, visc_acc, Position[i], Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -97,6 +98,7 @@ using LinearAlgebra
                                       CellDict, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
+                                      max_speed = nothing,
                                       min_dt_force = nothing;
                                       Position = SimParticles.Position,
                                       Density = SimParticles.Density,
@@ -155,7 +157,7 @@ using LinearAlgebra
             Acceleration[i] = acc_acc
             Kernel[i] = kernel_acc
             KernelGradient[i] = kernel_grad_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, visc_acc, Position[i], Velocity[i], acc_acc, SimKernel)
+            UpdateTimeStepBuffers!(max_visc, max_speed, min_dt_force, i, visc_acc, Position[i], Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -167,6 +169,7 @@ using LinearAlgebra
                                       CellDict, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
+                                      max_speed = nothing,
                                       min_dt_force = nothing;
                                       Position = SimParticles.Position,
                                       Density = SimParticles.Density,
@@ -224,7 +227,7 @@ using LinearAlgebra
             Acceleration[i] = acc_acc
             ∇Cᵢ[i] = shift_c_acc
             ∇◌rᵢ[i] = shift_r_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, visc_acc, Position[i], Velocity[i], acc_acc, SimKernel)
+            UpdateTimeStepBuffers!(max_visc, max_speed, min_dt_force, i, visc_acc, Position[i], Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -236,6 +239,7 @@ using LinearAlgebra
                                       CellDict, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, max_visc = nothing,
+                                      max_speed = nothing,
                                       min_dt_force = nothing;
                                       Position = SimParticles.Position,
                                       Density = SimParticles.Density,
@@ -299,8 +303,8 @@ using LinearAlgebra
             KernelGradient[i] = kernel_grad_acc
             ∇Cᵢ[i] = shift_c_acc
             ∇◌rᵢ[i] = shift_r_acc
-            UpdateTimeStepBuffers!(max_visc, min_dt_force, i, visc_acc, Position[i],
-                                      Velocity[i], acc_acc, SimKernel)
+            UpdateTimeStepBuffers!(max_visc, max_speed, min_dt_force, i, visc_acc, Position[i],
+                                   Velocity[i], acc_acc, SimKernel)
         end
 
         return nothing
@@ -422,7 +426,8 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
-            visc_acc += abs(h * dot(vᵢ, Position[i])) / (dᵢⱼ^2 + η²)
+            visc_term_dt = dot(vᵢⱼ, xᵢⱼ) / (dᵢⱼ^2 + η²)
+            visc_acc = max(visc_acc, visc_term_dt)
 
             kernel_acc, kernel_grad_acc =
                 compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc,
@@ -475,7 +480,8 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
-            visc_acc += abs(h * dot(vᵢ, Position[i])) / (dᵢⱼ^2 + η²)
+            visc_term_dt = dot(vᵢⱼ, xᵢⱼ) / (dᵢⱼ^2 + η²)
+            visc_acc = max(visc_acc, visc_term_dt)
         end
 
         return dρdt_acc, acc_acc, visc_acc
@@ -528,7 +534,8 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
-            visc_acc += abs(h * dot(vᵢ, Position[i])) / (dᵢⱼ^2 + η²)
+            visc_term_dt = dot(vᵢⱼ, xᵢⱼ) / (dᵢⱼ^2 + η²)
+            visc_acc = max(visc_acc, visc_term_dt)
 
             kernel_acc, kernel_grad_acc =
                 compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc,
@@ -588,7 +595,8 @@ using LinearAlgebra
                                              dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
-            visc_acc += abs(h * dot(vᵢ, Position[i])) / (dᵢⱼ^2 + η²)
+            visc_term_dt = dot(vᵢⱼ, xᵢⱼ) / (dᵢⱼ^2 + η²)
+            visc_acc = max(visc_acc, visc_term_dt)
 
             MLcond = MotionLimiter[i] * MotionLimiter[j]
             shift_c_acc += (m₀ / ρᵢ) * ∇ᵢWᵢⱼ
@@ -747,6 +755,7 @@ using LinearAlgebra
 
         @no_escape begin
             max_visc = @alloc(FloatType, length(Position))
+            max_speed = @alloc(FloatType, length(Position))
             min_dt_force = @alloc(FloatType, length(Position))
 
             dt₂ = dt * 0.5
@@ -810,7 +819,7 @@ using LinearAlgebra
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, ParticleRanges, CellDict,
                         NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
-                        max_visc, min_dt_force,
+                        max_visc, max_speed, min_dt_force,
                         Position = Positionₙ⁺,
                         Density = ρₙ⁺,
                         Velocity = Velocityₙ⁺,
@@ -820,7 +829,7 @@ using LinearAlgebra
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, ParticleRanges, CellDict,
                         NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ,
-                        max_visc, min_dt_force,
+                        max_visc, max_speed, min_dt_force,
                         Position = Positionₙ⁺,
                         Density = ρₙ⁺,
                         Velocity = Velocityₙ⁺,
@@ -835,7 +844,7 @@ using LinearAlgebra
             
                 @timeit SimMetaData.HourGlass "12 Update MetaData"                       UpdateMetaData!(SimMetaData, dt)
 
-                @timeit SimMetaData.HourGlass "13 Update TimeStep" dt = FinalizeTimeStep(max_visc, min_dt_force, SimConstants, SimKernel)
+                @timeit SimMetaData.HourGlass "13 Update TimeStep" dt = FinalizeTimeStep(max_visc, max_speed, min_dt_force, SimConstants, SimKernel)
             end
         end
         

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -42,7 +42,7 @@ function FinalizeTimeStep(max_visc, max_speed, min_dt_force, SimulationConstants
     global_speed    = maximum(max_speed)
     global_dt_force = minimum(min_dt_force)
 
-    dt2 = h / (max(c₀, global_speed * 10) + h * global_visc)
+    dt2 = h / (max(c₀, global_speed) + h * global_visc)
     return CFL * min(global_dt_force, dt2)
 end
 
@@ -101,7 +101,7 @@ function Δt(Position, Velocity, Acceleration, SimulationConstants, SPHKernel)
             end
         end
 
-        CFL * min(minimum(d_buffer), h / max(c₀, maximum(v_buffer) * 10))
+        CFL * min(minimum(d_buffer), h / max(c₀, maximum(v_buffer)))
     end
 end
 

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -10,36 +10,39 @@ using ..SimulationEquations
 using ..SimulationGeometry
 using ..SimulationMetaDataConfiguration
 
-@inline function UpdateTimeStepBuffers!(::Nothing, ::Nothing, index, visc_sum,
+@inline function UpdateTimeStepBuffers!(::Nothing, ::Nothing, ::Nothing, index, visc_sum,
                                            position, velocity, acceleration, sim_kernel)
     return nothing
 end
 
-@inline function UpdateTimeStepBuffers!(max_visc, min_dt_force, index, visc_sum,
+@inline function UpdateTimeStepBuffers!(max_visc, max_speed, min_dt_force, index, visc_sum,
                                            position, velocity, acceleration, sim_kernel)
     h             = sim_kernel.h
     a_mag         = norm(acceleration)
-    curr_dt_force = sqrt(h / a_mag)
+    curr_dt_force = a_mag > 0 ? sqrt(h / a_mag) : Inf
+    speed_mag     = norm(velocity)
     @inbounds begin
         max_visc[index] = visc_sum
+        max_speed[index] = speed_mag
         min_dt_force[index] = curr_dt_force
     end
     return nothing
 end
 
 """
-    FinalizeTimeStep(max_visc, min_dt_force, SimulationConstants, SPHKernel)
+    FinalizeTimeStep(max_visc, max_speed, min_dt_force, SimulationConstants, SPHKernel)
 
 Compute the CFL-limited time step from the per-particle buffers.
 """
-function FinalizeTimeStep(max_visc, min_dt_force, SimulationConstants, SPHKernel)
+function FinalizeTimeStep(max_visc, max_speed, min_dt_force, SimulationConstants, SPHKernel)
     @unpack c₀, CFL = SimulationConstants
     @unpack h = SPHKernel
 
     global_visc     = maximum(max_visc)
+    global_speed    = maximum(max_speed)
     global_dt_force = minimum(min_dt_force)
 
-    dt2 = h / (c₀ + global_visc)
+    dt2 = h / (max(c₀, global_speed * 10) + h * global_visc)
     return CFL * min(global_dt_force, dt2)
 end
 
@@ -61,7 +64,7 @@ viscous, and force-based criteria.
 """
 function Δt(Position, Velocity, Acceleration, SimulationConstants, SPHKernel)
     @unpack c₀, CFL = SimulationConstants
-    @unpack h, η²   = SPHKernel
+    @unpack h   = SPHKernel
 
     N = length(Position)
     n_chunks = Threads.nthreads()
@@ -76,18 +79,15 @@ function Δt(Position, Velocity, Acceleration, SimulationConstants, SPHKernel)
                 idx_start = (i - 1) * chunk_size + 1
                 idx_end   = min(i * chunk_size, N)
 
-                t_visc = 0.0
+                t_vel = 0.0
                 t_dt   = Inf
 
                 if idx_start <= idx_end
                     @inbounds for j in idx_start:idx_end
-                        r = Position[j]
                         v = Velocity[j]
                         a = Acceleration[j]
 
-                        r_sq = sqrt(dot(r, r))^2
-                        curr_visc = abs(h * dot(v, r) / (r_sq + η²))
-                        t_visc = max(t_visc, curr_visc)
+                        t_vel = max(t_vel, norm(v))
 
                         a_mag = norm(a)
                         if a_mag > 0
@@ -96,12 +96,12 @@ function Δt(Position, Velocity, Acceleration, SimulationConstants, SPHKernel)
                     end
                 end
 
-                v_buffer[i] = t_visc
+                v_buffer[i] = t_vel
                 d_buffer[i] = t_dt
             end
         end
 
-        CFL * min(minimum(d_buffer), h / (c₀ + maximum(v_buffer)))
+        CFL * min(minimum(d_buffer), h / max(c₀, maximum(v_buffer) * 10))
     end
 end
 


### PR DESCRIPTION
### Motivation
- Fix incorrect viscous timestep accumulation and dot-product use that caused overly small timesteps by following the expected SPH formulation (use relative velocity and separation, and take per-particle maximum rather than summing).
- Ensure the CFL viscous denominator accounts for the actual particle kinematics by tracking the maximum particle speed and comparing it against the speed of sound.
- Avoid invalid / NaN timesteps from zero accelerations by guarding the force-based time-step calculation.

### Description
- Replace per-pair viscous accumulation with a per-particle maximum and compute the viscous limiter as `dot(vᵢⱼ, xᵢⱼ) / (dᵢⱼ^2 + η²)` in all interaction variants inside `src/SPHCellList.jl` instead of using `dot(vᵢ, Position[i])` or summation.
- Add a `max_speed` per-particle buffer: extend `UpdateTimeStepBuffers!` to accept and store `max_speed`, allocate and propagate `max_speed` through neighbor loops, and update calls accordingly.
- Update `FinalizeTimeStep` and `Δt` to incorporate `max_speed` in the CFL denominator by using `h / (max(c₀, global_speed * 10) + h * global_visc)` and change the initial Δt calculation to compute the chunk-wise maximum particle speed instead of the previous viscous proxy.
- Make the force-based dt computation robust by returning `Inf` when acceleration magnitude is zero to avoid dividing by zero.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ac21010d48323a3a8e55c93e829b8)