### PR TITLE
Type hot-loop numeric literals to match simulation element type

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -399,7 +399,7 @@ using LinearAlgebra
         if xᵢⱼ² <= H²
             dᵢⱼ = sqrt(abs(xᵢⱼ²))
             dᵢⱼ² = dᵢⱼ^2
-            q = clamp(dᵢⱼ * h⁻¹, 0.0, 2.0)
+            q = clamp(dᵢⱼ * h⁻¹, zero(T), T(2))
             ∇ᵢWᵢⱼ = @fastpow ∇Wᵢⱼ(SimKernel, q, xᵢⱼ)
 
             ρᵢ = Density[i]
@@ -483,7 +483,7 @@ using LinearAlgebra
         if xᵢⱼ² <= H²
             dᵢⱼ = sqrt(abs(xᵢⱼ²))
             dᵢⱼ² = dᵢⱼ^2
-            q = clamp(dᵢⱼ * h⁻¹, 0.0, 2.0)
+            q = clamp(dᵢⱼ * h⁻¹, zero(T), T(2))
             Wᵢⱼ  = @fastpow SPHKernels.Wᵢⱼ(SimKernel, q)
             ∇ᵢWᵢⱼ = @fastpow ∇Wᵢⱼ(SimKernel, q, xᵢⱼ)
 
@@ -538,7 +538,7 @@ using LinearAlgebra
         if xᵢⱼ² <= H²
             dᵢⱼ = sqrt(abs(xᵢⱼ²))
             dᵢⱼ² = dᵢⱼ^2
-            q = clamp(dᵢⱼ * h⁻¹, 0.0, 2.0)
+            q = clamp(dᵢⱼ * h⁻¹, zero(T), T(2))
             Wᵢⱼ  = @fastpow SPHKernels.Wᵢⱼ(SimKernel, q)
             ∇ᵢWᵢⱼ = @fastpow ∇Wᵢⱼ(SimKernel, q, xᵢⱼ)
 
@@ -592,7 +592,7 @@ using LinearAlgebra
             xᵢⱼ² = dot(xᵢⱼ, xᵢⱼ)
             if xᵢⱼ² <= H²
                 dᵢⱼ = sqrt(abs(xᵢⱼ²))
-                q = clamp(dᵢⱼ * h⁻¹, 0.0, 2.0)
+                q = clamp(dᵢⱼ * h⁻¹, zero(FloatType), FloatType(2))
         
                 ρⱼ = Density[j]
 
@@ -648,18 +648,20 @@ using LinearAlgebra
         GhostPoints = SimParticles.GhostPoints
 
         ρ₀ = SimConstants.ρ₀
+        T = eltype(Density)
+        DetTolerance = T(1e-3)
         #https://github.com/DualSPHysics/DualSPHysics/blob/f4fa76ad5083873fa1c6dd3b26cdce89c55a9aeb/src/source/JSphCpu_mdbc.cpp#L347
         @inbounds @simd ivdep for i in eachindex(Position)
             A = Aᵧ[i]
 
             # Since Aᵧ is not reset anymore, we need to check if it is zero
             if !iszero(GhostPoints[i])
-                if abs(det(A)) >= 1e-3
+                if abs(det(A)) >= DetTolerance
                         GhostPointDensity = A \ bᵧ[i]
                         diff = Position[i] - GhostPoints[i]
                         v1   = first(GhostPointDensity) + sum(GhostPointDensity[j+1] * diff[j] for j in eachindex(diff))
                         Density[i] = isnan(v1) ? ρ₀ : v1
-                elseif first(A) > 0.0
+                elseif first(A) > zero(T)
                         v = first(bᵧ[i]) / first(A)
                         Density[i] = isnan(v) ? ρ₀ : v
                 end


### PR DESCRIPTION
### Motivation
- Hot inner loops used Float64 literals (`0.0`, `2.0`, `1e-3`) which cause type-promotion warnings and extra allocations when running simulations with a different element type (e.g. `Float32`).
- Ensure numeric clamp bounds and MDBC thresholds are expressed in the simulation's element type to avoid promotions in performance-sensitive code paths.

### Description
- Replace literal clamp bounds in particle interaction hot paths with typed expressions derived from the simulation type parameter, using `zero(T)` and `T(2)` where `T` is available in the function scope.
- In the MDBC neighbor routine, use `zero(FloatType)` and `FloatType(2)` for the clamp bounds and derive a typed determinant tolerance with `T = eltype(Density); DetTolerance = T(1e-3)`.
- Replace comparison against `0.0` with `zero(T)` for matrix-entry checks to keep the checks on the same numeric type as `Density`.
- All changes are contained in `src/SPHCellList.jl` and only adjust literal constants and small local variable introductions to preserve existing behavior while matching types.

### Testing
- Ran `julia --project=. -e 'using SPHExample'` which precompiled and loaded the package successfully.
- Ran `julia --project=. -e 'using Pkg; Pkg.test()'` which executed precompilation but the test suite errored in the existing `time stepping` test with a missing `Δt` method for vector arguments; this error appears unrelated to these literal-typing changes and is reported by the test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ad11500d48323884e6e43575ed271)