### PR TITLE
Handle interrupted VTKHDF output

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Run the script to start the simulation. Results are written in `hdfvtk` format
 which can be loaded with ParaView 5.12 or newer. Output is written
 asynchronously, so files finish flushing when the simulation completes.
 Pressing `Ctrl+C` during `RunSimulation` also flushes and closes the active
-VTKHDF output before opening the data written so far in ParaView.
+VTKHDF output, finalizes the `.log` file, and opens the data written so far in
+ParaView.
 To color exported cell grids by particle counts, set
 `ExportGridCellParticleCounts=true` in `SimulationMetaData`. This also adds a
 `ParticleNeighborsPerCell` array that includes each cell's particle count minus

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ and adjust the simulation parameters or the `ComputerInteractions!` function.
 Run the script to start the simulation. Results are written in `hdfvtk` format
 which can be loaded with ParaView 5.12 or newer. Output is written
 asynchronously, so files finish flushing when the simulation completes.
+Pressing `Ctrl+C` during `RunSimulation` also flushes and closes the active
+VTKHDF output before opening the data written so far in ParaView.
 To color exported cell grids by particle counts, set
 `ExportGridCellParticleCounts=true` in `SimulationMetaData`. This also adds a
 `ParticleNeighborsPerCell` array that includes each cell's particle count minus

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -839,6 +839,36 @@ using TimerOutputs: @timeit
         return nothing
     end
 
+    function RunWithSimulationFinalizer!(RunFunction, SimMetaData, SimLogger, output)
+        OutputFinalized = Ref(false)
+
+        atexit() do
+            if !OutputFinalized[]
+                @warn "Julia is exiting before the simulation completed; closing VTKHDF output, finalizing the log, and opening ParaView for the data written so far."
+                FinalizeSimulationOutput!(SimMetaData, SimLogger, output; log_status="stopped as Julia exited")
+                OutputFinalized[] = true
+            end
+        end
+
+        Base.exit_on_sigint(false)
+
+        try
+            RunFunction(OutputFinalized)
+        catch e
+            if e isa InterruptException
+                @warn "Simulation interrupted; closing VTKHDF output, finalizing the log, and opening ParaView for the data written so far."
+                if !OutputFinalized[]
+                    FinalizeSimulationOutput!(SimMetaData, SimLogger, output; log_status="interrupted")
+                    OutputFinalized[] = true
+                end
+                return nothing
+            end
+            rethrow()
+        end
+
+        return nothing
+    end
+
     ###===
     function RunSimulation(;SimGeometry::Vector{Geometry{Dimensions, FloatType}}, #Don't further specify type for now
         SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
@@ -903,58 +933,50 @@ using TimerOutputs: @timeit
 
         MotionDefinition = GenerateMotionDetails(SimParticles, SimGeometry, Dimensions, FloatType)
 
-        OutputFinalized = Ref(false)
-        Base.exit_on_sigint(true)
-        atexit() do
-            if !OutputFinalized[]
-                @warn "Julia is exiting before the simulation completed; closing VTKHDF output, finalizing the log, and opening ParaView for the data written so far."
-                FinalizeSimulationOutput!(SimMetaData, SimLogger, output; log_status="stopped as Julia exited")
-                OutputFinalized[] = true
-            end
-        end
+        RunWithSimulationFinalizer!(SimMetaData, SimLogger, output) do OutputFinalized
+            @inbounds while true
 
-        @inbounds while true
-
-            @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
-                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                SimConstants, SimParticles, FullStencil, ParticleRanges,
-                UniqueCells, CellListIndices, SortingScratchSpace,
-                NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
-                ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
-            )
-            push!(SimMetaData.TimeSteps, SimMetaData.CurrentTimeStep)
-
-            LogStep!(SimMetaData, SimLogger)
-
-            SimMetaData.OutputIterationCounter += 1
-
-            UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-            cell_particle_counts = nothing
-            cell_neighbor_counts = nothing
-            if SimMetaData.ExportGridCellParticleCounts
-                cell_particle_counts = ComputeCellParticleCounts(
-                    ParticleRanges,
-                    length(UniqueCellsView),
+                @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
+                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                    SimConstants, SimParticles, FullStencil, ParticleRanges,
+                    UniqueCells, CellListIndices, SortingScratchSpace,
+                    NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
+                    ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
                 )
-                cell_neighbor_counts = ComputeCellNeighborCounts(
-                    ParticleRanges,
-                    NeighborCellLists,
-                    length(UniqueCellsView),
-                )
-            end
+                push!(SimMetaData.TimeSteps, SimMetaData.CurrentTimeStep)
 
