### PR TITLE
Speed neighbor cell lookup

### DIFF
--- a/src/SPHNeighborList.jl
+++ b/src/SPHNeighborList.jl
@@ -24,23 +24,34 @@ function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView
     TargetLen   = length(UniqueCellsView)
     OriginalLen = length(NeighborCellLists)
     resize!(NeighborCellLists, TargetLen)
+    MaxNeighborCount = max(length(FullStencil) - 1, 0)
 
     if TargetLen > OriginalLen
         @inbounds for Index in (OriginalLen + 1):TargetLen
             NeighborCellLists[Index] = Int[]
+            sizehint!(NeighborCellLists[Index], MaxNeighborCount)
+        end
+    end
+
+    CellIndexMap = Dict{eltype(UniqueCellsView), Int}()
+    sizehint!(CellIndexMap, TargetLen)
+    @inbounds for CellIndex in eachindex(UniqueCellsView)
+        if ParticleRanges[CellIndex] < ParticleRanges[CellIndex + 1]
+            CellIndexMap[UniqueCellsView[CellIndex]] = CellIndex
         end
     end
 
     @inbounds for CellIndex in eachindex(UniqueCellsView)
         Neighbors = NeighborCellLists[CellIndex]
         empty!(Neighbors)
+        if ParticleRanges[CellIndex] >= ParticleRanges[CellIndex + 1]
+            continue
+        end
         Cell = UniqueCellsView[CellIndex]
         for Offset in FullStencil
             NeighborCell = Cell + Offset
-            NeighborIndex = FindCellIndex(UniqueCellsView, NeighborCell)
-            StartIndex = ParticleRanges[NeighborIndex]
-            EndIndex = ParticleRanges[NeighborIndex + 1] - 1
-            if StartIndex <= EndIndex && NeighborIndex != CellIndex
+            NeighborIndex = get(CellIndexMap, NeighborCell, 0)
+            if !iszero(NeighborIndex) && NeighborIndex != CellIndex
                 push!(Neighbors, NeighborIndex)
             end
         end


### PR DESCRIPTION
### Motivation
- Reduce the cost of rebuilding neighbor-cell lists by avoiding repeated binary searches for every stencil offset and reduce allocation churn during rebuilds.

### Description
- Build a hash map (`CellIndexMap`) of occupied cells once per rebuild and use `get(CellIndexMap, NeighborCell, 0)` for O(1) neighbor lookups instead of calling `FindCellIndex` repeatedly.
- Pre-size newly-created neighbor vectors with `sizehint!` using `MaxNeighborCount` to reduce reallocations during `push!`.
- Skip empty/sentinel cells (where `ParticleRanges[idx] >= ParticleRanges[idx+1]`) before traversing the stencil to avoid unnecessary work.
- Add a `sizehint!` for `CellIndexMap` to reduce hash-table growth overhead.

### Testing
- Ran a correctness check that compares the new `BuildNeighborCellLists!` output with the previous algorithm using `@assert oldlists == newlists`, which passed on a properly ordered test dataset.
- Measured performance with a synthetic 120×120 occupied-cell grid using a short benchmark (see command below) and observed an average speedup of about `1.3×`.
- Ran package tests with `Pkg.test()` which errored in an existing time-stepping test because `Δt` has no method for the tested five-argument signature; this failure appears unrelated to the neighbor-list change.

Commands executed:
- `julia --project=. --startup-file=no -e '...oldbuild!/new build/benchmark...'` (benchmark and correctness assertion shown in the PR discussion)
- `julia --project=. -e 'using Pkg; Pkg.test()'` (package tests; errored due to unrelated `Δt` method issue)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a540abfa3148323a9569cd02d8380f8)