### PR TITLE
Support Float32 simulation paths

### DIFF
--- a/src/AuxiliaryFunctions.jl
+++ b/src/AuxiliaryFunctions.jl
@@ -17,7 +17,7 @@ Fill each array in `arrays` with zeros in place.
 
 Convert a vector of 2D `SVector`s to 3D by appending a zero z-component.
 """
-@inline to_3d(vec_2d) = [SVector(v..., 0.0) for v in vec_2d]
+@inline to_3d(vec_2d) = [SVector{3,eltype(v)}(v[1], v[2], zero(eltype(v))) for v in vec_2d]
 
 """
     to_3d!(dest, src)

--- a/src/SPHKernels.jl
+++ b/src/SPHKernels.jl
@@ -113,7 +113,7 @@ end
 # Tensile Corrections for specific kernels
 #---------------------------------------------------------------
 @inline function tensile_correction(instance::SPHKernelInstance{<:WendlandC2}, Pᵢ, ρᵢ, Pⱼ, ρⱼ, q, dx)
-     return zero(eltype(q))
+    return zero(q)
 end
 
 @inline function tensile_correction(instance::SPHKernelInstance{<:CubicSpline}, Pᵢ, ρᵢ, Pⱼ, ρⱼ, q, dx; n = 4)

--- a/src/SimulationEquations.jl
+++ b/src/SimulationEquations.jl
@@ -46,21 +46,10 @@ end
     return SVector{N, T}(ntuple(i -> i == N ? value : 0, N))
 end
 
-#https://discourse.julialang.org/t/can-this-be-written-even-faster-cpu/109924/28
-@inline function Estimate7thRoot(x)
-    # todo tune the magic constant
-    # initial guess based on fast inverse sqrt trick but adjusted to compute x^(1/7)
-    t = copysign(reinterpret(Float64, 0x36cd000000000000 + reinterpret(UInt64,abs(x))÷7), x)
-    @fastmath for _ in 1:2
-        # newton's method for t^3 - x/t^4 = 0
-        t2 = t*t
-        t3 = t2*t
-        t4 = t2*t2
-        xot4 = x/t4
-        t = t - t*(t3 - xot4)/(4*t3 + 3*xot4)
-    end
-    t
+@inline function Estimate7thRoot(x::T) where {T<:AbstractFloat}
+    return copysign(abs(x)^(inv(T(7))), x)
 end
-@inline InverseHydrostaticEquationOfState(ρ₀, P, invCb) = ρ₀ * ( Estimate7thRoot( 1 + (P * invCb)) - 1)
+@inline Estimate7thRoot(x::Real) = Estimate7thRoot(float(x))
+@inline InverseHydrostaticEquationOfState(ρ₀, P, invCb) = ρ₀ * (Estimate7thRoot(one(P * invCb) + (P * invCb)) - one(P * invCb))
 
 end

--- a/src/TimeStepping.jl
+++ b/src/TimeStepping.jl
@@ -33,6 +33,14 @@ function Δt(max_acceleration, SimulationConstants, SPHKernel)
     return CFL * min(dt_speed, dt_force)
 end
 
