### PR TITLE
SimulationMetaData: use typed float defaults and add typed keyword constructor

### DIFF
--- a/src/SimulationMetaDataConfiguration.jl
+++ b/src/SimulationMetaDataConfiguration.jl
@@ -40,14 +40,14 @@ struct SingleNeighborTimeStepping <: TimeSteppingMode end
     SaveLocation::String
     HourGlass::TimerOutput                  = TimerOutput()
     Iteration::Int                          = 0
-    OutputEach::FloatType                   = 0.02 #seconds
+    OutputEach::FloatType                   = FloatType(0.02) #seconds
     OutputTimes::Union{FloatType,Vector{FloatType}} = OutputEach
     OutputIterationCounter::Int             = 0
     StepsTakenForLastOutput::Int            = 0
-    CurrentTimeStep::FloatType              = 0
-    TotalTime::FloatType                    = 0
-    SimulationTime::FloatType               = 0
-    TimeSteps                               = Vector{FloatType}() 
+    CurrentTimeStep::FloatType              = zero(FloatType)
+    TotalTime::FloatType                    = zero(FloatType)
+    SimulationTime::FloatType               = zero(FloatType)
+    TimeSteps                               = FloatType[]
     IndexCounter::Int                       = 0
     VisualizeInParaview::Bool               = true
     ExportSingleVTKHDF::Bool                = true
@@ -56,6 +56,54 @@ struct SingleNeighborTimeStepping <: TimeSteppingMode end
     OpenLogFile::Bool                       = true
     Δx::FloatType                           = zero(FloatType)
     TimeSteppingMode::TimeSteppingMode      = SingleNeighborTimeStepping()
