### PR TITLE
Specialize particle boundary types

### DIFF
--- a/src/PreProcess.jl
+++ b/src/PreProcess.jl
@@ -1,10 +1,13 @@
 module PreProcess
 
-export LoadBoundaryNormals, LoadMDBCNormals!, AllocateDataStructures, AllocateSupportDataStructures, AllocateThreadedArrays
+export LoadBoundaryNormals, LoadMDBCNormals!, AllocateDataStructures, AllocateSupportDataStructures, AllocateThreadedArrays, SimParticleStructArray
 
 using CSV
 using StaticArrays
 using StructArrays
+
+"""Concrete one-dimensional StructArray shape used for simulation particles."""
+const SimParticleStructArray{ParticleTuple, FieldArrays, IndexType} = StructArray{ParticleTuple, 1, FieldArrays, IndexType}
 
 using ..SimulationGeometry
 using ..SimulationMetaDataConfiguration

--- a/src/ProduceHDFVTK.jl
+++ b/src/ProduceHDFVTK.jl
@@ -21,6 +21,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     using Base.Threads
     using HDF5
     using StaticArrays
+    using StructArrays: StructArray
 
     using ..AuxiliaryFunctions: to_3d!
     using ..SimulationGeometry
@@ -659,7 +660,7 @@ export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure,
     particle snapshots, and the queue must be flushed before closing files.
     Uses single or multi-file mode depending on `SimMetaData.ExportSingleVTKHDF`.
     """
-    function SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)
+    function SetupVTKOutput(SimMetaData, SimParticles::StructArray{ParticleTuple, 1, FieldArrays, IndexType}, SimKernel, Dimensions) where {ParticleTuple, FieldArrays, IndexType}
         # Generate save locations
         particle_savepath = joinpath(SimMetaData.SaveLocation, SimMetaData.SimulationName)
         grid_savepath = joinpath(SimMetaData.SaveLocation, "CellGrid_$(SimMetaData.SimulationName)")

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -34,7 +34,7 @@ using LinearAlgebra
 
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L},
-                                      SimConstants, SimParticles, ParticleRanges,
+                                      SimConstants, SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}, ParticleRanges,
                                       CellListIndices, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
@@ -44,7 +44,8 @@ using LinearAlgebra
                                       Velocity = SimParticles.Velocity) where {D,T,
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
-                                                  SV<:SPHViscosity}
+                                                  SV<:SPHViscosity,
+                                                  ParticleTuple, FieldArrays, IndexType}
         ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
@@ -90,7 +91,7 @@ using LinearAlgebra
 
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L},
-                                      SimConstants, SimParticles, ParticleRanges,
+                                      SimConstants, SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}, ParticleRanges,
                                       CellListIndices, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
@@ -101,7 +102,8 @@ using LinearAlgebra
                                                   K<:KernelOutputMode,
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
-                                                  SV<:SPHViscosity}
+                                                  SV<:SPHViscosity,
+                                                  ParticleTuple, FieldArrays, IndexType}
         @unpack Kernel, KernelGradient = SimParticles
         ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
@@ -158,7 +160,7 @@ using LinearAlgebra
 
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
-                                      SimConstants, SimParticles, ParticleRanges,
+                                      SimConstants, SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}, ParticleRanges,
                                       CellListIndices, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
@@ -168,7 +170,8 @@ using LinearAlgebra
                                       Velocity = SimParticles.Velocity) where {D,T,
                                                   S<:ShiftingMode,B<:MDBCMode,
                                                   L<:LogMode,SDD<:SPHDensityDiffusion,
-                                                  SV<:SPHViscosity}
+                                                  SV<:SPHViscosity,
+                                                  ParticleTuple, FieldArrays, IndexType}
         ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
@@ -224,7 +227,7 @@ using LinearAlgebra
 
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,K,B,L},
-                                      SimConstants, SimParticles, ParticleRanges,
+                                      SimConstants, SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}, ParticleRanges,
                                       CellListIndices, NeighborCellLists, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
@@ -236,7 +239,8 @@ using LinearAlgebra
                                                   K<:KernelOutputMode,
                                                   B<:MDBCMode,L<:LogMode,
                                                   SDD<:SPHDensityDiffusion,
-                                                  SV<:SPHViscosity}
+                                                  SV<:SPHViscosity,
+                                                  ParticleTuple, FieldArrays, IndexType}
         @unpack Kernel, KernelGradient = SimParticles
         ParticleType = SimParticles.Type
         @inbounds Threads.@threads for i in eachindex(Position)
@@ -384,13 +388,14 @@ using LinearAlgebra
     @inline function ComputeInteractionsPerParticleNoShiftingCore!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L}, SimConstants,
-        SimParticles, Position, Density, Pressure, Velocity, ParticleType,
+        SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}, Position, Density, Pressure, Velocity, ParticleType,
         dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, i, j) where {D,T,
                                                                      K<:KernelOutputMode,
                                                                      B<:MDBCMode,
                                                                      L<:LogMode,
                                                                      SDD<:SPHDensityDiffusion,
-                                                                     SV<:SPHViscosity}
+                                                                     SV<:SPHViscosity,
+                                                                     ParticleTuple, FieldArrays, IndexType}
         @unpack m₀, dx = SimConstants
         @unpack h⁻¹, H², h = SimKernel
 
@@ -434,13 +439,14 @@ using LinearAlgebra
     Base.@propagate_inbounds function ComputeInteractionsPerParticle!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L}, SimConstants,
-        SimParticles, Position, Density, Pressure, Velocity, ParticleType,
+        SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}, Position, Density, Pressure, Velocity, ParticleType,
         dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, i, j) where {D,T,
                                                                      K<:KernelOutputMode,
                                                                      B<:MDBCMode,
                                                                      L<:LogMode,
                                                                      SDD<:SPHDensityDiffusion,
-                                                                     SV<:SPHViscosity}
+                                                                     SV<:SPHViscosity,
+                                        ParticleTuple, FieldArrays, IndexType}
         return ComputeInteractionsPerParticleNoShiftingCore!(
             SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants,
             SimParticles, Position, Density, Pressure, Velocity, ParticleType,
@@ -451,10 +457,11 @@ using LinearAlgebra
     Base.@propagate_inbounds function ComputeInteractionsPerParticle!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L}, SimConstants,
-        SimParticles, Position, Density, Pressure, Velocity, ParticleType,
+        SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}, Position, Density, Pressure, Velocity, ParticleType,
         dρdt_acc, acc_acc, i, j) where {D,T,B<:MDBCMode,L<:LogMode,
                                         SDD<:SPHDensityDiffusion,
-                                        SV<:SPHViscosity}
+                                        SV<:SPHViscosity,
+                                  ParticleTuple, FieldArrays, IndexType}
         dρdt_acc, acc_acc, _, _ = ComputeInteractionsPerParticleNoShiftingCore!(
             SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData, SimConstants,
             SimParticles, Position, Density, Pressure, Velocity, ParticleType,
@@ -467,14 +474,15 @@ using LinearAlgebra
     Base.@propagate_inbounds function ComputeInteractionsPerParticle!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,S,K,B,L}, SimConstants,
-        SimParticles, Position, Density, Pressure, Velocity, ParticleType,
+        SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}, Position, Density, Pressure, Velocity, ParticleType,
         dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
         shift_r_acc, i, j) where {D,T,S<:ShiftingMode,
                                   K<:KernelOutputMode,
                                   B<:MDBCMode,
                                   L<:LogMode,
                                   SDD<:SPHDensityDiffusion,
-                                  SV<:SPHViscosity}
+                                  SV<:SPHViscosity,
+                                                                  ParticleTuple, FieldArrays, IndexType}
         @unpack m₀, dx = SimConstants
         @unpack h⁻¹, H², h = SimKernel
 
@@ -523,13 +531,14 @@ using LinearAlgebra
     Base.@propagate_inbounds function ComputeInteractionsPerParticle!(
         SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
         SimMetaData::SimulationMetaData{D,T,S,NoKernelOutput,B,L}, SimConstants,
-        SimParticles, Position, Density, Pressure, Velocity, ParticleType,
+        SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}, Position, Density, Pressure, Velocity, ParticleType,
         dρdt_acc, acc_acc, shift_c_acc, shift_r_acc, i, j) where {D,T,
                                                                   S<:ShiftingMode,
                                                                   B<:MDBCMode,
                                                                   L<:LogMode,
                                                                   SDD<:SPHDensityDiffusion,
-                                                                  SV<:SPHViscosity}
+                                                                  SV<:SPHViscosity,
+                                                ParticleTuple, FieldArrays, IndexType}
         @unpack m₀, dx = SimConstants
         @unpack h⁻¹, H², h = SimKernel
 
@@ -690,7 +699,7 @@ using LinearAlgebra
 
     @inbounds function SimulationLoop(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
-                                      SimConstants, SimParticles, FullStencil,
+                                      SimConstants, SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}, FullStencil,
                                       ParticleRanges, UniqueCells, CellListIndices,
                                       SortingScratchSpace,
                                       NeighborCellLists, dρdtI, Velocityₙ⁺,
@@ -707,7 +716,8 @@ using LinearAlgebra
                                                 Dimensions, FloatType, SMode, KMode,
                                                 BMode, LMode,
                                                 SDD<:SPHDensityDiffusion,
-                                                SV<:SPHViscosity}
+                                                SV<:SPHViscosity,
+                                                ParticleTuple, FieldArrays, IndexType}
         ParticleType   = SimParticles.Type
         ParticleMarker = SimParticles.GroupMarker
         GhostPoints    = hasproperty(SimParticles, :GhostPoints) ? SimParticles.GhostPoints : nothing
@@ -828,12 +838,12 @@ using LinearAlgebra
         SimConstants::SimulationConstants,
         SimKernel::SPHKernelInstance,
         SimLogger::SimulationLogger,
-        SimParticles::StructArray,
+        SimParticles::SimParticleStructArray{ParticleTuple, FieldArrays, IndexType},
         SimViscosity::SV,
         SimDensityDiffusion::SDD,
         SimTimeStepping::TimeSteppingMode,
         ParticleNormalsPath::Union{Nothing,String} = nothing
-        ) where {Dimensions,FloatType,SMode,KMode,BMode,LMode,SV<:SPHViscosity,SDD<:SPHDensityDiffusion}
+        ) where {Dimensions,FloatType,SMode,KMode,BMode,LMode,SV<:SPHViscosity,SDD<:SPHDensityDiffusion,ParticleTuple,FieldArrays,IndexType}
 
         NumberOfPoints = length(SimParticles)
 

--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -33,7 +33,7 @@ module SPHExample
     export ParticleType, Fixed, Fluid, Moving, Geometry, MotionDetails
 
     using .PreProcess
-    export AllocateDataStructures, AllocateSupportDataStructures, AllocateThreadedArrays, LoadBoundaryNormals
+    export AllocateDataStructures, AllocateSupportDataStructures, AllocateThreadedArrays, LoadBoundaryNormals, SimParticleStructArray
 
     using .ProduceHDFVTK
     export SaveVTKHDF, GenerateGeometryStructure, GenerateStepStructure, AppendVTKHDFData, SaveCellGridVTKHDF, AppendVTKHDFGridData, SetupVTKOutput


### PR DESCRIPTION
### Motivation
- Improve compiler specialization at the simulation boundary by making the particle `StructArray` shape concrete so the particle field tuple is visible to methods called from `RunSimulation` and neighbor loops.
- Reduce runtime dynamic field lookup and potential JET reports by threading a concrete particle container alias through hot entry points and kernels.

### Description
- Add `SimParticleStructArray` alias in `src/PreProcess.jl` as `const SimParticleStructArray{ParticleTuple, FieldArrays, IndexType} = StructArray{ParticleTuple, 1, FieldArrays, IndexType}` and export it.
- Thread the `SimParticleStructArray{ParticleTuple, FieldArrays, IndexType}` type into signatures for `RunSimulation`, `SimulationLoop`, all `NeighborLoopPerParticle!` overloads, and `ComputeInteractionsPerParticle!` variants in `src/SPHCellList.jl` so the particle tuple and field arrays are concrete to the compiler.
- Specialize `SetupVTKOutput` in `src/ProduceHDFVTK.jl` to accept a typed `StructArray` (`StructArray{ParticleTuple, 1, FieldArrays, IndexType}`) and add the necessary `StructArrays` import.
- Re-export `SimParticleStructArray` from the package entrypoint in `src/SPHExample.jl` so downstream code can use the alias in signatures.

### Testing
- Verified package loads with `julia --project=. -e 'using SPHExample; println("loaded")'`, which succeeded.
- Ran the test suite with `julia --project=. -e 'using Pkg; Pkg.test()'`, which errored: `time stepping` test raised `MethodError` for a `Δt` call (no matching 5-argument method); this failure appears unrelated to the particle-container specialization.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ad0b3beb88323933889f4f3916aa9)