### PR TITLE
Compress neighbor cell adjacency storage

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -15,7 +15,7 @@ using ..OpenExternalPrograms
 using ..SPHKernels
 using ..SPHViscosityModels
 using ..SPHDensityDiffusionModels
-using ..SPHNeighborList: BuildNeighborCellLists!, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, FindCellIndex, MapFloor, UpdateNeighbors!, UpdateΔx!
+using ..SPHNeighborList: BuildNeighborCellLists!, CompressedNeighborCellLists, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, FindCellIndex, MapFloor, UpdateNeighbors!, UpdateΔx!
 
 using Base.Threads: @threads
 using Bumper: @alloc, @no_escape
@@ -728,7 +728,7 @@ using TimerOutputs: @timeit
 
             SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace, ParticleRanges, UniqueCells, CellListIndices)
             UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-            BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
+            NeighborCellLists = BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
 
             if TimeSteppingMode isa SingleNeighborTimeStepping
                 @timeit SimMetaData.HourGlass "00 Init Pressure"                          Pressure!(SimParticles.Pressure, SimParticles.Density, SimConstants)
@@ -759,7 +759,7 @@ using TimerOutputs: @timeit
                         @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellListIndices)
                         SimMetaData.Δx    = zero(eltype(dρdtI))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
-                        BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
+                        NeighborCellLists = BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
                     end
                 end
 
@@ -855,7 +855,7 @@ using TimerOutputs: @timeit
         UniqueCells            = zeros(CartesianIndex{Dimensions}, NumberOfPoints)
         CellListIndices        = zeros(Int, NumberOfPoints)
         FullStencil            = ConstructStencil(Val(Dimensions))
-        NeighborCellLists      = [Int[] for _ in 1:length(UniqueCells)]
+        NeighborCellLists      = CompressedNeighborCellLists(FullStencil, length(UniqueCells))
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
 
         output = SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)

--- a/src/SPHExample.jl
+++ b/src/SPHExample.jl
@@ -58,7 +58,7 @@ module SPHExample
     export SimulationConstants
 
     using .SPHNeighborList
-    export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts
+    export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts, CompressedNeighborCellLists
 
     using .SPHCellList
     export NeighborLoop!, ComputeInteractions!, RunSimulation

--- a/src/SPHNeighborList.jl
+++ b/src/SPHNeighborList.jl
@@ -1,6 +1,6 @@
 module SPHNeighborList
 
-export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts, UpdateΔx!, FindCellIndex
+export ConstructStencil, ExtractCells!, UpdateNeighbors!, BuildNeighborCellLists!, ComputeCellParticleCounts, ComputeCellNeighborCounts, UpdateΔx!, FindCellIndex, CompressedNeighborCellLists
 
 using StaticArrays
 
@@ -20,20 +20,67 @@ end
     return 1
 end
 
-function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
-    TargetLen   = length(UniqueCellsView)
-    OriginalLen = length(NeighborCellLists)
-    resize!(NeighborCellLists, TargetLen)
+"""
+    CompressedNeighborCellLists(FullStencil, CellCapacity)
 
-    if TargetLen > OriginalLen
-        @inbounds for Index in (OriginalLen + 1):TargetLen
-            NeighborCellLists[Index] = Int[]
-        end
+Stores per-cell neighbor adjacency in one dense `(max_neighbors, n_cells)` matrix
+plus a count per cell, avoiding one small `Vector{Int}` allocation per cell.
+"""
+mutable struct CompressedNeighborCellLists
+    Indices::Matrix{Int}
+    Counts::Vector{Int}
+end
+
+function CompressedNeighborCellLists(FullStencil, CellCapacity::Integer)
+    MaxNeighborCount = length(FullStencil) - 1
+    return CompressedNeighborCellLists(Matrix{Int}(undef, MaxNeighborCount, CellCapacity), zeros(Int, CellCapacity))
+end
+
+struct NeighborCellIndices
+    Indices::Matrix{Int}
+    CellIndex::Int
+    Count::Int
+end
+
+@inline Base.length(Neighbors::NeighborCellIndices) = Neighbors.Count
+@inline Base.eltype(::Type{NeighborCellIndices}) = Int
+@inline Base.IteratorSize(::Type{NeighborCellIndices}) = Base.HasLength()
+
+@inline function Base.iterate(Neighbors::NeighborCellIndices, State::Int = 1)
+    State > Neighbors.Count && return nothing
+    return (@inbounds(Neighbors.Indices[State, Neighbors.CellIndex]), State + 1)
+end
+
+@inline function Base.getindex(NeighborCellLists::CompressedNeighborCellLists, CellIndex::Integer)
+    return NeighborCellIndices(NeighborCellLists.Indices, CellIndex, @inbounds(NeighborCellLists.Counts[CellIndex]))
+end
+
+function EnsureNeighborCellCapacity!(NeighborCellLists::CompressedNeighborCellLists, CellCount::Integer)
+    if CellCount <= length(NeighborCellLists.Counts)
+        return nothing
     end
 
