### PR TITLE
Branch shifting limiter terms

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -510,10 +510,11 @@ using TimerOutputs: @timeit
 
             kernel_acc, kernel_grad_acc = compute_kernel_output_local(SimMetaData, kernel_acc, kernel_grad_acc, SimKernel, q, ∇ᵢWᵢⱼ)
 
-            MotionLimiterCondition = ParticleType[i]==Fluid && ParticleType[j]==Fluid #MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
-            Vᵢ = m₀ / ρᵢ
-            shift_c_acc += Vⱼ * Wᵢⱼ * Vᵢ * ∇ᵢWᵢⱼ * MotionLimiterCondition
-            shift_r_acc += Vⱼ * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MotionLimiterCondition
+            if ParticleType[i] == Fluid && ParticleType[j] == Fluid
+                Vᵢ = m₀ / ρᵢ
+                shift_c_acc += Vⱼ * Wᵢⱼ * Vᵢ * ∇ᵢWᵢⱼ
+                shift_r_acc += Vⱼ * dot(-xᵢⱼ, ∇ᵢWᵢⱼ)
+            end
         end
 
         return dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc, shift_r_acc
@@ -566,9 +567,10 @@ using TimerOutputs: @timeit
 
             acc_acc += dvdt⁺ + visc_term
 
-            MotionLimiterCondition = ParticleType[i]==Fluid && ParticleType[j]==Fluid #MotionLimiterValue(eltype(ρᵢ), ParticleType[i]) * MotionLimiterValue(eltype(ρᵢ), ParticleType[j])
-            shift_c_acc += Vⱼ * Wᵢⱼ * Vⱼ * ∇ᵢWᵢⱼ * MotionLimiterCondition
-            shift_r_acc += Vⱼ * dot(-xᵢⱼ, ∇ᵢWᵢⱼ) * MotionLimiterCondition
+            if ParticleType[i] == Fluid && ParticleType[j] == Fluid
+                shift_c_acc += Vⱼ * Wᵢⱼ * Vⱼ * ∇ᵢWᵢⱼ
+                shift_r_acc += Vⱼ * dot(-xᵢⱼ, ∇ᵢWᵢⱼ)
+            end
         end
 
         return dρdt_acc, acc_acc, shift_c_acc, shift_r_acc


### PR DESCRIPTION
### Motivation
- Avoid computing shift-related vector expressions for non-fluid interaction pairs because boolean-multiplied vector expressions can still perform expensive math even when the logical condition is false, so a branch can save work when many neighbours are boundary/non-fluid.
- Microbenchmarking indicated the branched form is faster in a mixed fluid/boundary workload while producing identical results.

### Description
- Replace `MotionLimiterCondition` boolean scalar multiplication with an explicit `if ParticleType[i] == Fluid && ParticleType[j] == Fluid` branch in the kernel-output shifting path in `src/SPHCellList.jl` so `Vᵢ` and shift accumulations are only computed for fluid-fluid pairs.
- Apply the same explicit fluid-fluid branch in the no-kernel-output shifting path in `src/SPHCellList.jl` to avoid computing unnecessary `shift_c_acc` and `shift_r_acc` terms for non-fluid pairs.
- Commit contains only these branch replacements and associated minor reformatting in `src/SPHCellList.jl`.

### Testing
- Ran `julia --project=. -e 'using Pkg; Pkg.test()'`, which errored in an existing `time stepping` test due to a preexisting `MethodError: no method matching Δt(...)` unrelated to this change (tests did not pass).
- Ran `julia --project=. -e 'using SPHExample; println("loaded")'` which succeeded and precompiled the package.
- Executed an ad-hoc automated microbenchmark comparing boolean-multiplication vs branched accumulation over 5,000,000 mixed pairs, which returned `boolmul seconds=0.016947455`, `branched seconds=0.006823296`, and identical numeric results (`same=true`).
- Ran `git diff --check` (no whitespace/errors reported) as part of verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aeb94b0988323b7764e4742188780)