### PR TITLE
Remove per-particle gravity/motion arrays and derive values from ParticleType

### DIFF
--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -99,28 +99,6 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
     GroupMarker = GroupMarker[sort_perm]
     Idp = Idp[sort_perm]
 
-    GravityFactor = similar(Density)
-    for i ∈ eachindex(GravityFactor)
-        fac = 0
-        if     Types[i] == Fluid
-            fac = -1
-        elseif Types[i] == Moving
-            fac =  1
-        end
-        GravityFactor[i] = fac
-    end
-
-    MotionLimiter = similar(Density)
-    for i ∈ eachindex(MotionLimiter)
-        fac = 0
-        if   Types[i] == Fluid
-            fac =  1
-        else Types[i] == Moving
-            fac =  0
-        end
-        MotionLimiter[i] = fac
-    end
-
     if !RequireKernelOutput && ("Kernel" in OutputVariables || "KernelGradient" in OutputVariables)
         error("Kernel output requires StoreKernelOutput in SimulationMetaData.")
     end
@@ -138,8 +116,6 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
         Velocity = Velocity,
         Density = Density,
         Pressure = Pressureᵢ,
-        GravityFactor = GravityFactor,
-        MotionLimiter = MotionLimiter,
         Type = Types,
         GroupMarker = GroupMarker,
     )
@@ -157,7 +133,7 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
         ParticleFields = merge(ParticleFields, (; GhostNormals = GhostNormals))
     end
     if "BoundaryBool" in OutputVariables
-        BoundaryBool = UInt8.(.!Bool.(MotionLimiter))
+        BoundaryBool = UInt8.(Types .!= Fluid)
         ParticleFields = merge(ParticleFields, (; BoundaryBool = BoundaryBool))
     end
     if "ID" in OutputVariables

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -132,10 +132,6 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
         GhostNormals = zeros(PositionType, NumberOfPoints)
         ParticleFields = merge(ParticleFields, (; GhostNormals = GhostNormals))
     end
-    if "BoundaryBool" in OutputVariables
-        BoundaryBool = UInt8.(Types .!= Fluid)
-        ParticleFields = merge(ParticleFields, (; BoundaryBool = BoundaryBool))
-    end
     if "ID" in OutputVariables
         ParticleFields = merge(ParticleFields, (; ID = Idp))
     end

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -23,6 +23,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     using StaticArrays
 
     using ..AuxiliaryFunctions: to_3d!
+    using ..SimulationGeometry
 
 
     const idType = Int64
@@ -573,7 +574,6 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                 "Pressure" => :Pressure,
                 "Velocity" => :Velocity,
                 "Acceleration" => :Acceleration,
-                "BoundaryBool" => :BoundaryBool,
                 "ID" => :ID,
                 "Type" => :Type,
                 "GroupMarker" => :GroupMarker,
@@ -583,12 +583,14 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             output_data_init = Vector{Any}(undef, length(output_vars))
             for (i, name) in pairs(output_vars)
                 prop = get(field_map, name, nothing)
-                if prop === nothing || !hasproperty(SimParticles, prop)
-                    error("OutputVariables includes $(name) but SimParticles has no field $(name).")
-                end
                 if name == "Type"
                     output_data_init[i] = Int8.(getproperty(SimParticles, prop))
+                elseif name == "BoundaryBool"
+                    output_data_init[i] = UInt8.(SimParticles.Type .!= Fluid)
                 else
+                    if prop === nothing || !hasproperty(SimParticles, prop)
+                        error("OutputVariables includes $(name) but SimParticles has no field $(name).")
+                    end
                     output_data_init[i] = getproperty(SimParticles, prop)
                 end
             end
@@ -636,7 +638,6 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             "Pressure" => :Pressure,
             "Velocity" => :Velocity,
             "Acceleration" => :Acceleration,
-            "BoundaryBool" => :BoundaryBool,
             "ID" => :ID,
             "Type" => :Type,
             "GroupMarker" => :GroupMarker,
@@ -654,6 +655,8 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                     output_data[i] = Vector{SVector{3, T}}(undef, n)
                 elseif name == "Type"
                     output_data[i] = Vector{Int8}(undef, n)
+                elseif name == "BoundaryBool"
+                    output_data[i] = Vector{UInt8}(undef, n)
                 else
                     prop = field_map[name]
                     if !hasproperty(SimParticles, prop)
@@ -679,6 +682,11 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                     src = SimParticles.Type
                     @inbounds for j in eachindex(src)
                         buf[j] = Int8(src[j])
