### PR TITLE
Fix ParaView 6.1 warnings

### DIFF
--- a/src/OpenExternalPrograms.jl
+++ b/src/OpenExternalPrograms.jl
@@ -161,10 +161,12 @@ function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames;
                             Simulation_vtkhdfDisplay.RescaleTransferFunctionToDataRange(True, False)
 
                             # show color bar/color legend
-                            Simulation_vtkhdfDisplay.SetScalarBarVisibility(renderView1, True)
                             colorTransferFunction = GetColorTransferFunction('$(color_variable)')
                             colorLegend = GetScalarBar(colorTransferFunction, renderView1)
+                            colorLegend.AutomaticLabelFormat = 0
                             colorLegend.LabelFormat = '{:.0f}'
+                            colorLegend.RangeLabelFormat = '{:.0f}'
+                            Simulation_vtkhdfDisplay.SetScalarBarVisibility(renderView1, True)
                             
                             # Focus the camera on the dataset
                             renderView1.ResetCamera()

--- a/src/OpenExternalPrograms.jl
+++ b/src/OpenExternalPrograms.jl
@@ -86,10 +86,10 @@ function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames;
                             # import regex library
                             import re
 
-                            # state file generated using paraview version 6.0.0
+                            # state file generated using paraview version 6.1.0
                             import paraview
                             paraview.compatibility.major = 6
-                            paraview.compatibility.minor = 0
+                            paraview.compatibility.minor = 1
                             
                             # Directory containing the .vtkhdf files
                             directory = "$(SimMetaData.SaveLocation)"
@@ -162,6 +162,9 @@ function AutoOpenParaview(SimMetaData::SimulationMetaData, OutputVariableNames;
 
                             # show color bar/color legend
                             Simulation_vtkhdfDisplay.SetScalarBarVisibility(renderView1, True)
+                            colorTransferFunction = GetColorTransferFunction('$(color_variable)')
+                            colorLegend = GetScalarBar(colorTransferFunction, renderView1)
+                            colorLegend.LabelFormat = '{:.0f}'
                             
                             # Focus the camera on the dataset
                             renderView1.ResetCamera()


### PR DESCRIPTION
### Motivation
- Avoid deprecation and compatibility warnings emitted by ParaView 6.1 when loading the auto-generated state file by updating the generated compatibility metadata and switching the scalar bar label format to `std::format` syntax.

### Description
- Modify `src/OpenExternalPrograms.jl` to update the generated ParaView state to `paraview.compatibility.minor = 1` and add explicit scalar bar formatting via `GetColorTransferFunction`, `GetScalarBar`, and `colorLegend.LabelFormat = '{:.0f}'` to prevent printf-to-std::format conversion warnings.

### Testing
- Ran `julia --project=. -e 'using SPHExample'`, which precompiled and loaded the package successfully; ran `git diff --check`, which reported no issues; and ran `julia --project=. -e 'using Pkg; Pkg.test()'`, which failed due to an existing unrelated test error (`MethodError: no method matching Δt(...)` in `test/runtests.jl`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ae995db308323bb1b72bf10c27567)