### PR TITLE
Format kernel output call onto one line

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -506,9 +506,7 @@ using LinearAlgebra
 
             acc_acc += dvdt⁺ + visc_term
 
-            kernel_acc, kernel_grad_acc =
-                compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc,
-                                            SimKernel, q, ∇ᵢWᵢⱼ)
+            kernel_acc, kernel_grad_acc = compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc, SimKernel, q, ∇ᵢWᵢⱼ)
 
             MLcond = MotionLimiter[i] * MotionLimiter[j]
             shift_c_acc += (m₀ / ρᵢ) * ∇ᵢWᵢⱼ

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -490,9 +490,7 @@ using LinearAlgebra
             density_symmetric_term = dot(-vᵢⱼ, ∇ᵢWᵢⱼ)
             dρdt⁺ = -ρᵢ * (m₀ / ρⱼ) * density_symmetric_term
 
-            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel,
-                                              SimConstants, SimParticles, xᵢⱼ,
-                                              ∇ᵢWᵢⱼ, xᵢⱼ², i, j, MotionLimiter)
+            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, xᵢⱼ², i, j, MotionLimiter)
 
             dρdt_acc += dρdt⁺ + Dᵢ
 
@@ -555,9 +553,7 @@ using LinearAlgebra
             f_ab = tensile_correction(SimKernel, Pᵢ, ρᵢ, Pⱼ, ρⱼ, q, dx)
             dvdt⁺ = -m₀ * (Pfac + f_ab) * ∇ᵢWᵢⱼ
 
-            visc_term, _ = compute_viscosity(SimViscosity, SimKernel, SimConstants,
-                                             SimParticles, xᵢⱼ, vᵢⱼ, ∇ᵢWᵢⱼ,
-                                             dᵢⱼ^2, i, j)
+            visc_term, _ = compute_viscosity(SimViscosity, SimKernel, SimConstants, SimParticles, xᵢⱼ, vᵢⱼ, ∇ᵢWᵢⱼ, dᵢⱼ^2, i, j)
 
             acc_acc += dvdt⁺ + visc_term
 


### PR DESCRIPTION
### Motivation
- Keep line formatting consistent by collapsing the kernel output accumulation call into a single line as requested.

### Description
- Replace the multi-line `compute_kernel_output_local(...)` invocation with a single-line call in `src/SPHCellList.jl` to improve consistency and satisfy the formatting request.

### Testing
- No automated tests were run; commands executed were `ls`, `cat AGENTS.md`, `rg -n "compute_kernel_output_local" -S src example`, `sed -n '380,440p' src/SPHCellList.jl`, `sed -n '480,540p' src/SPHCellList.jl`, `git status -sb`, `git add src/SPHCellList.jl`, `git commit -m "Format kernel output call"`, and `nl -ba src/SPHCellList.jl | sed -n '500,530p'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b8c0e11c48323ab36616c0daae9dd)