+    MaxNeighborCount = size(NeighborCellLists.Indices, 1)
+    NewIndices = Matrix{Int}(undef, MaxNeighborCount, CellCount)
+    NewCounts = zeros(Int, CellCount)
+    OldCellCount = length(NeighborCellLists.Counts)
+    @inbounds for CellIndex in 1:OldCellCount
+        NewCounts[CellIndex] = NeighborCellLists.Counts[CellIndex]
+        for NeighborOffset in 1:MaxNeighborCount
+            NewIndices[NeighborOffset, CellIndex] = NeighborCellLists.Indices[NeighborOffset, CellIndex]
+        end
+    end
+    NeighborCellLists.Indices = NewIndices
+    NeighborCellLists.Counts = NewCounts
+    return nothing
+end
+
+function BuildNeighborCellLists!(NeighborCellLists::CompressedNeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
+    TargetLen = length(UniqueCellsView)
+    EnsureNeighborCellCapacity!(NeighborCellLists, TargetLen)
+
     @inbounds for CellIndex in eachindex(UniqueCellsView)
-        Neighbors = NeighborCellLists[CellIndex]
-        empty!(Neighbors)
+        NeighborCount = 0
         Cell = UniqueCellsView[CellIndex]
         for Offset in FullStencil
             NeighborCell = Cell + Offset
@@ -41,12 +88,14 @@ function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView
             StartIndex = ParticleRanges[NeighborIndex]
             EndIndex = ParticleRanges[NeighborIndex + 1] - 1
             if StartIndex <= EndIndex && NeighborIndex != CellIndex
-                push!(Neighbors, NeighborIndex)
+                NeighborCount += 1
+                NeighborCellLists.Indices[NeighborCount, CellIndex] = NeighborIndex
             end
         end
+        NeighborCellLists.Counts[CellIndex] = NeighborCount
     end
 
-    return nothing
+    return NeighborCellLists
 end
 
 """


### PR DESCRIPTION
### Motivation
- Reduce allocations and pointer-chasing from `Vector{Vector{Int}}` per-cell neighbor lists by using a compact adjacency layout. 
- The stencil size is bounded (max 3^D - 1), so a fixed-size dense layout plus per-cell counts can improve cache locality in the inner neighbor loops. 
- Preserve existing neighbor-iteration ergonomics so calling code in hot loops requires minimal changes. 

### Description
- Add `CompressedNeighborCellLists` (dense `Matrix{Int}` of shape `(max_neighbors, n_cells)` plus `Counts::Vector{Int}`) to store adjacency compactly. 
- Provide `NeighborCellIndices` iterator and `Base.getindex` so `for NeighborIdx in NeighborCellLists[cell]` remains valid. 
- Implement `EnsureNeighborCellCapacity!` and update `BuildNeighborCellLists!` to populate the compressed layout and return the structure. 
- Update alloc/rebuild sites in `src/SPHCellList.jl` to allocate `CompressedNeighborCellLists(...)` and accept the returned value from `BuildNeighborCellLists!`, and re-export `CompressedNeighborCellLists` from the top-level module. 

### Testing
- Ran `git diff --check` which reported no whitespace/errors. 
- Ran `julia --project=. -e 'using SPHExample'` which precompiled and loaded the package successfully. 
- Ran a focused neighbor-list unit check with `julia --project=. -e 'using Test; using SPHExample.SPHNeighborList; ... BuildNeighborCellLists!(...) ; @test collect(lists[2]) == [3,4]'` which validated neighbor enumeration and succeeded. 
- Ran the full test suite with `julia --project=. -e 'using Pkg; Pkg.test()'`, which errored in an existing time-stepping test due to a mismatched `Δt` method signature unrelated to the neighbor-list changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4aeb26bf588323a68689a482554e3b)