+end
+
+const SimulationMetaDataKeywordNames = (:SimulationName, :SaveLocation, :HourGlass, :Iteration, :OutputEach,
+                                        :OutputTimes, :OutputIterationCounter, :StepsTakenForLastOutput,
+                                        :CurrentTimeStep, :TotalTime, :SimulationTime, :TimeSteps,
+                                        :IndexCounter, :VisualizeInParaview, :ExportSingleVTKHDF,
+                                        :ExportGridCells, :ExportGridCellParticleCounts, :OpenLogFile,
+                                        :Δx, :TimeSteppingMode)
+
+@inline ConvertMetaDataFloat(::Type{T}, Value::Real) where {T <: AbstractFloat} = T(Value)
+@inline ConvertMetaDataFloat(::Type{T}, Value::AbstractVector{<:Real}) where {T <: AbstractFloat} = T.(Value)
+@inline ConvertMetaDataFloat(::Type{T}, Value) where {T <: AbstractFloat} = Value
+
+function SimulationMetaData{D,T,S,K,B,L}(; kwargs...) where {D,T<:AbstractFloat,S<:ShiftingMode,K<:KernelOutputMode,B<:MDBCMode,L<:LogMode}
+    for Key in keys(kwargs)
+        Key in SimulationMetaDataKeywordNames || throw(ArgumentError("unsupported SimulationMetaData keyword: $Key"))
+    end
+
+    haskey(kwargs, :SimulationName) || throw(UndefKeywordError(:SimulationName))
+    haskey(kwargs, :SaveLocation) || throw(UndefKeywordError(:SaveLocation))
+
+    SimulationName = kwargs[:SimulationName]
+    SaveLocation = kwargs[:SaveLocation]
+    HourGlass = get(kwargs, :HourGlass, TimerOutput())
+    Iteration = get(kwargs, :Iteration, 0)
+    OutputEach = ConvertMetaDataFloat(T, get(kwargs, :OutputEach, T(0.02)))
+    OutputTimes = ConvertMetaDataFloat(T, get(kwargs, :OutputTimes, OutputEach))
+    OutputIterationCounter = get(kwargs, :OutputIterationCounter, 0)
+    StepsTakenForLastOutput = get(kwargs, :StepsTakenForLastOutput, 0)
+    CurrentTimeStep = ConvertMetaDataFloat(T, get(kwargs, :CurrentTimeStep, zero(T)))
+    TotalTime = ConvertMetaDataFloat(T, get(kwargs, :TotalTime, zero(T)))
+    SimulationTime = ConvertMetaDataFloat(T, get(kwargs, :SimulationTime, zero(T)))
+    TimeSteps = ConvertMetaDataFloat(T, get(kwargs, :TimeSteps, T[]))
+    IndexCounter = get(kwargs, :IndexCounter, 0)
+    VisualizeInParaview = get(kwargs, :VisualizeInParaview, true)
+    ExportSingleVTKHDF = get(kwargs, :ExportSingleVTKHDF, true)
+    ExportGridCells = get(kwargs, :ExportGridCells, false)
+    ExportGridCellParticleCounts = get(kwargs, :ExportGridCellParticleCounts, false)
+    OpenLogFile = get(kwargs, :OpenLogFile, true)
+    Δx = ConvertMetaDataFloat(T, get(kwargs, :Δx, zero(T)))
+    TimeSteppingMode = get(kwargs, :TimeSteppingMode, SingleNeighborTimeStepping())
+
+    return SimulationMetaData{D,T,S,K,B,L}(SimulationName, SaveLocation, HourGlass, Iteration, OutputEach,
+                                          OutputTimes, OutputIterationCounter, StepsTakenForLastOutput,
+                                          CurrentTimeStep, TotalTime, SimulationTime, TimeSteps,
+                                          IndexCounter, VisualizeInParaview, ExportSingleVTKHDF,
+                                          ExportGridCells, ExportGridCellParticleCounts, OpenLogFile,
+                                          Δx, TimeSteppingMode)
 end
 SimulationMetaData{D,T,S,K,B}(; kwargs...) where {D,T,S<:ShiftingMode,K<:KernelOutputMode,B<:MDBCMode} =
     SimulationMetaData{D,T,S,K,B,NoLog}(; kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,45 @@ using StructArrays
     @test alloc == 0
 end
 
+
+@testset "SimulationMetaData Float32 keyword conversion" begin
+    meta = SimulationMetaData{2,Float32}(
+        SimulationName="typed",
+        SaveLocation=".",
+        OutputEach=0.05,
+        OutputTimes=[0.05, 0.1],
+        CurrentTimeStep=0.001,
+        TotalTime=1.0,
+        SimulationTime=2.0,
+        TimeSteps=[0.001, 0.002],
+        Δx=0.01,
+    )
+
+    @test meta.OutputEach isa Float32
+    @test meta.OutputTimes isa Vector{Float32}
+    @test meta.CurrentTimeStep isa Float32
+    @test meta.TotalTime isa Float32
+    @test meta.SimulationTime isa Float32
+    @test meta.TimeSteps isa Vector{Float32}
+    @test meta.Δx isa Float32
+    @test meta.OutputEach == Float32(0.05)
+    @test meta.OutputTimes == Float32[0.05, 0.1]
+    @test meta.CurrentTimeStep == Float32(0.001)
+    @test meta.TotalTime == Float32(1.0)
+    @test meta.SimulationTime == Float32(2.0)
+    @test meta.TimeSteps == Float32[0.001, 0.002]
+    @test meta.Δx == Float32(0.01)
+
+    scalar_output_meta = SimulationMetaData{2,Float32}(
+        SimulationName="scalar",
+        SaveLocation=".",
+        OutputTimes=0.2,
+    )
+
+    @test scalar_output_meta.OutputTimes isa Float32
+    @test scalar_output_meta.TimeSteps isa Vector{Float32}
+end
+
 @testset "isolated particle" begin
     D = 2
     T = Float64


### PR DESCRIPTION
### Motivation
- Ensure float-like defaults in `SimulationMetaData` are explicitly typed to the `FloatType` parameter to avoid unintended promotion or ambiguity. 
- Allow users to construct `SimulationMetaData{D,T,...}` with `Real` literals (e.g., `Float64`) while coercing numeric fields to the declared `T` to make typed usage ergonomic and safer.

### Description
- Replace float-like default literals with typed forms: `OutputEach = FloatType(0.02)`, `CurrentTimeStep/TotalTime/SimulationTime = zero(FloatType)`, and `TimeSteps = FloatType[]` in `src/SimulationMetaDataConfiguration.jl`.
- Add an outer keyword constructor `SimulationMetaData{D,T,S,K,B,L}(; kwargs...)` that validates allowed keyword names, preserves non-numeric fields, and converts numeric scalar and vector metadata fields to `T` using `ConvertMetaDataFloat` helpers.
- Provide `ConvertMetaDataFloat` inline helpers to convert `Real` scalars and vectors into the target floating type `T` while leaving other values untouched.
- Add tests in `test/runtests.jl` (`SimulationMetaData Float32 keyword conversion`) that construct `SimulationMetaData{2,Float32}` from `Float64` literals and assert that `OutputEach`, `OutputTimes`, `CurrentTimeStep`, `TotalTime`, `SimulationTime`, `TimeSteps`, and `Δx` use `Float32`.

### Testing
- Ran a quick runtime check with `julia --project=. -e 'using SPHExample; m=SimulationMetaData{2,Float32}(SimulationName="x",SaveLocation=".",OutputEach=0.05,OutputTimes=[0.05,0.1],CurrentTimeStep=0.001,TotalTime=1.0,SimulationTime=2.0,TimeSteps=[0.001,0.002],Δx=0.01); @show typeof(m) typeof(m.OutputEach) typeof(m.OutputTimes) typeof(m.TimeSteps) typeof(m.Δx); m2=SimulationMetaData{2,Float32}(SimulationName="x",SaveLocation=".",OutputTimes=0.2); @show typeof(m2.OutputTimes) typeof(m2.TimeSteps)'` which showed the fields were converted to `Float32` as expected. 
- Ran the full test suite with `julia --project=. -e 'using Pkg; Pkg.test()'`, which errored in a pre-existing `time stepping` test due to `MethodError: no method matching Δt(..., ::SimulationConstants{Float64}, ::SPHKernelInstance{...})` before the new metadata tests executed. 
- Added the unit test `SimulationMetaData Float32 keyword conversion` to `test/runtests.jl`; the manual checks above confirm the constructor behavior passes for the exercised cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d6a3cd45883239ff47731e0fea3e4)