+                    end
+                elseif name == "BoundaryBool"
+                    src = SimParticles.Type
+                    @inbounds for j in eachindex(src)
+                        buf[j] = UInt8(src[j] != Fluid)
                     end
                 elseif name in vector_fields
                     prop = field_map[name]

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -45,7 +45,8 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        @unpack Cells, MotionLimiter = SimParticles
+        @unpack Cells = SimParticles
+        ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -59,14 +60,14 @@ using LinearAlgebra
                 dρdt_acc, acc_acc = ComputeInteractionsPerParticleNoKernel!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, Position, Density, Pressure,
-                    Velocity, MotionLimiter, dρdt_acc, acc_acc, i, j,
+                    Velocity, ParticleType, dρdt_acc, acc_acc, i, j,
                 )
             end
             @inbounds for j in (i + 1):SameCellEnd
                 dρdt_acc, acc_acc = ComputeInteractionsPerParticleNoKernel!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, Position, Density, Pressure,
-                    Velocity, MotionLimiter, dρdt_acc, acc_acc, i, j,
+                    Velocity, ParticleType, dρdt_acc, acc_acc, i, j,
                 )
             end
             for NeighborIdx in NeighborCellIndices
@@ -76,7 +77,7 @@ using LinearAlgebra
                     dρdt_acc, acc_acc = ComputeInteractionsPerParticleNoKernel!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
-                        Velocity, MotionLimiter, dρdt_acc, acc_acc, i, j,
+                        Velocity, ParticleType, dρdt_acc, acc_acc, i, j,
                     )
                 end
             end
@@ -103,7 +104,8 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        @unpack Cells, MotionLimiter, Kernel, KernelGradient = SimParticles
+        @unpack Cells, Kernel, KernelGradient = SimParticles
+        ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -120,7 +122,7 @@ using LinearAlgebra
                     ComputeInteractionsPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
-                        Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                        Velocity, ParticleType, dρdt_acc, acc_acc, kernel_acc,
                         kernel_grad_acc, i, j,
                     )
             end
@@ -129,7 +131,7 @@ using LinearAlgebra
                     ComputeInteractionsPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
-                        Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                        Velocity, ParticleType, dρdt_acc, acc_acc, kernel_acc,
                         kernel_grad_acc, i, j,
                     )
             end
@@ -141,7 +143,7 @@ using LinearAlgebra
                         ComputeInteractionsPerParticle!(
                             SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                             SimConstants, SimParticles, Position, Density, Pressure,
-                            Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                            Velocity, ParticleType, dρdt_acc, acc_acc, kernel_acc,
                             kernel_grad_acc, i, j,
                         )
                 end
@@ -170,7 +172,8 @@ using LinearAlgebra
                                                   S<:ShiftingMode,B<:MDBCMode,
                                                   L<:LogMode,SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        @unpack Cells, MotionLimiter = SimParticles
+        @unpack Cells = SimParticles
+        ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -187,7 +190,7 @@ using LinearAlgebra
                     ComputeInteractionsPerParticleNoKernel!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
-                        Velocity, MotionLimiter, dρdt_acc, acc_acc, shift_c_acc,
+                        Velocity, ParticleType, dρdt_acc, acc_acc, shift_c_acc,
                         shift_r_acc, i, j,
                     )
             end
@@ -196,7 +199,7 @@ using LinearAlgebra
                     ComputeInteractionsPerParticleNoKernel!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
-                        Velocity, MotionLimiter, dρdt_acc, acc_acc, shift_c_acc,
+                        Velocity, ParticleType, dρdt_acc, acc_acc, shift_c_acc,
                         shift_r_acc, i, j,
                     )
             end
@@ -208,7 +211,7 @@ using LinearAlgebra
                         ComputeInteractionsPerParticleNoKernel!(
                             SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                             SimConstants, SimParticles, Position, Density, Pressure,
-                            Velocity, MotionLimiter, dρdt_acc, acc_acc, shift_c_acc,
+                            Velocity, ParticleType, dρdt_acc, acc_acc, shift_c_acc,
                             shift_r_acc, i, j,
                         )
                 end
@@ -239,7 +242,8 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        @unpack Cells, MotionLimiter, Kernel, KernelGradient = SimParticles
+        @unpack Cells, Kernel, KernelGradient = SimParticles
+        ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
@@ -258,7 +262,7 @@ using LinearAlgebra
                     shift_r_acc = ComputeInteractionsPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, Position, Density, Pressure,
