### PR TITLE
Replace cell dict with per-particle index lookups

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -18,7 +18,7 @@ using ..OpenExternalPrograms
 using ..SPHKernels
 using ..SPHViscosityModels
 using ..SPHDensityDiffusionModels
-using ..SPHNeighborList: BuildNeighborCellLists!, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, MapFloor, UpdateNeighbors!, UpdateΔx!
+using ..SPHNeighborList: BuildNeighborCellLists!, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, FindCellIndex, MapFloor, UpdateNeighbors!, UpdateΔx!
 
 using StaticArrays
 using StructArrays: StructArray, foreachfield
@@ -35,7 +35,7 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, dρdtI,
+                                      CellListIndices, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
                                       Position = SimParticles.Position,
@@ -45,13 +45,11 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        @unpack Cells = SimParticles
         ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
-            CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
+            CellListIndex = CellListIndices[i]
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
             NeighborCellIndices = NeighborCellLists[CellListIndex]
@@ -93,7 +91,7 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, dρdtI,
+                                      CellListIndices, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
                                       Position = SimParticles.Position,
@@ -104,15 +102,14 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        @unpack Cells, Kernel, KernelGradient = SimParticles
+        @unpack Kernel, KernelGradient = SimParticles
         ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
             kernel_acc = zero(Kernel[i])
             kernel_grad_acc = zero(KernelGradient[i])
-            CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
+            CellListIndex = CellListIndices[i]
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
             NeighborCellIndices = NeighborCellLists[CellListIndex]
@@ -162,7 +159,7 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, dρdtI,
+                                      CellListIndices, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
                                       Position = SimParticles.Position,
@@ -172,15 +169,13 @@ using LinearAlgebra
                                                   S<:ShiftingMode,B<:MDBCMode,
                                                   L<:LogMode,SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        @unpack Cells = SimParticles
         ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
             shift_c_acc = zero(∇Cᵢ[i])
             shift_r_acc = zero(∇◌rᵢ[i])
-            CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
+            CellListIndex = CellListIndices[i]
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
             NeighborCellIndices = NeighborCellLists[CellListIndex]
@@ -230,7 +225,7 @@ using LinearAlgebra
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellDict, NeighborCellLists, dρdtI,
+                                      CellListIndices, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
                                       Position = SimParticles.Position,
@@ -242,7 +237,7 @@ using LinearAlgebra
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
-        @unpack Cells, Kernel, KernelGradient = SimParticles
+        @unpack Kernel, KernelGradient = SimParticles
         ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
@@ -251,8 +246,7 @@ using LinearAlgebra
             kernel_grad_acc = zero(KernelGradient[i])
             shift_c_acc = zero(∇Cᵢ[i])
             shift_r_acc = zero(∇◌rᵢ[i])
-            CellIndex = Cells[i]
-            CellListIndex = get(CellDict, CellIndex, 1)
+            CellListIndex = CellListIndices[i]
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
             NeighborCellIndices = NeighborCellLists[CellListIndex]
@@ -304,7 +298,7 @@ using LinearAlgebra
     f(SimKernel, GhostPoint) = CartesianIndex(map(x -> MapFloor(x, SimKernel.H⁻¹), Tuple(GhostPoint)))
     function NeighborLoopMDBC!(SimKernel,
                                SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
-                               SimConstants, ParticleRanges, CellDict, Position,
+                               SimConstants, ParticleRanges, UniqueCellsView, Position,
                                Density, GhostPoints, GhostNormals, ParticleType,
                                bᵧ, Aᵧ) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}
         
@@ -326,7 +320,7 @@ using LinearAlgebra
                     # Returns a range, x>:x for exact match and x=:x for no match
                     # utilizes that it is a sorted array and requires no isequal constructor,
                     # so I prefer this for now
-                    NeighborIdx = get(CellDict, SCellIndex, 1)
+                    NeighborIdx = FindCellIndex(UniqueCellsView, SCellIndex)
 
                     StartIndex_       = ParticleRanges[NeighborIdx] 
                     EndIndex_         = ParticleRanges[NeighborIdx + 1] - 1
@@ -627,14 +621,15 @@ using LinearAlgebra
 
     function ApplyMDBCBeforeHalf!(SimMetaData::SimulationMetaData{D,T,S,K,SimpleMDBC,L},
                                   SimKernel, SimConstants, SimParticles,
-                                  ParticleRanges, CellDict, Position, Density,
+                                  ParticleRanges, UniqueCells, Position, Density,
                                   GhostPoints, GhostNormals, ParticleType
                                  ) where {D,T,S<:ShiftingMode,K<:KernelOutputMode,L<:LogMode}
         @no_escape begin
             DimensionsPlus = D + 1
             bᵧ = @alloc(SVector{DimensionsPlus, T}, length(Position))
             Aᵧ = @alloc(SMatrix{DimensionsPlus, DimensionsPlus, T, DimensionsPlus*DimensionsPlus}, length(Position))
