### PR TITLE
Simplify Δt force timestep calculation

### DIFF
--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -28,7 +28,7 @@ function Δt(max_acceleration, SimulationConstants, SPHKernel)
     @unpack c₀, CFL = SimulationConstants
     @unpack h   = SPHKernel
 
-    dt_force = max_acceleration > 0 ? sqrt(h / max_acceleration) : h / c₀
+    dt_force = sqrt(h / max_acceleration)
     return CFL * min(h / c₀, dt_force)
 end
 


### PR DESCRIPTION
### Motivation
- Use the direct force-based timestep formula and remove the non-positive acceleration guard.

### Description
- Replace `dt_force = max_acceleration > 0 ? sqrt(h / max_acceleration) : h / c₀` with `dt_force = sqrt(h / max_acceleration)` in `src/TimeStepping.jl`.

### Testing
- No automated tests were run; commands executed during the change included `rg -n "function Δt" -S src`, `sed -n '1,120p' src/TimeStepping.jl`, `nl -ba src/TimeStepping.jl | sed -n '20,60p'`, `git add src/TimeStepping.jl`, and `git commit -m "Simplify Δt force timestep"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b85a5b78c8323a8fe06a3eba4d62b)