-                    Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                    Velocity, ParticleType, dρdt_acc, acc_acc, kernel_acc,
                     kernel_grad_acc, shift_c_acc, shift_r_acc, i, j,
                 )
             end
@@ -267,7 +271,7 @@ using LinearAlgebra
                     shift_r_acc = ComputeInteractionsPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, Position, Density, Pressure,
-                    Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                    Velocity, ParticleType, dρdt_acc, acc_acc, kernel_acc,
                     kernel_grad_acc, shift_c_acc, shift_r_acc, i, j,
                 )
             end
@@ -279,7 +283,7 @@ using LinearAlgebra
                         shift_r_acc = ComputeInteractionsPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, Position, Density, Pressure,
-                        Velocity, MotionLimiter, dρdt_acc, acc_acc, kernel_acc,
+                        Velocity, ParticleType, dρdt_acc, acc_acc, kernel_acc,
                         kernel_grad_acc, shift_c_acc, shift_r_acc, i, j,
                     )
                 end
@@ -370,7 +374,7 @@ using LinearAlgebra
     Base.@propagate_inbounds function ComputeInteractionsPerParticle!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L}, SimConstants,
-        SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
+        SimParticles, Position, Density, Pressure, Velocity, ParticleType,
             dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, i, j) where {D,T,
                                                                       K<:KernelOutputMode,
                                                                       B<:MDBCMode,
@@ -397,7 +401,7 @@ using LinearAlgebra
             density_symmetric_term = dot(-vᵢⱼ, ∇ᵢWᵢⱼ)
             dρdt⁺ = -ρᵢ * (m₀ / ρⱼ) * density_symmetric_term
 
-            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, dᵢⱼ², i, j, MotionLimiter)
+            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, dᵢⱼ², i, j, ParticleType)
 
             dρdt_acc += dρdt⁺ + Dᵢ
 
@@ -420,7 +424,7 @@ using LinearAlgebra
     Base.@propagate_inbounds function ComputeInteractionsPerParticleNoKernel!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L}, SimConstants,
-        SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
+        SimParticles, Position, Density, Pressure, Velocity, ParticleType,
         dρdt_acc, acc_acc, i, j) where {D,T,B<:MDBCMode,L<:LogMode,
                                         SDD<:SPHDensityDiffusion,
                                         SV<:SPHViscosity}
@@ -444,7 +448,7 @@ using LinearAlgebra
             density_symmetric_term = dot(-vᵢⱼ, ∇ᵢWᵢⱼ)
             dρdt⁺ = -ρᵢ * (m₀ / ρⱼ) * density_symmetric_term
 
-            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, dᵢⱼ², i, j, MotionLimiter)
+            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, dᵢⱼ², i, j, ParticleType)
 
             dρdt_acc += dρdt⁺ + Dᵢ
 
@@ -465,7 +469,7 @@ using LinearAlgebra
     Base.@propagate_inbounds function ComputeInteractionsPerParticle!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,S,K,B,L}, SimConstants,
-        SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
+        SimParticles, Position, Density, Pressure, Velocity, ParticleType,
         dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
         shift_r_acc, i, j) where {D,T,S<:ShiftingMode,
                                   K<:KernelOutputMode,
@@ -493,7 +497,7 @@ using LinearAlgebra
             density_symmetric_term = dot(-vᵢⱼ, ∇ᵢWᵢⱼ)
             dρdt⁺ = -ρᵢ * (m₀ / ρⱼ) * density_symmetric_term
 
-            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, dᵢⱼ², i, j, MotionLimiter)
+            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, dᵢⱼ², i, j, ParticleType)
 
             dρdt_acc += dρdt⁺ + Dᵢ
 
@@ -509,7 +513,7 @@ using LinearAlgebra
 
             kernel_acc, kernel_grad_acc = compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc, SimKernel, q, ∇ᵢWᵢⱼ)
 
-            MLcond = MotionLimiter[i] * MotionLimiter[j]
+            MLcond = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
             shift_c_acc += (m₀ / ρᵢ) * ∇ᵢWᵢⱼ
             shift_r_acc += (m₀ / ρⱼ) * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
         end
@@ -520,7 +524,7 @@ using LinearAlgebra
     Base.@propagate_inbounds function ComputeInteractionsPerParticleNoKernel!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,S,NoKernelOutput,B,L}, SimConstants,
