### PR TITLE
Use dispatch in SimulationLoop

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -700,57 +700,6 @@ using LinearAlgebra
 
     # Per-particle local Δx removed: use single scalar `SimMetaData.Δx`.
 
-    function ApplyMDBCBeforeHalfStep!(SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, NoMDBC, LMode},
-                                      SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
-                                      Position, Density, GhostPoints, GhostNormals, ParticleType) where {
-                                                                                                           Dimensions, FloatType, SMode, KMode, LMode}
-        ApplyMDBCBeforeHalf!(SimMetaData)
-        return nothing
-    end
-
-    function ApplyMDBCBeforeHalfStep!(SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
-                                      SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
-                                      Position, Density, GhostPoints, GhostNormals, ParticleType) where {
-                                                                                                           Dimensions, FloatType, SMode, KMode, BMode, LMode}
-        ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
-                             Position, Density, GhostPoints, GhostNormals, ParticleType)
-        return nothing
-    end
-
-    @inline function RunNeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel,
-                                      SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, NoKernelOutput, BMode, LMode},
-                                      SimConstants, SimParticles, ParticleRanges, CellDict,
-                                      NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax;
-                                      Position = SimParticles.Position, Density = SimParticles.Density, Velocity = SimParticles.Velocity) where {
-                                                                                                             Dimensions, FloatType, SMode, BMode, LMode}
-        NeighborLoopPerParticle!(
-            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-            SimConstants, SimParticles, ParticleRanges, CellDict,
-            NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
-            Position = Position,
-            Density = Density,
-            Velocity = Velocity,
-        )
-        return nothing
-    end
-
-    @inline function RunNeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel,
-                                      SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
-                                      SimConstants, SimParticles, ParticleRanges, CellDict,
-                                      NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax;
-                                      Position = SimParticles.Position, Density = SimParticles.Density, Velocity = SimParticles.Velocity) where {
-                                                                                                             Dimensions, FloatType, SMode, KMode, BMode, LMode}
-        NeighborLoopPerParticle!(
-            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-            SimConstants, SimParticles, ParticleRanges, CellDict,
-            NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
-            Position = Position,
-            Density = Density,
-            Velocity = Velocity,
-        )
-        return nothing
-    end
-
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
                                       SimConstants, SimParticles, FullStencil,
@@ -812,12 +761,12 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "02 Pressure"                              Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
-                @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalfStep!(
+                @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(
                     SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
                     Position, Density, GhostPoints, GhostNormals, ParticleType,
                 )
 
-                @timeit SimMetaData.HourGlass "04 First NeighborLoop" RunNeighborLoop!(
+                @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, ParticleRanges, CellDict,
                     NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
@@ -832,7 +781,7 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "07 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
-                @timeit SimMetaData.HourGlass "08 Second NeighborLoop" RunNeighborLoop!(
+                @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, ParticleRanges, CellDict,
                     NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -700,6 +700,57 @@ using LinearAlgebra
 
     # Per-particle local Δx removed: use single scalar `SimMetaData.Δx`.
 
+    function ApplyMDBCBeforeHalfStep!(SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, NoMDBC, LMode},
+                                      SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
+                                      Position, Density, GhostPoints, GhostNormals, ParticleType) where {
+                                                                                                           Dimensions, FloatType, SMode, KMode, LMode}
+        ApplyMDBCBeforeHalf!(SimMetaData)
+        return nothing
+    end
+
+    function ApplyMDBCBeforeHalfStep!(SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
+                                      SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
+                                      Position, Density, GhostPoints, GhostNormals, ParticleType) where {
+                                                                                                           Dimensions, FloatType, SMode, KMode, BMode, LMode}
+        ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
+                             Position, Density, GhostPoints, GhostNormals, ParticleType)
+        return nothing
+    end
+
+    @inline function RunNeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel,
+                                      SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, NoKernelOutput, BMode, LMode},
+                                      SimConstants, SimParticles, ParticleRanges, CellDict,
+                                      NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax;
+                                      Position = SimParticles.Position, Density = SimParticles.Density, Velocity = SimParticles.Velocity) where {
+                                                                                                             Dimensions, FloatType, SMode, BMode, LMode}
+        NeighborLoopPerParticle!(
+            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+            SimConstants, SimParticles, ParticleRanges, CellDict,
+            NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
+            Position = Position,
+            Density = Density,
+            Velocity = Velocity,
+        )
+        return nothing
+    end
+
+    @inline function RunNeighborLoop!(SimDensityDiffusion, SimViscosity, SimKernel,
+                                      SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
+                                      SimConstants, SimParticles, ParticleRanges, CellDict,
+                                      NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax;
+                                      Position = SimParticles.Position, Density = SimParticles.Density, Velocity = SimParticles.Velocity) where {
+                                                                                                             Dimensions, FloatType, SMode, KMode, BMode, LMode}
+        NeighborLoopPerParticle!(
+            SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+            SimConstants, SimParticles, ParticleRanges, CellDict,
+            NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
+            Position = Position,
+            Density = Density,
+            Velocity = Velocity,
+        )
+        return nothing
+    end
+
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
                                       SimConstants, SimParticles, FullStencil,
