### PR TITLE
Read shifting factor `A` from `SimulationConstants` and add default; update examples

### DIFF
--- a/example/LidDrivenCavity2d.jl
+++ b/example/LidDrivenCavity2d.jl
@@ -203,7 +203,8 @@ let
         c₀ = 10LidVelocity,
         α = 0.01,
         CFL = 0.2,
-        δᵩ = 0.1
+        δᵩ = 0.1,
+        A = 0.01
     )
 
     SimMetaData = SimulationMetaData{Dimensions, FloatType, PlanarShifting, NoKernelOutput, SimpleMDBC, StoreLog}(

--- a/example/MovingSquare2d.jl
+++ b/example/MovingSquare2d.jl
@@ -12,7 +12,8 @@ let
         g  = 0,
         Cb = 112000,
         α  = 1e-6,
-        CFL=0.2
+        CFL=0.2,
+        A  = 0.01
     )
 
     SimMetaDataMovingSquare  = SimulationMetaData{Dimensions,FloatType,PlanarShifting,NoKernelOutput,NoMDBC,StoreLog}(

--- a/example/MovingSquare2d.jl
+++ b/example/MovingSquare2d.jl
@@ -13,7 +13,7 @@ let
         Cb = 112000,
         α  = 1e-6,
         CFL=0.2,
-        A  = 0.01 # Default shifting value from earlier commits
+        A  = 2 # Manually set value for this parameter
     )
 
     SimMetaDataMovingSquare  = SimulationMetaData{Dimensions,FloatType,PlanarShifting,NoKernelOutput,NoMDBC,StoreLog}(

--- a/example/MovingSquare2d.jl
+++ b/example/MovingSquare2d.jl
@@ -13,7 +13,7 @@ let
         Cb = 112000,
         α  = 1e-6,
         CFL=0.2,
-        A  = 0.01
+        A  = 0.01 # Default shifting value from earlier commits
     )
 
     SimMetaDataMovingSquare  = SimulationMetaData{Dimensions,FloatType,PlanarShifting,NoKernelOutput,NoMDBC,StoreLog}(

--- a/src/SimulationConstantsConfiguration.jl
+++ b/src/SimulationConstantsConfiguration.jl
@@ -24,6 +24,7 @@ SimulationConstants is a parameterized struct representing the constants and par
 - `δᵩ::T`: Coefficient for density diffusion. Default is 0.1.
 - `CFL::T`: CFL (Courant-Friedrichs-Lewy) number (positive). Default is 0.2.
 - `η²::T`: Eta squared (positive). Default is computed as `(0.01 * H)^2`.
+- `A::T`: Shifting factor for particle shifting. Default is 0.01.
 
 # Example
 ```julia
@@ -44,6 +45,7 @@ constants = SimulationConstants(ρ₀=1017, dx=0.03, α=0.02)
     γ⁻¹::T  = 1/γ                 ; @assert γ⁻¹  > 0 "Inverse adiabatic index (γ⁻¹) must be positive"
     δᵩ::T  = 0.1                  ; @assert δᵩ   > 0 "Density variation (δᵩ) must be positive"
     CFL::T = 0.2                  ; @assert CFL  > 0 "CFL condition (CFL) must be positive"
+    A::T   = 0.01                 ; @assert A    > 0 "Shifting factor (A) must be positive"
     Cb::T  = (c₀^2 * ρ₀)/γ        ; @assert Cb  >= 0 "Cb (pressure coefficient) must be positive"
     Cb⁻¹::T  = inv(Cb)            ; @assert Cb⁻¹>= 0 "Inverse Cb (inverse pressure coefficient) must be positive"
     ν₀::T    = 1e-6               ; @assert ν₀  >= 0 "Kinematic viscosity must be positive"

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -143,7 +143,7 @@ function FullTimeStep(::SimulationMetaData{D,T,S,K,B,L}, SimKernel, SimConstants
     @unpack Position, Velocity, Acceleration = SimParticles
     ParticleType = SimParticles.Type
     AccelerationScalarType = eltype(eltype(Acceleration))
-    A     = 0.01# Value between 1 to 6 advised
+    A     = SimConstants.A
     A_FST = 0; # zero for internal flows
     A_FSM = length(first(Position)); #2d, 3d val different
     @inbounds @simd ivdep for i in eachindex(Position)


### PR DESCRIPTION
### Motivation
- Make the particle shifting coefficient controllable from simulation configuration rather than hard-coded in the time-stepping logic.
- Ensure the codebase has a single authoritative source for the shifting parameter so examples and simulations can change behavior without editing core files.
- Preserve existing behavior by providing a sensible default so existing examples keep running unchanged.
- Keep moving-object motion controlled from the simulation/example files and avoid embedding motion control in core modules.

### Description
- Add `A::T = 0.01` to `SimulationConstants` in `src/SimulationConstantsConfiguration.jl` so the shifting factor is part of the simulation configuration and has a backward-compatible default.
- Change the shifting branch in `src/TimeStepping.jl` to read `A` from `SimConstants` (use `SimConstants.A`) instead of a hard-coded literal or ad-hoc fallback.
- Update example simulations `example/MovingSquare2d.jl` and `example/LidDrivenCavity2d.jl` to explicitly set `A = 0.01` so their runtime behavior matches the prior default without modifying core code.
- Inspection and repository commands run during the rollout included `rg`, `sed`/`nl` for file inspection and `git add`/`git commit` to record the changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979fe9e7dcc8323aade01cbd184ca35)