-        SimParticles, Position, Density, Pressure, Velocity, MotionLimiter,
+        SimParticles, Position, Density, Pressure, Velocity, ParticleType,
         dρdt_acc, acc_acc, shift_c_acc, shift_r_acc, i, j) where {D,T,
                                                                   S<:ShiftingMode,
                                                                   B<:MDBCMode,
@@ -547,7 +551,7 @@ using LinearAlgebra
             density_symmetric_term = dot(-vᵢⱼ, ∇ᵢWᵢⱼ)
             dρdt⁺ = -ρᵢ * (m₀ / ρⱼ) * density_symmetric_term
 
-            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, dᵢⱼ², i, j, MotionLimiter)
+            Dᵢ, _ = compute_density_diffusion(SimDensityDiffusion, SimKernel, SimConstants, SimParticles, xᵢⱼ, ∇ᵢWᵢⱼ, dᵢⱼ², i, j, ParticleType)
 
             dρdt_acc += dρdt⁺ + Dᵢ
 
@@ -561,7 +565,7 @@ using LinearAlgebra
 
             acc_acc += dvdt⁺ + visc_term
 
-            MLcond = MotionLimiter[i] * MotionLimiter[j]
+            MLcond = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
             shift_c_acc += (m₀ / ρᵢ) * ∇ᵢWᵢⱼ
             shift_r_acc += (m₀ / ρⱼ) * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
         end
@@ -704,8 +708,7 @@ using LinearAlgebra
                                                 BMode, LMode,
                                                 SDD<:SPHDensityDiffusion,
                                                 SV<:SPHViscosity}
-        @unpack Position, Density, Pressure, Velocity, Acceleration, MotionLimiter,
-                GroupMarker = SimParticles
+        @unpack Position, Density, Pressure, Velocity, Acceleration, GroupMarker = SimParticles
         ParticleType   = SimParticles.Type
         ParticleMarker = GroupMarker
         GhostPoints    = hasproperty(SimParticles, :GhostPoints) ? SimParticles.GhostPoints : nothing
@@ -777,7 +780,7 @@ using LinearAlgebra
 
                     @timeit SimMetaData.HourGlass "05 Update To Half TimeStep"               HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
 
-                    @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary"           LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, MotionLimiter)
+                    @timeit SimMetaData.HourGlass "06 Half LimitDensityAtBoundary"           LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, ParticleType)
 
                     @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
 
@@ -798,7 +801,7 @@ using LinearAlgebra
 
                     @timeit SimMetaData.HourGlass "03 Update To Half TimeStep"               HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
 
-                    @timeit SimMetaData.HourGlass "04 Half LimitDensityAtBoundary"           LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, MotionLimiter)
+                    @timeit SimMetaData.HourGlass "04 Half LimitDensityAtBoundary"           LimitDensityAtBoundary!(ρₙ⁺, SimConstants.ρ₀, ParticleType)
 
                     @timeit SimMetaData.HourGlass "Motion"                                   ProgressMotion(SimParticles, dt₂, MotionDefinition, SimMetaData)
 
@@ -815,7 +818,7 @@ using LinearAlgebra
 
                 @timeit SimMetaData.HourGlass "07 Final Density"                         DensityEpsi!(Density, dρdtI, ρₙ⁺, dt)
 
-                @timeit SimMetaData.HourGlass "08 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, MotionLimiter)
+                @timeit SimMetaData.HourGlass "08 Final LimitDensityAtBoundary"          LimitDensityAtBoundary!(Density, SimConstants.ρ₀, ParticleType)
 
                 @timeit SimMetaData.HourGlass "09 Update To Final TimeStep"              FullTimeStep(SimMetaData, SimKernel, SimConstants, SimParticles, Velocityₙ⁺, ∇Cᵢ, ∇◌rᵢ, dt)
 

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -513,9 +513,9 @@ using LinearAlgebra
 
             kernel_acc, kernel_grad_acc = compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc, SimKernel, q, ∇ᵢWᵢⱼ)
 
-            MLcond = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
+            MotionLimiterCondition = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
             shift_c_acc += (m₀ / ρᵢ) * ∇ᵢWᵢⱼ
-            shift_r_acc += (m₀ / ρⱼ) * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
+            shift_r_acc += (m₀ / ρⱼ) * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MotionLimiterCondition
         end
 
         return dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc, shift_r_acc
@@ -565,9 +565,9 @@ using LinearAlgebra
 
             acc_acc += dvdt⁺ + visc_term
 