-            @timeit SimMetaData.HourGlass "13 Save Particle Data"  begin
-                output.enqueue_particles(SimMetaData.OutputIterationCounter)
-                output.enqueue_grid(SimMetaData.OutputIterationCounter, UniqueCellsView, cell_particle_counts=cell_particle_counts, cell_neighbor_counts=cell_neighbor_counts)
-            end
+                LogStep!(SimMetaData, SimLogger)
 
-            if SimMetaData.TotalTime > SimMetaData.SimulationTime
+                SimMetaData.OutputIterationCounter += 1
 
-                # At end of simulation
-                FinalizeSimulationOutput!(SimMetaData, SimLogger, output)
-                OutputFinalized[] = true
+                UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
+                cell_particle_counts = nothing
+                cell_neighbor_counts = nothing
+                if SimMetaData.ExportGridCellParticleCounts
+                    cell_particle_counts = ComputeCellParticleCounts(
+                        ParticleRanges,
+                        length(UniqueCellsView),
+                    )
+                    cell_neighbor_counts = ComputeCellNeighborCounts(
+                        ParticleRanges,
+                        NeighborCellLists,
+                        length(UniqueCellsView),
+                    )
+                end
 
-                break
+                @timeit SimMetaData.HourGlass "13 Save Particle Data"  begin
+                    output.enqueue_particles(SimMetaData.OutputIterationCounter)
+                    output.enqueue_grid(SimMetaData.OutputIterationCounter, UniqueCellsView, cell_particle_counts=cell_particle_counts, cell_neighbor_counts=cell_neighbor_counts)
+                end
+
+                if SimMetaData.TotalTime > SimMetaData.SimulationTime
+
+                    # At end of simulation
+                    FinalizeSimulationOutput!(SimMetaData, SimLogger, output)
+                    OutputFinalized[] = true
+
+                    break
+                end
             end
         end
     end

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -904,6 +904,7 @@ using TimerOutputs: @timeit
         MotionDefinition = GenerateMotionDetails(SimParticles, SimGeometry, Dimensions, FloatType)
 
         OutputFinalized = Ref(false)
+        Base.exit_on_sigint(true)
         atexit() do
             if !OutputFinalized[]
                 @warn "Julia is exiting before the simulation completed; closing VTKHDF output, finalizing the log, and opening ParaView for the data written so far."
@@ -912,61 +913,49 @@ using TimerOutputs: @timeit
             end
         end
 
-        try
-            @inbounds while true
+        @inbounds while true
 
-                @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
-                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                    SimConstants, SimParticles, FullStencil, ParticleRanges,
-                    UniqueCells, CellListIndices, SortingScratchSpace,
-                    NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
-                    ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
+            @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
+                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                SimConstants, SimParticles, FullStencil, ParticleRanges,
+                UniqueCells, CellListIndices, SortingScratchSpace,
+                NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
+                ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
+            )
+            push!(SimMetaData.TimeSteps, SimMetaData.CurrentTimeStep)
+
+            LogStep!(SimMetaData, SimLogger)
+
+            SimMetaData.OutputIterationCounter += 1
+
+            UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
+            cell_particle_counts = nothing
+            cell_neighbor_counts = nothing
+            if SimMetaData.ExportGridCellParticleCounts
+                cell_particle_counts = ComputeCellParticleCounts(
+                    ParticleRanges,
+                    length(UniqueCellsView),
                 )
-                push!(SimMetaData.TimeSteps, SimMetaData.CurrentTimeStep)
-
-                LogStep!(SimMetaData, SimLogger)
-
-                SimMetaData.OutputIterationCounter += 1
-
-                UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-                cell_particle_counts = nothing
-                cell_neighbor_counts = nothing
-                if SimMetaData.ExportGridCellParticleCounts
-                    cell_particle_counts = ComputeCellParticleCounts(
-                        ParticleRanges,
-                        length(UniqueCellsView),
-                    )
-                    cell_neighbor_counts = ComputeCellNeighborCounts(
-                        ParticleRanges,
-                        NeighborCellLists,
-                        length(UniqueCellsView),
-                    )
-                end
-
-                @timeit SimMetaData.HourGlass "13 Save Particle Data"  begin
-                    output.enqueue_particles(SimMetaData.OutputIterationCounter)
-                    output.enqueue_grid(SimMetaData.OutputIterationCounter, UniqueCellsView, cell_particle_counts=cell_particle_counts, cell_neighbor_counts=cell_neighbor_counts)
-                end
-
-                if SimMetaData.TotalTime > SimMetaData.SimulationTime
-
-                    # At end of simulation
-                    FinalizeSimulationOutput!(SimMetaData, SimLogger, output)
-                    OutputFinalized[] = true
-
-                    break
-                end
+                cell_neighbor_counts = ComputeCellNeighborCounts(
+                    ParticleRanges,
+                    NeighborCellLists,
+                    length(UniqueCellsView),
+                )
             end
