### PR TITLE
Simplify VTK/HDF output selection to SimParticles fields and exclude Cells/Position

### DIFF
--- a/example/StillWedgeMDBC.jl
+++ b/example/StillWedgeMDBC.jl
@@ -7,7 +7,7 @@ let
     SimConstantsWedge = SimulationConstants{FloatType}(dx=0.02,c₀=42.48576250492629, δᵩ = 0.1, CFL=0.5)
     # SimConstantsWedge = SimulationConstants{FloatType}(dx=0.01,c₀=43.4, δᵩ = 0.1, CFL=0.2)
 # 
-    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,StoreKernelOutput,NoMDBC,StoreLog}(
+    SimMetaDataWedge  = SimulationMetaData{Dimensions,FloatType,NoShifting,NoKernelOutput,NoMDBC,StoreLog}(
         SimulationName="StillWedge", 
         SaveLocation="W:/Simulations/StillWedge2D_MDBC",
         SimulationTime=4.0,

--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -59,7 +59,7 @@ end
     return normal, point
 end
 
-function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, FloatType}}; OutputVariables=String[], RequireMDBC::Bool=false, RequireKernelOutput::Bool=false) where {Dimensions, FloatType}
+function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, FloatType}}; RequireMDBC::Bool=false, RequireKernelOutput::Bool=false) where {Dimensions, FloatType}
     Position    = Vector{SVector{Dimensions, FloatType}}()
     Density     = Vector{FloatType}()
     Types       = Vector{ParticleType}()
@@ -99,10 +99,6 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
     GroupMarker = GroupMarker[sort_perm]
     Idp = Idp[sort_perm]
 
-    if !RequireKernelOutput && ("Kernel" in OutputVariables || "KernelGradient" in OutputVariables)
-        error("Kernel output requires StoreKernelOutput in SimulationMetaData.")
-    end
-
     Acceleration    = zeros(PositionType, NumberOfPoints)
     Velocity        = zeros(PositionType, NumberOfPoints)
     Pressureᵢ      = zeros(PositionUnderlyingType, NumberOfPoints)
@@ -124,17 +120,15 @@ function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, Float
         KernelGradient = zeros(PositionType, NumberOfPoints)
         ParticleFields = merge(ParticleFields, (; Kernel = Kernel, KernelGradient = KernelGradient))
     end
-    if RequireMDBC || "GhostPoints" in OutputVariables
+    if RequireMDBC
         GhostPoints = zeros(PositionType, NumberOfPoints)
         ParticleFields = merge(ParticleFields, (; GhostPoints = GhostPoints))
     end
-    if RequireMDBC || "GhostNormals" in OutputVariables
+    if RequireMDBC
         GhostNormals = zeros(PositionType, NumberOfPoints)
         ParticleFields = merge(ParticleFields, (; GhostNormals = GhostNormals))
     end
-    if "ID" in OutputVariables
-        ParticleFields = merge(ParticleFields, (; ID = Idp))
-    end
+    ParticleFields = merge(ParticleFields, (; ID = Idp))
 
     SimParticles = StructArray(ParticleFields)
 
@@ -144,7 +138,7 @@ end
 function AllocateDataStructures(SimGeometry::Vector{<:Geometry{Dimensions, FloatType}}, SimMetaData::SimulationMetaData{Dimensions, FloatType}) where {Dimensions, FloatType}
     RequireMDBC = !(SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, KMode, NoMDBC, LMode} where {SMode, KMode, LMode})
     RequireKernelOutput = !(SimMetaData isa SimulationMetaData{Dimensions, FloatType, SMode, NoKernelOutput, BMode, LMode} where {SMode, BMode, LMode})