-            MLcond = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
+            MotionLimiterCondition = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
             shift_c_acc += (m₀ / ρᵢ) * ∇ᵢWᵢⱼ
-            shift_r_acc += (m₀ / ρⱼ) * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
+            shift_r_acc += (m₀ / ρⱼ) * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MotionLimiterCondition
         end
 
         return dρdt_acc, acc_acc, shift_c_acc, shift_r_acc

--- a/src/SPHDensityDiffusionModels.jl
+++ b/src/SPHDensityDiffusionModels.jl
@@ -128,9 +128,9 @@ struct LinearDensityDiffusion <: SPHDensityDiffusion end
         ρⱼᵢ = ρⱼ - ρᵢ
         ψᵢⱼ = 2 * (ρⱼᵢ - ρᵢⱼᴴ)  * (-xᵢⱼ) * invdᵢⱼ²η²
 
-        MLcond = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
+        MotionLimiterCondition = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
 
-        Dᵢ  = δᵩ * h * c₀ * (m₀/ρⱼ) * dot(ψᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
+        Dᵢ  = δᵩ * h * c₀ * (m₀/ρⱼ) * dot(ψᵢⱼ, ∇ᵢWᵢⱼ) * MotionLimiterCondition
         Dⱼ  = -Dᵢ
 
         return Dᵢ, Dⱼ
@@ -180,9 +180,9 @@ struct ComplexDensityDiffusion <: SPHDensityDiffusion end
         ρⱼᵢ = ρⱼ - ρᵢ
         ψᵢⱼ = 2 * (ρⱼᵢ - ρᵢⱼᴴ)  * (-xᵢⱼ) * invdᵢⱼ²η²
 
-        MLcond = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
+        MotionLimiterCondition = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
 
-        Dᵢ  = δᵩ * h * c₀ * (m₀/ρⱼ) * dot(ψᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
+        Dᵢ  = δᵩ * h * c₀ * (m₀/ρⱼ) * dot(ψᵢⱼ, ∇ᵢWᵢⱼ) * MotionLimiterCondition
         Dⱼ  = -Dᵢ
 
         return Dᵢ, Dⱼ

--- a/src/SPHDensityDiffusionModels.jl
+++ b/src/SPHDensityDiffusionModels.jl
@@ -2,6 +2,7 @@ module SPHDensityDiffusionModels
 
 using StaticArrays, LinearAlgebra, Parameters
 using ..SimulationEquations
+using ..SimulationGeometry
 #---------------------------------------------------------------
 # Exported
 #---------------------------------------------------------------
@@ -39,7 +40,7 @@ struct ZeroDensityDiffusion <: SPHDensityDiffusion end
         d²,
         i,
         j,
-        MotionLimiter
+        ParticleType
 )
         return zero(d²), zero(d²)
 end
@@ -63,7 +64,7 @@ struct ZeroGravityLinearDensityDiffusion <: SPHDensityDiffusion end
         d²,
         i,
         j,
-        MotionLimiter
+        ParticleType
 )
 
         @unpack ρ₀, m₀, c₀, δᵩ, Cb, Cb⁻¹, γ    = SimConstants
@@ -107,7 +108,7 @@ struct LinearDensityDiffusion <: SPHDensityDiffusion end
         d²,
         i,
         j,
-        MotionLimiter
+        ParticleType
 )
 
         @unpack ρ₀, m₀, c₀, δᵩ, Cb, Cb⁻¹, γ, g = SimConstants
@@ -127,7 +128,7 @@ struct LinearDensityDiffusion <: SPHDensityDiffusion end
         ρⱼᵢ = ρⱼ - ρᵢ
         ψᵢⱼ = 2 * (ρⱼᵢ - ρᵢⱼᴴ)  * (-xᵢⱼ) * invdᵢⱼ²η²
 
-        MLcond = MotionLimiter[i] * MotionLimiter[j]
+        MLcond = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
 
         Dᵢ  = δᵩ * h * c₀ * (m₀/ρⱼ) * dot(ψᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
         Dⱼ  = -Dᵢ
@@ -157,7 +158,7 @@ struct ComplexDensityDiffusion <: SPHDensityDiffusion end
         d²,
         i,
         j,
-        MotionLimiter
+        ParticleType
 )
 
         @unpack ρ₀, m₀, c₀, δᵩ, Cb, Cb⁻¹, γ, g = SimConstants
