### PR TITLE
Clean SPHCellList imports

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -1,9 +1,6 @@
-﻿module SPHCellList
+module SPHCellList
 
 export NeighborLoop!, ComputeInteractions!, RunSimulation
-
-using Parameters, FastPow, StaticArrays, Base.Threads
-import LinearAlgebra: dot
 
 using ..SimulationEquations
 using ..SimulationGeometry
@@ -20,17 +17,14 @@ using ..SPHViscosityModels
 using ..SPHDensityDiffusionModels
 using ..SPHNeighborList: BuildNeighborCellLists!, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, FindCellIndex, MapFloor, UpdateNeighbors!, UpdateΔx!
 
-using StaticArrays
-using StructArrays: StructArray, foreachfield
-using LinearAlgebra: dot, norm, diagm, diag, cond, det
-using Parameters: @unpack
+using Base.Threads: @threads
+using Bumper: @alloc, @no_escape
 using FastPow: @fastpow
-using Format
-using TimerOutputs
-using HDF5
-using Base.Threads
-using LinearAlgebra
-    using Bumper
+using LinearAlgebra: det, dot, norm
+using Parameters: @unpack
+using StaticArrays: SMatrix, SVector
+using StructArrays: StructArray
+using TimerOutputs: @timeit
 
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L},
@@ -46,7 +40,7 @@ using LinearAlgebra
                                                   SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
         ParticleType = SimParticles.Type
-        @inbounds Threads.@threads for i in eachindex(Position)
+        @inbounds @threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
             CellListIndex = CellListIndices[i]
@@ -104,7 +98,7 @@ using LinearAlgebra
                                                   SV<:SPHViscosity}
         @unpack Kernel, KernelGradient = SimParticles
         ParticleType = SimParticles.Type
-        @inbounds Threads.@threads for i in eachindex(Position)
+        @inbounds @threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
             kernel_acc = zero(Kernel[i])
@@ -170,7 +164,7 @@ using LinearAlgebra
                                                   L<:LogMode,SDD<:SPHDensityDiffusion,
                                                   SV<:SPHViscosity}
         ParticleType = SimParticles.Type
-        @inbounds Threads.@threads for i in eachindex(Position)
+        @inbounds @threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
             shift_c_acc = zero(∇Cᵢ[i])
@@ -239,7 +233,7 @@ using LinearAlgebra
                                                   SV<:SPHViscosity}
         @unpack Kernel, KernelGradient = SimParticles
         ParticleType = SimParticles.Type
-        @inbounds Threads.@threads for i in eachindex(Position)
+        @inbounds @threads for i in eachindex(Position)
             dρdt_acc = zero(dρdtI[i])
             acc_acc = zero(Acceleration[i])
             kernel_acc = zero(Kernel[i])


### PR DESCRIPTION
### Motivation
- Reduce duplicated and broad imports in `src/SPHCellList.jl` to make the module surface explicit and easier to audit. 
- Limit threading and linear-algebra imports to only the macros/functions actually used to avoid namespace clutter and improve static analysis output.
- Remove unused package imports discovered via static search and JET/lint output to simplify dependency friction for analysis tools.

### Description
- Consolidated multiple import lines into a single explicit import block at the top of `src/SPHCellList.jl` and removed duplicate entries. 
- Replaced `using Base.Threads` + `Threads.@threads` occurrences with `using Base.Threads: @threads` and updated loop annotations to `@threads`. 
- Replaced broad `LinearAlgebra` imports with `using LinearAlgebra: det, dot, norm`. 
- Added targeted imports for `Bumper: @alloc, @no_escape`, `FastPow: @fastpow`, `Parameters: @unpack`, `StaticArrays: SMatrix, SVector`, `StructArrays: StructArray`, and `TimerOutputs: @timeit`, and removed unused imports such as `Format` and `HDF5`.

### Testing
- Ran a targeted symbol search with `rg` to confirm remaining symbols in the file and validate removal of unused imports, which succeeded. 
- Executed a JET analysis run (`tmp=$(mktemp -d) && JULIA_PROJECT=$tmp julia -e 'using Pkg; Pkg.develop(path="."); Pkg.add("JET"); using SPHExample, JET; report_package(SPHExample)'`) to ensure the module is analyzable, which completed and produced analyzer output. 
- Verified the package loads with `julia --project=. -e 'using SPHExample; println("SPHExample loaded")'`, which succeeded. 
- Ran the test suite with `julia --project=. -e 'using Pkg; Pkg.test()'`, which failed in the existing time-stepping test with `MethodError: no method matching Δt(::Vector{SVector{2, Float64}}, ::Vector{SVector{2, Float64}}, ::Vector{SVector{2, Float64}}, ::SimulationConstants{Float64}, ::SPHKernelInstance{WendlandC2, 2, Float64})` and is unrelated to the import cleanup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ae397d5d4832389edd8b6082629e4)