-    return AllocateDataStructures(SimGeometry; OutputVariables = SimMetaData.OutputVariables, RequireMDBC = RequireMDBC, RequireKernelOutput = RequireKernelOutput)
+    return AllocateDataStructures(SimGeometry; RequireMDBC = RequireMDBC, RequireKernelOutput = RequireKernelOutput)
 end
 
 function AllocateSupportDataStructures(::SimulationMetaData{D,T,NoShifting,K,B,L}, Position) where {D,T,K<:KernelOutputMode,

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -149,6 +149,56 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         return payload
     end
 
+    @inline function IsVectorField(Source)
+        return eltype(Source) <: StaticVector || eltype(Source) <: CartesianIndex
+    end
+
+    @inline function VectorElementType(Source)
+        if eltype(Source) <: StaticVector
+            return eltype(eltype(Source))
+        elseif eltype(Source) <: CartesianIndex
+            return eltype(first(Source))
+        end
+        return eltype(Source)
+    end
+
+    @inline function AllocateVectorBuffer(Source, n)
+        element_type = VectorElementType(Source)
+        return Vector{SVector{3, element_type}}(undef, n)
+    end
+
+    function FillVectorBuffer!(Dest, Source, Dimensions)
+        if eltype(Source) <: StaticVector
+            if Dimensions == 2
+                to_3d!(Dest, Source)
+            else
+                copy!(Dest, Source)
+            end
+            return Dest
+        end
+        if eltype(Source) <: CartesianIndex
+            if Dimensions == 2
+                @inbounds for i in eachindex(Source)
+                    idx = Source[i]
+                    Dest[i] = SVector(idx[1], idx[2], zero(VectorElementType(Source)))
+                end
+            else
+                @inbounds for i in eachindex(Source)
+                    idx = Source[i]
+                    Dest[i] = SVector(idx[1], idx[2], idx[3])
+                end
+            end
+            return Dest
+        end
+        copy!(Dest, Source)
+        return Dest
+    end
+
+    function ResolveParticleField(Name, SimParticles)
+        FieldSymbol = Symbol(Name)
+        return hasproperty(SimParticles, FieldSymbol) ? FieldSymbol : nothing
+    end
+
     function SaveVTKHDF(fid_vector, index, filepath, points, variable_names = String[], args...)
         @assert length(variable_names) == length(args) "Same number of variable_names as args is necessary"
         io = h5open(filepath, "w")
@@ -546,7 +596,10 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
         particle_filename = (iter) -> "$(particle_savepath)_$(lpad(iter,6,"0")).vtkhdf"
         grid_filename = (iter) -> "$(grid_savepath)_$(lpad(iter,6,"0")).vtkhdf"
         
-        output_vars = SimMetaData.OutputVariables
+        output_vars = filter(
+            Name -> !(Name in ("Cells", "Position")),
+            string.(propertynames(SimParticles)),
+        )
     
         # Initialize storage for file handles
         file_handles = if !SimMetaData.ExportSingleVTKHDF
@@ -565,31 +618,23 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             OutputVTKHDF = h5open("$(particle_savepath).vtkhdf", "w")
             root = HDF5.create_group(OutputVTKHDF, "VTKHDF")
             
-            field_map = Dict(
-                "Kernel" => :Kernel,
-                "KernelGradient" => :KernelGradient,
-                "Density" => :Density,
-                "Pressure" => :Pressure,
-                "Velocity" => :Velocity,
-                "Acceleration" => :Acceleration,
-                "ID" => :ID,
-                "Type" => :Type,
-                "GroupMarker" => :GroupMarker,
-                "GhostPoints" => :GhostPoints,
-                "GhostNormals" => :GhostNormals,
-            )
             output_data_init = Vector{Any}(undef, length(output_vars))
-            for (i, name) in pairs(output_vars)
-                prop = get(field_map, name, nothing)
-                if name == "Type"
-                    output_data_init[i] = Int8.(getproperty(SimParticles, prop))
-                elseif name == "BoundaryBool"
+            for (i, Name) in pairs(output_vars)
+                if Name == "BoundaryBool"
                     output_data_init[i] = UInt8.(SimParticles.Type .!= Fluid)
                 else
-                    if prop === nothing || !hasproperty(SimParticles, prop)
-                        error("OutputVariables includes $(name) but SimParticles has no field $(name).")
+                    FieldSymbol = ResolveParticleField(Name, SimParticles)
+                    if Name == "Type"
+                        output_data_init[i] = Int8.(getproperty(SimParticles, FieldSymbol))
+                    else
+                        Source = getproperty(SimParticles, FieldSymbol)
+                        if IsVectorField(Source)
+                            output_data_init[i] = AllocateVectorBuffer(Source, length(Source))
+                            FillVectorBuffer!(output_data_init[i], Source, Dimensions)
+                        else
+                            output_data_init[i] = Source
+                        end
                     end
-                    output_data_init[i] = getproperty(SimParticles, prop)
                 end
             end
 
@@ -622,46 +667,24 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
             end
         end
 
-        vector_fields = Set([
-            "KernelGradient",
-            "Velocity",
-            "Acceleration",
-            "GhostPoints",
-            "GhostNormals",
-        ])
-        field_map = Dict(
-            "Kernel" => :Kernel,
-            "KernelGradient" => :KernelGradient,
-            "Density" => :Density,
-            "Pressure" => :Pressure,
-            "Velocity" => :Velocity,
-            "Acceleration" => :Acceleration,
-            "ID" => :ID,
-            "Type" => :Type,
-            "GroupMarker" => :GroupMarker,
-            "GhostPoints" => :GhostPoints,
-            "GhostNormals" => :GhostNormals,
-        )
-
         T = eltype(eltype(SimParticles.Position))
         function allocate_particle_snapshot()
             n = length(SimParticles.Position)
             positions = Vector{SVector{3, T}}(undef, n)
             output_data = Vector{Any}(undef, length(output_vars))
-            for (i, name) in pairs(output_vars)
-                if name in vector_fields
-                    output_data[i] = Vector{SVector{3, T}}(undef, n)
-                elseif name == "Type"
+            for (i, Name) in pairs(output_vars)
+                if Name == "Type"
                     output_data[i] = Vector{Int8}(undef, n)
-                elseif name == "BoundaryBool"
+                elseif Name == "BoundaryBool"
                     output_data[i] = Vector{UInt8}(undef, n)
                 else
-                    prop = field_map[name]
-                    if !hasproperty(SimParticles, prop)
-                        error("OutputVariables includes $(name) but SimParticles has no field $(name).")
+                    FieldSymbol = ResolveParticleField(Name, SimParticles)
+                    Source = getproperty(SimParticles, FieldSymbol)
+                    if IsVectorField(Source)
+                        output_data[i] = AllocateVectorBuffer(Source, n)
+                    else
+                        output_data[i] = similar(Source, n)
                     end
-                    src = getproperty(SimParticles, prop)
-                    output_data[i] = similar(src, n)
                 end
             end
             return ParticleSnapshot(positions, output_data)
@@ -674,36 +697,26 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
                 copy!(snapshot.positions, SimParticles.Position)
             end
 
-            for (i, name) in pairs(output_vars)
+            for (i, Name) in pairs(output_vars)
                 buf = snapshot.output_data[i]
-                if name == "Type"
+                if Name == "Type"
                     src = SimParticles.Type
                     @inbounds for j in eachindex(src)
                         buf[j] = Int8(src[j])
                     end
-                elseif name == "BoundaryBool"
+                elseif Name == "BoundaryBool"
                     src = SimParticles.Type
                     @inbounds for j in eachindex(src)
                         buf[j] = UInt8(src[j] != Fluid)
                     end
-                elseif name in vector_fields
-                    prop = field_map[name]
-                    if !hasproperty(SimParticles, prop)
-                        error("OutputVariables includes $(name) but SimParticles has no field $(name).")
-                    end
-                    src = getproperty(SimParticles, prop)
-                    if Dimensions == 2
-                        to_3d!(buf, src)
-                    else
-                        copy!(buf, src)
-                    end
                 else
-                    prop = field_map[name]
-                    if !hasproperty(SimParticles, prop)
-                        error("OutputVariables includes $(name) but SimParticles has no field $(name).")
+                    FieldSymbol = ResolveParticleField(Name, SimParticles)
+                    Source = getproperty(SimParticles, FieldSymbol)
+                    if IsVectorField(Source)
+                        FillVectorBuffer!(buf, Source, Dimensions)
+                    else
+                        copy!(buf, Source)
                     end
-                    src = getproperty(SimParticles, prop)
-                    copy!(buf, src)
                 end
             end
             return snapshot

--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -53,14 +53,6 @@ struct SingleNeighborTimeStepping <: TimeSteppingMode end
     ExportSingleVTKHDF::Bool                = true
     ExportGridCells::Bool                   = false
     ExportGridCellParticleCounts::Bool      = false
-    OutputVariables::Vector{String}         = [
-        "Density",
-        "Pressure",
-        "Velocity",
-        "Acceleration",
-        "Type",
-        "GroupMarker",
-    ]
     OpenLogFile::Bool                       = true
     Δx::FloatType                           = zero(FloatType)
     TimeSteppingMode::TimeSteppingMode      = SingleNeighborTimeStepping()


### PR DESCRIPTION
### Motivation
- Simplify and reduce confusion by removing the `OutputVariables` option and driving VTK/HDF exports directly from the actual `SimParticles` fields. 
- Ensure `Cells` and `Position` are never exported since they are always present and should be excluded from output variable lists.

### Description
- Remove `OutputVariables` from `SimulationMetaData` and stop threading it through `AllocateDataStructures`, while preserving kernel/MDBC-driven allocations via the existing flags. 
- Drive VTK/HDF output selection with `output_vars = filter(Name -> !(Name in ("Cells","Position")), string.(propertynames(SimParticles)))` so exported variables come from `SimParticles` fields. 
- Add helpers `IsVectorField`, `VectorElementType`, `AllocateVectorBuffer`, `FillVectorBuffer!`, and `ResolveParticleField` in `ProduceHDFVTK.jl` and update single-file initialization (`output_data_init`), snapshot allocation (`allocate_particle_snapshot`), and population (`fill_particle_snapshot!`) to allocate/copy buffers correctly for vector-like fields and handle `Type`/`BoundaryBool` specially. 
- Always include `ID` in `ParticleFields` during data allocation to keep exports consistent.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970bed48e908323818a2a0a5c1ee8f3)