@@ -179,7 +180,7 @@ struct ComplexDensityDiffusion <: SPHDensityDiffusion end
         ρⱼᵢ = ρⱼ - ρᵢ
         ψᵢⱼ = 2 * (ρⱼᵢ - ρᵢⱼᴴ)  * (-xᵢⱼ) * invdᵢⱼ²η²
 
-        MLcond = MotionLimiter[i] * MotionLimiter[j]
+        MLcond = MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
 
         Dᵢ  = δᵩ * h * c₀ * (m₀/ρⱼ) * dot(ψᵢⱼ, ∇ᵢWᵢⱼ) * MLcond
         Dⱼ  = -Dᵢ

--- a/src/SimulationEquations.jl
+++ b/src/SimulationEquations.jl
@@ -36,7 +36,7 @@ end
 # This version of the function uses ParticleType instead of BoundaryBool
 @inline function LimitDensityAtBoundary!(Density, ρ₀, ParticleType)
     @inbounds for i in eachindex(Density)
-        if (Density[i] < ρ₀) * (ParticleType[i] != Fluid)
+        if (Density[i] < ρ₀) && (ParticleType[i] != Fluid)
             Density[i] = ρ₀
         end
     end

--- a/src/SimulationEquations.jl
+++ b/src/SimulationEquations.jl
@@ -5,6 +5,7 @@ export EquationOfState, EquationOfStateGamma7, Pressure!, DensityEpsi!, LimitDen
 using StaticArrays
 using Parameters
 using FastPow
+using ..SimulationGeometry
 
 @inline function EquationOfStateGamma7(ρ,c₀,ρ₀)
     return @fastpow ((c₀^2*ρ₀)/7) * ((ρ/ρ₀)^7 - 1)
@@ -32,10 +33,10 @@ end
     end
 end
 
-# This version of the function using !Bool(MotionLimiter) instead of BoundaryBool
-@inline function LimitDensityAtBoundary!(Density,ρ₀, MotionLimiter)
+# This version of the function uses ParticleType instead of BoundaryBool
+@inline function LimitDensityAtBoundary!(Density, ρ₀, ParticleType)
     @inbounds for i in eachindex(Density)
-        if (Density[i] < ρ₀) * !Bool(MotionLimiter[i])
+        if (Density[i] < ρ₀) * (ParticleType[i] != Fluid)
             Density[i] = ρ₀
         end
     end

--- a/src/SimulationGeometry.jl
+++ b/src/SimulationGeometry.jl
@@ -4,13 +4,26 @@ using StaticArrays
 using Parameters
 
 # Export relevant types and structs
-export ParticleType, Geometry, Fluid, Fixed, Moving, MotionDetails
+export ParticleType, Geometry, Fluid, Fixed, Moving, MotionDetails, GravityFactorValue, MotionLimiterValue
 
 # Use the existing @enum for ParticleType
 @enum ParticleType::UInt8 begin
     Fluid  = UInt8(1)
     Fixed  = UInt8(2)
     Moving = UInt8(3)
+end
+
+@inline function GravityFactorValue(::Type{T}, particle_type::ParticleType) where {T}
+    if particle_type == Fluid
+        return -one(T)
+    elseif particle_type == Moving
+        return one(T)
+    end
+    return zero(T)
+end
+
+@inline function MotionLimiterValue(::Type{T}, particle_type::ParticleType) where {T}
+    return particle_type == Fluid ? one(T) : zero(T)
 end
 
 # Define a struct to store motion details, with parametric dimensions and floating point type

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -84,11 +84,11 @@ function HalfTimeStep(::SimulationMetaData{Dimensions, FloatType, SMode, KMode, 
     AccelerationScalarType = eltype(eltype(Acceleration))
 
     @inbounds @simd ivdep for i in eachindex(Position)
-        motion_limiter = MotionLimiterValue(AccelerationScalarType, ParticleType[i])
-        gravity_factor = GravityFactorValue(AccelerationScalarType, ParticleType[i])
-        Acceleration[i]  +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * gravity_factor)
-        Positionₙ⁺[i]     =  Position[i]   + Velocity[i]   * dt₂  * motion_limiter
-        Velocityₙ⁺[i]     =  Velocity[i]   + Acceleration[i]  *  dt₂ * motion_limiter
+        MotionLimiterFactor = MotionLimiterValue(AccelerationScalarType, ParticleType[i])
+        GravityFactor = GravityFactorValue(AccelerationScalarType, ParticleType[i])
+        Acceleration[i]  +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor)
+        Positionₙ⁺[i]     =  Position[i]   + Velocity[i]   * dt₂  * MotionLimiterFactor
+        Velocityₙ⁺[i]     =  Velocity[i]   + Acceleration[i]  *  dt₂ * MotionLimiterFactor
         ρₙ⁺[i]            =  Density[i]    + dρdtI[i]       *  dt₂
     end
 