-            NeighborLoopMDBC!(SimKernel, SimMetaData, SimConstants, ParticleRanges, CellDict, Position, Density, GhostPoints,GhostNormals, ParticleType, bᵧ, Aᵧ)
+            UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
+            NeighborLoopMDBC!(SimKernel, SimMetaData, SimConstants, ParticleRanges, UniqueCellsView, Position, Density, GhostPoints, GhostNormals, ParticleType, bᵧ, Aᵧ)
             ApplyMDBCCorrection(SimConstants, SimParticles, bᵧ, Aᵧ)
         end
 
@@ -691,7 +686,7 @@ using LinearAlgebra
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
                                       SimConstants, SimParticles, FullStencil,
-                                      ParticleRanges, UniqueCells, CellDict,
+                                      ParticleRanges, UniqueCells, CellListIndices,
                                       SortingScratchSpace,
                                       NeighborCellLists, dρdtI, Velocityₙ⁺,
                                       Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
@@ -724,19 +719,19 @@ using LinearAlgebra
             AccelerationMax = @alloc(FloatType, length(Position))
             dt₂ = dt * 0.5
 
-            SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace, ParticleRanges, UniqueCells, CellDict)
+            SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace, ParticleRanges, UniqueCells, CellListIndices)
             UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-            BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellDict)
+            BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
 
             if TimeSteppingMode isa SingleNeighborTimeStepping
                 @timeit SimMetaData.HourGlass "00 Init Pressure"                          Pressure!(SimParticles.Pressure, SimParticles.Density, SimConstants)
                 @timeit SimMetaData.HourGlass "00a Init MDBC"                              ApplyMDBCBeforeHalf!(
-                    SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
+                    SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, UniqueCells,
                     Position, Density, GhostPoints, GhostNormals, ParticleType,
                 )
                 @timeit SimMetaData.HourGlass "00b Init NeighborLoop" NeighborLoopPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, ParticleRanges, CellDict,
+                    SimConstants, SimParticles, ParticleRanges, CellListIndices,
                     NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
                 )
             end
@@ -756,10 +751,10 @@ using LinearAlgebra
                     # Remove if statement logic if you want to update each iteration
                     # if mod(SimMetaData.Iteration, ceil(Int, SimKernel.H / (SimConstants.c₀ * dt * (1/SimConstants.CFL)) )) == 0 || SimMetaData.Iteration == 1
                     if ShouldRebuild
-                        @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellDict)
+                        @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellListIndices)
                         SimMetaData.Δx    = zero(eltype(dρdtI))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
-                        BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellDict)
+                        BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
                     end
                 end
 
@@ -768,13 +763,13 @@ using LinearAlgebra
                 if TimeSteppingMode isa SymplecticTimeStepping
                     @timeit SimMetaData.HourGlass "02 Pressure"                              Pressure!(SimParticles.Pressure, SimParticles.Density, SimConstants)
                     @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(
-                        SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
+                        SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, UniqueCells,
                         Position, Density, GhostPoints, GhostNormals, ParticleType,
                     )
 
                     @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        SimConstants, SimParticles, ParticleRanges, CellListIndices,
                         NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
                     )
 
@@ -787,7 +782,7 @@ using LinearAlgebra
                     @timeit SimMetaData.HourGlass "07 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺, SimConstants)
                     @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        SimConstants, SimParticles, ParticleRanges, CellListIndices,
                         NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
                         Position = Positionₙ⁺,
                         Density = ρₙ⁺,
@@ -795,7 +790,7 @@ using LinearAlgebra
                     )
                 else
                     @timeit SimMetaData.HourGlass "02 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(
-                        SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, CellDict,
+                        SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, UniqueCells,
                         Position, Density, GhostPoints, GhostNormals, ParticleType,
                     )
 
@@ -808,7 +803,7 @@ using LinearAlgebra
                     @timeit SimMetaData.HourGlass "05 Pressure"                              Pressure!(SimParticles.Pressure, ρₙ⁺, SimConstants)
                     @timeit SimMetaData.HourGlass "06 NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                        SimConstants, SimParticles, ParticleRanges, CellDict,
+                        SimConstants, SimParticles, ParticleRanges, CellListIndices,
                         NeighborCellLists, dρdtI, Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
                         Position = Positionₙ⁺,
                         Density = ρₙ⁺,
@@ -859,7 +854,7 @@ using LinearAlgebra
         # Produce sorting related variables
         ParticleRanges         = zeros(Int, NumberOfPoints + 1 + 1) # +1 for the last particle, +1 for dummy entry
         UniqueCells            = zeros(CartesianIndex{Dimensions}, NumberOfPoints)
-        CellDict               = Dict{CartesianIndex{Dimensions}, Int}()
+        CellListIndices        = zeros(Int, NumberOfPoints)
         FullStencil            = ConstructStencil(Val(Dimensions))
         NeighborCellLists      = [Int[] for _ in 1:length(UniqueCells)]
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
@@ -900,7 +895,7 @@ using LinearAlgebra
             @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
                 SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                 SimConstants, SimParticles, FullStencil, ParticleRanges,
