### PR TITLE
Use muladd/Horner forms for kernel polynomials

### DIFF
--- a/src/SPHKernels.jl
+++ b/src/SPHKernels.jl
@@ -2,7 +2,6 @@ module SPHKernels
 
 using Parameters
 using LinearAlgebra
-using FastPow
 
 export SPHKernel, SPHKernelInstance, WendlandC2, CubicSpline, Wᵢⱼ, ∇Wᵢⱼ, tensile_correction
 
@@ -74,7 +73,9 @@ end
 # Kernel Evaluation Functions
 @inline function Wᵢⱼ(kernel::SPHKernelInstance{<:WendlandC2}, q::T) where {T}
     @unpack αD = kernel
-    return αD * (1 - q/2)^4 * (2q + 1)
+    s = muladd(-q, T(1//2), one(T))
+    s² = s * s
+    return αD * s² * s² * muladd(T(2), q, one(T))
 end
 
 @inline function ∇Wᵢⱼ(kernel::SPHKernelInstance{<:WendlandC2}, q::T, xᵢⱼ) where {T}
@@ -82,13 +83,23 @@ end
     # Subhan Allah, if this math is correct, then η² can be avoided
     # denom = (q * h + η²)
     # factor = αD * 5 * (q - 2)^3 * q / (8 * h * denom)
-    factor = αD * 5 * (q - 2)^3 / (8 * h * h)
+    qₘ₂ = q - T(2)
+    factor = αD * T(5//8) * qₘ₂ * qₘ₂ * qₘ₂ / (h * h)
     return factor * xᵢⱼ
 end
 
 @inline function Wᵢⱼ(kernel::SPHKernelInstance{<:CubicSpline}, q::T) where {T}
     @unpack αD = kernel
-    return αD * (((1 - (3/2)*q^2 + (3/4)*q^3) * (0 <= q <= 1)) + ((1/4)*(2 - q)^3 * (1 < q <= 2)))
+
+    if 0 <= q <= 1
+        q² = q * q
+        return αD * muladd(muladd(T(3//4), q, T(-3//2)), q², one(T))
+    elseif 1 < q <= 2
+        q₂ = T(2) - q
+        return αD * T(1//4) * q₂ * q₂ * q₂
+    else
+        return zero(T)
+    end
 end
 
 @inline function ∇Wᵢⱼ(kernel::SPHKernelInstance{<:CubicSpline}, q::T, xᵢⱼ) where {T}
@@ -97,9 +108,10 @@ end
     # inv_r_h = 1/(r + η²)  # η² is a small regularization to avoid division by zero
     
     if 0 <= q <= 1
-        dWdq = αD * (-3*q + (9/4)*q^2)
+        dWdq = αD * q * muladd(T(9//4), q, T(-3))
     elseif 1 < q <= 2
-        dWdq = αD * (-3/4)*(2 - q)^2
+        q₂ = T(2) - q
+        dWdq = αD * T(-3//4) * q₂ * q₂
     else
         dWdq = zero(T)
     end


### PR DESCRIPTION
### Motivation
- Replace small polynomial `^`/expanded forms in kernel evaluations with `muladd`/Horner-style and explicit repeated products to reduce per-pair allocation and improve performance for hot inner loops.
- Remove the now-unused `FastPow` import since kernels no longer rely on small `^` operations.

### Description
- Removed `using FastPow` from `src/SPHKernels.jl` and kept the public API unchanged.
- Rewrote `Wᵢⱼ` for `WendlandC2` to compute `s = 1 - q/2` via `muladd`, use `s*s` repeated products, and evaluate the linear factor with `muladd` to avoid small powers.
- Rewrote the `WendlandC2` gradient to compute `(q-2)^3` via an explicit `qₘ₂` variable and repeated multiplications and replace the numeric literal `5/8` with `T(5//8)` for correct typed arithmetic.
- Rewrote `CubicSpline` branches to use a Horner-style `muladd` form for `0 <= q <= 1` and explicit cubic/square products for `1 < q <= 2`, and adjusted the derivative branch to the corresponding `muladd`/explicit-product forms.

### Testing
- Ran the smoke-check command `julia --project=. -e 'using SPHExample; k=SPHKernelInstance{2,Float64}(WendlandC2(); dx=0.1); Wᵢⱼ(k, 0.5); ∇Wᵢⱼ(k, 0.5, [1.0, 0.0]); c=SPHKernelInstance{2,Float64}(CubicSpline{Float64}(); dx=0.1); Wᵢⱼ(c, 0.5); ∇Wᵢⱼ(c, 0.5, [1.0, 0.0]); println("ok")'` which executed and printed `ok`.
- Ran the full test suite with `julia --project=. -e 'using Pkg; Pkg.test()'` which exercised precompilation but resulted in an existing unrelated test error in the `time stepping` suite (`MethodError: no method matching Δt(...)`), so package tests did not fully pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4af32de3008323b687771cbd7aea41)