@@ -104,11 +104,11 @@ function FullTimeStep(::SimulationMetaData{D,T,NoShifting,K,B,L}, SimKernel,
     ParticleType = SimParticles.Type
     AccelerationScalarType = eltype(eltype(Acceleration))
     @inbounds @simd ivdep for i in eachindex(Position)
-        motion_limiter = MotionLimiterValue(AccelerationScalarType, ParticleType[i])
-        gravity_factor = GravityFactorValue(AccelerationScalarType, ParticleType[i])
-        Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * gravity_factor)
-        Velocity[i]       +=  Acceleration[i] * dt * motion_limiter
-        Position[i]       +=  (Velocityₙ⁺[i] * dt) * motion_limiter
+        MotionLimiterFactor = MotionLimiterValue(AccelerationScalarType, ParticleType[i])
+        GravityFactor = GravityFactorValue(AccelerationScalarType, ParticleType[i])
+        Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor)
+        Velocity[i]       +=  Acceleration[i] * dt * MotionLimiterFactor
+        Position[i]       +=  (Velocityₙ⁺[i] * dt) * MotionLimiterFactor
     end
     return nothing
 end
@@ -125,10 +125,10 @@ function FullTimeStep(::SimulationMetaData{D,T,S,K,B,L}, SimKernel, SimConstants
     A_FST = 0; # zero for internal flows
     A_FSM = length(first(Position)); #2d, 3d val different
     @inbounds @simd ivdep for i in eachindex(Position)
-        motion_limiter = MotionLimiterValue(AccelerationScalarType, ParticleType[i])
-        gravity_factor = GravityFactorValue(AccelerationScalarType, ParticleType[i])
-        Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * gravity_factor)
-        Velocity[i]       +=  Acceleration[i] * dt * motion_limiter
+        MotionLimiterFactor = MotionLimiterValue(AccelerationScalarType, ParticleType[i])
+        GravityFactor = GravityFactorValue(AccelerationScalarType, ParticleType[i])
+        Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor)
+        Velocity[i]       +=  Acceleration[i] * dt * MotionLimiterFactor
 
         A_FSC                  = (∇◌rᵢ[i] - A_FST)/(A_FSM - A_FST)
         if A_FSC < 0
@@ -137,7 +137,7 @@ function FullTimeStep(::SimulationMetaData{D,T,S,K,B,L}, SimKernel, SimConstants
             δxᵢ = -A_FSC * A * SimKernel.h * norm(Velocityₙ⁺[i]) * dt * ∇Cᵢ[i]
         end
 
-        Position[i]           += (Velocityₙ⁺[i] * dt + δxᵢ) * motion_limiter
+        Position[i]           += (Velocityₙ⁺[i] * dt + δxᵢ) * MotionLimiterFactor
     end
     return nothing
 end

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -79,12 +79,16 @@ end
 function HalfTimeStep(::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
                           SimConstants, SimParticles, Positionₙ⁺,
                           Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}
-    @unpack Position, Density, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
+    @unpack Position, Density, Velocity, Acceleration = SimParticles
+    ParticleType = SimParticles.Type
+    AccelerationScalarType = eltype(eltype(Acceleration))
 
     @inbounds @simd ivdep for i in eachindex(Position)
-        Acceleration[i]  +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
-        Positionₙ⁺[i]     =  Position[i]   + Velocity[i]   * dt₂  * MotionLimiter[i]
-        Velocityₙ⁺[i]     =  Velocity[i]   + Acceleration[i]  *  dt₂ * MotionLimiter[i]
+        motion_limiter = MotionLimiterValue(AccelerationScalarType, ParticleType[i])
+        gravity_factor = GravityFactorValue(AccelerationScalarType, ParticleType[i])
+        Acceleration[i]  +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * gravity_factor)
+        Positionₙ⁺[i]     =  Position[i]   + Velocity[i]   * dt₂  * motion_limiter
+        Velocityₙ⁺[i]     =  Velocity[i]   + Acceleration[i]  *  dt₂ * motion_limiter
         ρₙ⁺[i]            =  Density[i]    + dρdtI[i]       *  dt₂
     end
 