+@inline function Δt(Position, Velocity, Acceleration, SimulationConstants, SPHKernel)
+    max_acceleration = zero(eltype(first(Acceleration)))
+    @inbounds for a in Acceleration
+        max_acceleration = max(max_acceleration, norm(a))
+    end
+    return Δt(max_acceleration, SimulationConstants, SPHKernel)
+end
+
 """
     UpdateTimeStep(AccelerationMax, SimConstants, SimKernel)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,7 +59,7 @@ end
                                            ρ_n, dρdtI, dt2)
         LimitDensityAtBoundary!(ρ_n, sc.ρ₀, particles.MotionLimiter)
         Pressure!(press, ρ_n, sc)
-        SPHExample.SPHCellList.FullTimeStep(meta, ker, sc, particles, ∇C, ∇r, dt)
+        SPHExample.SPHCellList.FullTimeStep(meta, ker, sc, particles, vel_n, ∇C, ∇r, dt)
         DensityEpsi!(dens, dρdtI, ρ_n, dt)
         LimitDensityAtBoundary!(dens, sc.ρ₀, particles.MotionLimiter)
         SPHExample.SPHCellList.UpdateMetaData!(meta, dt)
@@ -71,4 +71,29 @@ end
     @test particles.Position[1][1] == 0
     @test particles.Velocity[1][1] == 0
     @test particles.Velocity[1][2] < 0
+end
+
+@testset "Float32 support" begin
+    D = 2
+    T = Float32
+    sc = SimulationConstants{T}()
+    ker = SPHKernelInstance{D,T}(WendlandC2(); dx=sc.dx)
+
+    @test sc.dx isa T
+    @test ker.h isa T
+    @test Estimate7thRoot(T(1.1)) isa T
+    @test InverseHydrostaticEquationOfState(sc.ρ₀, T(1), sc.Cb⁻¹) isa T
+    @test tensile_correction(ker, T(0), sc.ρ₀, T(0), sc.ρ₀, T(0.5), sc.dx) === zero(T)
+
+    pos2 = [SVector{2,T}(1, 2)]
+    pos3 = to_3d(pos2)
+    @test pos3 isa Vector{SVector{3,T}}
+    @test pos3[1] == SVector{3,T}(1, 2, 0)
+
+    pos = [SVector{D,T}(0, 0), SVector{D,T}(1, 0)]
+    vel = [SVector{D,T}(0, 0), SVector{D,T}(0, 0)]
+    acc = [SVector{D,T}(0, 0), SVector{D,T}(0, -sc.g)]
+    dt = Δt(pos, vel, acc, sc, ker)
+    @test dt isa T
+    @test dt > zero(T)
 end


### PR DESCRIPTION
### Motivation
- Enable the library to run simulations and helper functions with `Float32` without accidental promotion to `Float64` or reinterpret casts that fail for smaller floats.
- Preserve element types when converting 2D `SVector`s to 3D so generated vectors keep the same float precision.
- Make kernel/tensile helper and timestep utilities accept particle-array inputs and return type-consistent scalar results for `Float32`.

### Description
- Replace the `Float64`-only reinterpret trick in `Estimate7thRoot` with a type-generic implementation and add an overload for `Real`, and update `InverseHydrostaticEquationOfState` to be type-preserving. (`src/SimulationEquations.jl`)
- Preserve element types in `to_3d` by constructing `SVector{3,eltype(v)}` and using `zero(eltype(v))` for the z-component. (`src/AuxiliaryFunctions.jl`)
- Make the Wendland tensile correction return `zero(q)` so scalar `q` inputs (including `Float32`) produce a zero of the correct type. (`src/SPHKernels.jl`)
- Add a convenience `Δt` overload that accepts particle `Position`, `Velocity`, and `Acceleration` vectors and computes the maximum acceleration before delegating to the scalar `Δt` path. (`src/TimeStepping.jl`)
- Add a `Float32` coverage testset exercising constants, kernel instance creation, `Estimate7thRoot`, `InverseHydrostaticEquationOfState`, `tensile_correction`, `to_3d`, and the particle-vector `Δt`. (`test/runtests.jl`)

### Testing
- Ran the package test file with `julia --project=. test/runtests.jl` and observed the full test suite (including the new `Float32 support` tests) pass. (success)
- Executed a direct runtime smoke check with `julia --project=. -e 'using SPHExample, StaticArrays; T=Float32; ...'` that asserts key functions and types return `Float32` values and that `Δt` returns a `Float32` timestep. (success)
- Attempted `julia --project=. -e 'using Pkg; Pkg.test()'` but the invocation stalled during temporary test-environment precompilation; the direct test file execution was used to validate changes instead. (precompilation stalled)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4af2efb86083238f3bd32e1ded30a0)