-        catch e
-            if e isa InterruptException
-                @warn "Simulation interrupted; closing VTKHDF output, finalizing the log, and opening ParaView for the data written so far."
-                if !OutputFinalized[]
-                    FinalizeSimulationOutput!(SimMetaData, SimLogger, output; log_status="interrupted")
-                    OutputFinalized[] = true
-                end
-                return nothing
+
+            @timeit SimMetaData.HourGlass "13 Save Particle Data"  begin
+                output.enqueue_particles(SimMetaData.OutputIterationCounter)
+                output.enqueue_grid(SimMetaData.OutputIterationCounter, UniqueCellsView, cell_particle_counts=cell_particle_counts, cell_neighbor_counts=cell_neighbor_counts)
             end
-            rethrow()
+
+            if SimMetaData.TotalTime > SimMetaData.SimulationTime
+
+                # At end of simulation
+                FinalizeSimulationOutput!(SimMetaData, SimLogger, output)
+                OutputFinalized[] = true
+
+                break
+            end
         end
     end
     

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -839,6 +839,15 @@ using TimerOutputs: @timeit
         return nothing
     end
 
+    """
+        RunWithSimulationFinalizer!(RunFunction, SimMetaData, SimLogger, output)
+
+    Run the simulation body with a single cleanup boundary around it. Ctrl+C in
+    interactive Julia sessions is delivered as an `InterruptException` instead
+    of process exit, so `atexit` alone does not run for that path. Keep the
+    interrupt handling here to register Ctrl+C reliably while leaving the main
+    simulation loop free of `try`/`catch` structure.
+    """
     function RunWithSimulationFinalizer!(RunFunction, SimMetaData, SimLogger, output)
         OutputFinalized = Ref(false)
 
@@ -852,6 +861,9 @@ using TimerOutputs: @timeit
 
         Base.exit_on_sigint(false)
 
+        # This is the smallest reliable Ctrl+C boundary for REPL/VS Code/terminal
+        # execution: without catching `InterruptException`, Julia returns control
+        # to the caller and the `atexit` hook is not guaranteed to run.
         try
             RunFunction(OutputFinalized)
         catch e

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -825,6 +825,22 @@ using TimerOutputs: @timeit
         return nothing
     end
     
+    function FinalizeSimulationOutput!(SimMetaData, SimLogger, output; finalize_log::Bool=true)
+        @timeit SimMetaData.HourGlass "13B Close Data Streams" output.close_files()
+
+        show(SimMetaData.HourGlass,sortby=:name)
+        show(SimMetaData.HourGlass)
+
+        AutoOpenParaview(SimMetaData, output.variable_names)
+
+        if finalize_log
+            FinalizeLog!(SimMetaData, SimLogger)
+            AutoOpenLogFile(SimLogger, SimMetaData)
+        end
+
+        return nothing
+    end
+
     ###===
     function RunSimulation(;SimGeometry::Vector{Geometry{Dimensions, FloatType}}, #Don't further specify type for now
         SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
@@ -889,56 +905,69 @@ using TimerOutputs: @timeit
 
         MotionDefinition = GenerateMotionDetails(SimParticles, SimGeometry, Dimensions, FloatType)
 
-        @inbounds while true
+        OutputFinalized = Ref(false)
+        atexit() do
+            if !OutputFinalized[]
+                @warn "Julia is exiting before the simulation completed; closing VTKHDF output and opening ParaView for the data written so far."
+                FinalizeSimulationOutput!(SimMetaData, SimLogger, output; finalize_log=false)
+                OutputFinalized[] = true
+            end
+        end
 
-            @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
-                SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
-                SimConstants, SimParticles, FullStencil, ParticleRanges,
-                UniqueCells, CellListIndices, SortingScratchSpace,
-                NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
-                ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
-            )
-            push!(SimMetaData.TimeSteps, SimMetaData.CurrentTimeStep)
+        try
+            @inbounds while true
 