@@ -96,11 +100,15 @@ function FullTimeStep(::SimulationMetaData{D,T,NoShifting,K,B,L}, SimKernel,
                                                                              K<:KernelOutputMode,
                                                                              B<:MDBCMode,
                                                                              L<:LogMode}
-    @unpack Position, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
+    @unpack Position, Velocity, Acceleration = SimParticles
+    ParticleType = SimParticles.Type
+    AccelerationScalarType = eltype(eltype(Acceleration))
     @inbounds @simd ivdep for i in eachindex(Position)
-        Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
-        Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
-        Position[i]       +=  (Velocityₙ⁺[i] * dt) * MotionLimiter[i]
+        motion_limiter = MotionLimiterValue(AccelerationScalarType, ParticleType[i])
+        gravity_factor = GravityFactorValue(AccelerationScalarType, ParticleType[i])
+        Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * gravity_factor)
+        Velocity[i]       +=  Acceleration[i] * dt * motion_limiter
+        Position[i]       +=  (Velocityₙ⁺[i] * dt) * motion_limiter
     end
     return nothing
 end
@@ -110,13 +118,17 @@ function FullTimeStep(::SimulationMetaData{D,T,S,K,B,L}, SimKernel, SimConstants
                                                              K<:KernelOutputMode,
                                                              B<:MDBCMode,
                                                              L<:LogMode}
-    @unpack Position, Velocity, Acceleration, GravityFactor, MotionLimiter = SimParticles
+    @unpack Position, Velocity, Acceleration = SimParticles
+    ParticleType = SimParticles.Type
+    AccelerationScalarType = eltype(eltype(Acceleration))
     A     = 2# Value between 1 to 6 advised
     A_FST = 0; # zero for internal flows
     A_FSM = length(first(Position)); #2d, 3d val different
     @inbounds @simd ivdep for i in eachindex(Position)
-        Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * GravityFactor[i])
-        Velocity[i]       +=  Acceleration[i] * dt * MotionLimiter[i]
+        motion_limiter = MotionLimiterValue(AccelerationScalarType, ParticleType[i])
+        gravity_factor = GravityFactorValue(AccelerationScalarType, ParticleType[i])
+        Acceleration[i]   +=  ConstructGravitySVector(Acceleration[i], SimConstants.g * gravity_factor)
+        Velocity[i]       +=  Acceleration[i] * dt * motion_limiter
 
         A_FSC                  = (∇◌rᵢ[i] - A_FST)/(A_FSM - A_FST)
         if A_FSC < 0
@@ -125,7 +137,7 @@ function FullTimeStep(::SimulationMetaData{D,T,S,K,B,L}, SimKernel, SimConstants
             δxᵢ = -A_FSC * A * SimKernel.h * norm(Velocityₙ⁺[i]) * dt * ∇Cᵢ[i]
         end
 
-        Position[i]           += (Velocityₙ⁺[i] * dt + δxᵢ) * MotionLimiter[i]
+        Position[i]           += (Velocityₙ⁺[i] * dt + δxᵢ) * motion_limiter
     end
     return nothing
 end


### PR DESCRIPTION
### Motivation
- Remove stored per-particle `GravityFactor` and `MotionLimiter` arrays to avoid keeping redundant arrays while preserving runtime behaviour by computing values on demand. 
- Simplify particle storage and I/O by deriving boundary flags directly from `ParticleType` instead of storing extra boolean/float arrays. 

### Description
- Added `GravityFactorValue(::Type{T}, ::ParticleType)` and `MotionLimiterValue(::Type{T}, ::ParticleType)` helpers in `src/SimulationGeometry.jl` to compute gravity and motion factors on demand. 
- Dropped allocation and storage of `GravityFactor` and `MotionLimiter` in `src/PreProcess.jl` and changed `BoundaryBool` output to `UInt8.(Types .!= Fluid)`. 
- Replaced uses of stored motion/gravity arrays with `ParticleType` + helpers across the timestepping code in `src/TimeStepping.jl` (half/full steps and symplectic path). 
- Updated solver loops in `src/SPHCellList.jl` and density diffusion in `src/SPHDensityDiffusionModels.jl` to pass `ParticleType` and use `MotionLimiterValue` for shifting/diffusion conditions, and changed `LimitDensityAtBoundary!` in `src/SimulationEquations.jl` to accept `ParticleType` instead of motion flags. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f871feb8c832389318b95c2816e30)