### PR TITLE
Ensure VTKHDF outputs are closed on simulation failures

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -851,11 +851,18 @@ using TimerOutputs: @timeit
     function RunWithSimulationFinalizer!(RunFunction, SimMetaData, SimLogger, output)
         OutputFinalized = Ref(false)
 
+        function FinalizeOnce!(log_status::String)
+            if !OutputFinalized[]
+                FinalizeSimulationOutput!(SimMetaData, SimLogger, output; log_status=log_status)
+                OutputFinalized[] = true
+            end
+            return nothing
+        end
+
         atexit() do
             if !OutputFinalized[]
                 @warn "Julia is exiting before the simulation completed; closing VTKHDF output, finalizing the log, and opening ParaView for the data written so far."
-                FinalizeSimulationOutput!(SimMetaData, SimLogger, output; log_status="stopped as Julia exited")
-                OutputFinalized[] = true
+                FinalizeOnce!("stopped as Julia exited")
             end
         end
 
@@ -863,18 +870,20 @@ using TimerOutputs: @timeit
 
         # This is the smallest reliable Ctrl+C boundary for REPL/VS Code/terminal
         # execution: without catching `InterruptException`, Julia returns control
-        # to the caller and the `atexit` hook is not guaranteed to run.
+        # to the caller and the `atexit` hook is not guaranteed to run. The same
+        # boundary also closes VTKHDF files for ordinary simulation failures
+        # before rethrowing the original error to the caller.
         try
             RunFunction(OutputFinalized)
         catch e
             if e isa InterruptException
                 @warn "Simulation interrupted; closing VTKHDF output, finalizing the log, and opening ParaView for the data written so far."
-                if !OutputFinalized[]
-                    FinalizeSimulationOutput!(SimMetaData, SimLogger, output; log_status="interrupted")
-                    OutputFinalized[] = true
-                end
+                FinalizeOnce!("interrupted")
                 return nothing
             end
+
+            @warn "Simulation failed; closing VTKHDF output, finalizing the log, and opening ParaView for the data written so far." exception=(e, catch_backtrace())
+            FinalizeOnce!("failed")
             rethrow()
         end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,3 +72,26 @@ end
     @test particles.Velocity[1][1] == 0
     @test particles.Velocity[1][2] < 0
 end
+
+@testset "simulation failure finalizes output" begin
+    mktempdir() do dir
+        meta = SimulationMetaData{2,Float64}(
+            SimulationName="failfinalizer",
+            SaveLocation=dir,
+            VisualizeInParaview=false,
+            OpenLogFile=false,
+        )
+        logger = SimulationLogger(dir; to_console=false)
+        closed = Ref(false)
+        output = (
+            close_files = () -> (closed[] = true; nothing),
+            variable_names = String[],
+        )
+
+        @test_throws ErrorException SPHExample.SPHCellList.RunWithSimulationFinalizer!(meta, logger, output) do _
+            error("boom")
+        end
+        @test closed[]
+        close(logger.LoggerIo)
+    end
+end


### PR DESCRIPTION
### Motivation
- Simulations that error (not via Ctrl+C) could leave VTKHDF files open because finalization was only triggered for exit/interrupt paths, so add a robust single-use finalizer to always close output on failure.

### Description
- Add a `FinalizeOnce!` helper in `RunWithSimulationFinalizer!` to ensure output finalization runs exactly once across normal exit, Ctrl+C, Julia exit, and ordinary exceptions (`src/SPHCellList.jl`).
- Replace direct finalization calls in the `atexit` handler and interrupt path with `FinalizeOnce!` and add handling for non-interrupt exceptions that finalizes with `log_status="failed"` before rethrowing.
- Add a regression test that invokes `RunWithSimulationFinalizer!` with a synthetic error and asserts `close_files` was called (`test/runtests.jl`).

### Testing
- Ran `julia --project=. -e 'using SPHExample'` which precompiled and loaded the package successfully.
- Executed an inline test that calls `RunWithSimulationFinalizer!` with a forced `error("boom")` and verified the provided `close_files` was invoked (test passed).
- Ran the full test suite with `julia --project=. -e 'using Pkg; Pkg.test()'` which exercised the new regression test but the overall test run failed due to a pre-existing unrelated failure in the `time stepping` test (`Δt` method signature mismatch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d72c11f70832385556fe81d43b7ec)