-                UniqueCells, CellDict, SortingScratchSpace,
+                UniqueCells, CellListIndices, SortingScratchSpace,
                 NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
                 ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
             )

--- a/src/SPHNeighborList.jl
+++ b/src/SPHNeighborList.jl
@@ -1,6 +1,6 @@
 module SPHNeighborList
 
-export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts, UpdateΔx!
+export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts, UpdateΔx!, FindCellIndex
 
 using StaticArrays
 
@@ -8,7 +8,19 @@ function ConstructStencil(V::Val{d}) where d
     return CartesianIndices(ntuple(_ -> -1:1, V))
 end
 
-function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellDict)
+@inline function MinCell(::Type{CartesianIndex{D}}) where D
+    return CartesianIndex(ntuple(_ -> typemin(Int), Val(D)))
+end
+
+@inline function FindCellIndex(UniqueCellsView, Cell)
+    idx = searchsortedfirst(UniqueCellsView, Cell)
+    if idx <= length(UniqueCellsView) && UniqueCellsView[idx] == Cell
+        return idx
+    end
+    return 1
+end
+
+function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
     TargetLen   = length(UniqueCellsView)
     OriginalLen = length(NeighborCellLists)
     resize!(NeighborCellLists, TargetLen)
@@ -25,7 +37,7 @@ function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView
         Cell = UniqueCellsView[CellIndex]
         for Offset in FullStencil
             NeighborCell = Cell + Offset
-            NeighborIndex = get(CellDict, NeighborCell, 1)
+            NeighborIndex = FindCellIndex(UniqueCellsView, NeighborCell)
             StartIndex = ParticleRanges[NeighborIndex]
             EndIndex = ParticleRanges[NeighborIndex + 1] - 1
             if StartIndex <= EndIndex && NeighborIndex != CellIndex
@@ -76,26 +88,26 @@ Updates the neighbor list and sorts particles by their cell indices.
 - `IndexCounter`: The number of unique cells identified.
 """
 function UpdateNeighbors!(Particles, InverseCutOff, SortingScratchSpace,
-                          ParticleRanges, UniqueCells, CellDict)
+                          ParticleRanges, UniqueCells, CellListIndices)
     ExtractCells!(Particles, InverseCutOff)
 
     sort!(Particles, by = p -> p.Cells; scratch=SortingScratchSpace)
     Cells = @views Particles.Cells
+    UniqueCells[1] = MinCell(eltype(Cells))
     @. ParticleRanges             = zero(eltype(ParticleRanges))
     ParticleRanges[1] = 1
     IndexCounter                  = 2
     ParticleRanges[IndexCounter]  = 1
     UniqueCells[IndexCounter]     = Cells[1]
-    empty!(CellDict)
-    CellDict[Cells[1]] = IndexCounter
+    CellListIndices[1]            = IndexCounter
 
     @inbounds @simd ivdep for Index in eachindex(Cells)[2:end]
         if Cells[Index] != Cells[Index - 1] # Equivalent to diff(Cells) != 0
             IndexCounter                 += 1
             ParticleRanges[IndexCounter]  = Index
             UniqueCells[IndexCounter]     = Cells[Index]
-            CellDict[Cells[Index]]       = IndexCounter
         end
+        CellListIndices[Index]            = IndexCounter
     end
     ParticleRanges[IndexCounter + 1]  = length(ParticleRanges)
 


### PR DESCRIPTION
### Motivation
- Remove hot-path dictionary lookups for cell→index mapping to improve neighbor-list performance and reduce allocations.
- Store per-particle cell list indices to eliminate repeated map lookups during neighbor loops and MDBC computations.

### Description
- Added `MinCell` sentinel and `FindCellIndex` (binary-search) in `src/SPHNeighborList.jl` and exported `FindCellIndex` to replace `Dict`-based lookups.
- Reworked `BuildNeighborCellLists!` signature to use a sorted `UniqueCellsView` and `ParticleRanges` only, using `FindCellIndex` for neighbor cell resolution instead of `CellDict`.
- Modified `UpdateNeighbors!` to emit a `CellListIndices` per-particle array and initialize `UniqueCells` with a sentinel instead of populating a `Dict`.
- Updated all neighbor-loop variants, `NeighborLoopMDBC!`, `ApplyMDBCBeforeHalf!`, `SimulationLoop`, and related call sites in `src/SPHCellList.jl` to accept and use `CellListIndices`/`UniqueCellsView` and to remove `CellDict` usage.

### Testing
- No automated tests were run on these changes.
- Commands executed while preparing the change included `rg` searches, `sed`/file inspections and local edits, `git add` and `git commit -m "Replace cell dict with indices"`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69701d6af48c8323b7cb5357256b8b48)