@@ -761,25 +812,16 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "02 Pressure"                              Pressure!(SimParticles.Pressure,SimParticles.Density,SimConstants)
-                if SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, KMode, NoMDBC, LMode} where {SMode, KMode, LMode}
-                    @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData)
-                else
-                    @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict, Position, Density, GhostPoints, GhostNormals, ParticleType)
-                end
+                @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalfStep!(
+                    SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
+                    Position, Density, GhostPoints, GhostNormals, ParticleType,
+                )
 
-                if SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, NoKernelOutput, BMode, LMode} where {SMode, BMode, LMode}
-                    @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
-                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
-                        NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
-                    )
-                else
-                    @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
-                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
-                        NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
-                    )
-                end
+                @timeit SimMetaData.HourGlass "04 First NeighborLoop" RunNeighborLoop!(
+                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
+                )
 
 
                 @timeit SimMetaData.HourGlass "05 Update To Half TimeStep"               HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
@@ -790,25 +832,14 @@ using LinearAlgebra
                 @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
             
                 @timeit SimMetaData.HourGlass "07 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺,SimConstants)
-                if SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, NoKernelOutput, BMode, LMode} where {SMode, BMode, LMode}
-                    @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
-                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
-                        NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
-                        Position = Positionₙ⁺,
-                        Density = ρₙ⁺,
-                        Velocity = Velocityₙ⁺,
-                    )
-                else
-                    @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
-                        SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
-                        NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
-                        Position = Positionₙ⁺,
-                        Density = ρₙ⁺,
-                        Velocity = Velocityₙ⁺,
-                    )
-                end
+                @timeit SimMetaData.HourGlass "08 Second NeighborLoop" RunNeighborLoop!(
+                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
+                    Position = Positionₙ⁺,
+                    Density = ρₙ⁺,
+                    Velocity = Velocityₙ⁺,
+                )
 
                 @timeit SimMetaData.HourGlass "09 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
             


### PR DESCRIPTION
### Motivation
- Replace runtime `isa` checks inside `SimulationLoop` with multiple-dispatch helper functions to make control flow clearer and rely on Julia's dispatch for variant behavior.
- Centralize MDBC handling and neighbor-loop invocation to reduce duplication and prepare for future maintenance.

### Description
- Added `ApplyMDBCBeforeHalfStep!` overloads that dispatch on the `SimulationMetaData` MDBC mode and forward to the appropriate `ApplyMDBCBeforeHalf!` implementation.
- Added `RunNeighborLoop!` overloads that dispatch on the kernel-output / neighbor-loop mode and forward to `NeighborLoopPerParticle!` while providing sensible default keyword arguments from `SimParticles`.
- Replaced inline `isa` checks in `SimulationLoop` with calls to `ApplyMDBCBeforeHalfStep!` and `RunNeighborLoop!` so `SimulationLoop` no longer branches on `SimulationMetaData` variants.

### Testing
- No automated tests were run for this change.
- Commands executed during the change include `git status -sb`, `rg "SimulationLoop" -n src`, `sed -n '650,820p' src/SPHCellList.jl`, `rg "function NeighborLoopPerParticle" -n src/SPHCellList.jl`, `sed -n '1,120p' src/SPHCellList.jl`, `nl -ba src/SPHCellList.jl | sed -n '690,820p'`, `nl -ba src/SPHCellList.jl | sed -n '820,940p'`, `git add src/SPHCellList.jl`, and `git commit -m "Use dispatch in SimulationLoop"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b86c12f9883238df4a7a342db43b2)