-            LogStep!(SimMetaData, SimLogger)
-
-            SimMetaData.OutputIterationCounter += 1
-
-            UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-            cell_particle_counts = nothing
-            cell_neighbor_counts = nothing
-            if SimMetaData.ExportGridCellParticleCounts
-                cell_particle_counts = ComputeCellParticleCounts(
-                    ParticleRanges,
-                    length(UniqueCellsView),
+                @timeit SimMetaData.HourGlass "00 SimulationLoop" SimulationLoop(
+                    SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
+                    SimConstants, SimParticles, FullStencil, ParticleRanges,
+                    UniqueCells, CellListIndices, SortingScratchSpace,
+                    NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
+                    ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
                 )
-                cell_neighbor_counts = ComputeCellNeighborCounts(
-                    ParticleRanges,
-                    NeighborCellLists,
-                    length(UniqueCellsView),
-                )
+                push!(SimMetaData.TimeSteps, SimMetaData.CurrentTimeStep)
+
+                LogStep!(SimMetaData, SimLogger)
+
+                SimMetaData.OutputIterationCounter += 1
+
+                UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
+                cell_particle_counts = nothing
+                cell_neighbor_counts = nothing
+                if SimMetaData.ExportGridCellParticleCounts
+                    cell_particle_counts = ComputeCellParticleCounts(
+                        ParticleRanges,
+                        length(UniqueCellsView),
+                    )
+                    cell_neighbor_counts = ComputeCellNeighborCounts(
+                        ParticleRanges,
+                        NeighborCellLists,
+                        length(UniqueCellsView),
+                    )
+                end
+
+                @timeit SimMetaData.HourGlass "13 Save Particle Data"  begin
+                    output.enqueue_particles(SimMetaData.OutputIterationCounter)
+                    output.enqueue_grid(SimMetaData.OutputIterationCounter, UniqueCellsView, cell_particle_counts=cell_particle_counts, cell_neighbor_counts=cell_neighbor_counts)
+                end
+
+                if SimMetaData.TotalTime > SimMetaData.SimulationTime
+
+                    # At end of simulation
+                    FinalizeSimulationOutput!(SimMetaData, SimLogger, output)
+                    OutputFinalized[] = true
+
+                    break
+                end
             end
-            
-            @timeit SimMetaData.HourGlass "13 Save Particle Data"  begin
-                output.enqueue_particles(SimMetaData.OutputIterationCounter)
-                output.enqueue_grid(SimMetaData.OutputIterationCounter, UniqueCellsView, cell_particle_counts=cell_particle_counts, cell_neighbor_counts=cell_neighbor_counts)
+        catch e
+            if e isa InterruptException
+                @warn "Simulation interrupted; closing VTKHDF output and opening ParaView for the data written so far."
+                if !OutputFinalized[]
+                    FinalizeSimulationOutput!(SimMetaData, SimLogger, output; finalize_log=false)
+                    OutputFinalized[] = true
+                end
             end
-
-            if SimMetaData.TotalTime > SimMetaData.SimulationTime
-
-                # At end of simulation
-                @timeit SimMetaData.HourGlass "13B Close Data Streams" output.close_files()
-
-                show(SimMetaData.HourGlass,sortby=:name)
-                show(SimMetaData.HourGlass)
-
-                AutoOpenParaview(SimMetaData, output.variable_names)
-
-                FinalizeLog!(SimMetaData, SimLogger)
-                AutoOpenLogFile(SimLogger, SimMetaData)
-
-                break
-            end
+            rethrow()
         end
     end
     

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -825,7 +825,7 @@ using TimerOutputs: @timeit
         return nothing
     end
     
-    function FinalizeSimulationOutput!(SimMetaData, SimLogger, output; finalize_log::Bool=true)
+    function FinalizeSimulationOutput!(SimMetaData, SimLogger, output; log_status::String="finished")
         @timeit SimMetaData.HourGlass "13B Close Data Streams" output.close_files()
 
         show(SimMetaData.HourGlass,sortby=:name)
@@ -833,10 +833,8 @@ using TimerOutputs: @timeit
 
         AutoOpenParaview(SimMetaData, output.variable_names)
 
-        if finalize_log
-            FinalizeLog!(SimMetaData, SimLogger)
-            AutoOpenLogFile(SimLogger, SimMetaData)
-        end
+        FinalizeLog!(SimMetaData, SimLogger; status=log_status)
+        AutoOpenLogFile(SimLogger, SimMetaData)
 
         return nothing
     end
@@ -908,8 +906,8 @@ using TimerOutputs: @timeit
         OutputFinalized = Ref(false)
         atexit() do
             if !OutputFinalized[]
-                @warn "Julia is exiting before the simulation completed; closing VTKHDF output and opening ParaView for the data written so far."
-                FinalizeSimulationOutput!(SimMetaData, SimLogger, output; finalize_log=false)
+                @warn "Julia is exiting before the simulation completed; closing VTKHDF output, finalizing the log, and opening ParaView for the data written so far."
+                FinalizeSimulationOutput!(SimMetaData, SimLogger, output; log_status="stopped as Julia exited")
                 OutputFinalized[] = true
             end
         end
@@ -961,11 +959,12 @@ using TimerOutputs: @timeit
             end
         catch e
             if e isa InterruptException
-                @warn "Simulation interrupted; closing VTKHDF output and opening ParaView for the data written so far."
+                @warn "Simulation interrupted; closing VTKHDF output, finalizing the log, and opening ParaView for the data written so far."
                 if !OutputFinalized[]
-                    FinalizeSimulationOutput!(SimMetaData, SimLogger, output; finalize_log=false)
+                    FinalizeSimulationOutput!(SimMetaData, SimLogger, output; log_status="interrupted")
                     OutputFinalized[] = true
                 end
+                return nothing
             end
             rethrow()
         end

--- a/src/SimulationLoggerConfiguration.jl
+++ b/src/SimulationLoggerConfiguration.jl
@@ -208,12 +208,12 @@ module SimulationLoggerConfiguration
     Called once the simulation loop ends. Prints total run time and a summary of
     the collected [`TimerOutput`] information.
     """
-    function LogFinal(SimLogger::SimulationLogger, HourGlass)
+    function LogFinal(SimLogger::SimulationLogger, HourGlass; status::String="finished")
         with_logger(SimLogger.Logger) do
             # Get the current date and time
             current_time = now()
             # Format the current date and time
-            formatted_time = "\n Simulation finished at: " * Dates.format(current_time, "dd-mm-yyyy HH:MM:SS")
+            formatted_time = "\n Simulation $(status) at: " * Dates.format(current_time, "dd-mm-yyyy HH:MM:SS")
 
             @info formatted_time
             @info "\n Simulation took " * @sprintf("%-.2f", TimerOutputs.tottime(HourGlass)/1e9) * "[s]"
@@ -252,12 +252,12 @@ module SimulationLoggerConfiguration
         return nothing
     end
 
-    function FinalizeLog!(::SimulationMetaData{D,T,S,K,B,NoLog}, _...) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, B<:MDBCMode}
+    function FinalizeLog!(::SimulationMetaData{D,T,S,K,B,NoLog}, args...; kwargs...) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, B<:MDBCMode}
         return nothing
     end
     
-    function FinalizeLog!(SimMetaData::SimulationMetaData{D,T,S,K,B,StoreLog}, SimLogger) where {D,T,S<:ShiftingMode, K<:KernelOutputMode, B<:MDBCMode}
-        LogFinal(SimLogger, SimMetaData.HourGlass)
+    function FinalizeLog!(SimMetaData::SimulationMetaData{D,T,S,K,B,StoreLog}, SimLogger; status::String="finished") where {D,T,S<:ShiftingMode, K<:KernelOutputMode, B<:MDBCMode}
+        LogFinal(SimLogger, SimMetaData.HourGlass; status=status)
         
         # Time steps line plot
         UnicodeTimeStepsGraph = lineplot(


### PR DESCRIPTION
### Motivation
- Ensure VTKHDF output files are cleanly closed and the results can be inspected in ParaView when a simulation is interrupted (Ctrl+C) or Julia exits unexpectedly. 
- Prevent partial output or locked HDF handles by centralizing finalization logic for simulation output streams. 
- Provide a convenient UX by automatically opening the written data in ParaView after a normal or interrupted run. 

### Description
- Introduced `FinalizeSimulationOutput!` to centralize closing VTKHDF streams, show timer output, launch ParaView state, and optionally finalize and open the log. 
- Wrapped the main simulation loop in a `try`/`catch` that handles `InterruptException` by closing outputs and opening ParaView for the data written so far before rethrowing. 
- Registered an `atexit` hook that performs output finalization if Julia exits before the simulation completes to cover non-interrupt shutdowns. 
- Updated `RunSimulation` to track finalization state with a `Ref` to avoid double-finalization and added a short README note documenting the `Ctrl+C` behavior. 

### Testing
- Ran `git diff --check` which reported no issues after a small trailing-whitespace fix. 
- Verified package precompilation by executing `julia --project=. -e 'using SPHExample'` which succeeded. 
- Executed the test suite with `julia --project=. -e 'using Pkg; Pkg.test()'` which reported an unrelated test error (a `Δt` method mismatch in `test/runtests.jl`) and therefore the package tests did not fully pass; this failure is orthogonal to the interrupted-output changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c324be9588323904a91a0367db484)