### PR TITLE
Use cell-index map for neighbor lookups and refactor MDBC neighbor loop

### DIFF
--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -29,7 +29,7 @@ using TimerOutputs: @timeit
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellListIndices, NeighborCellLists, dρdtI,
+                                      CellListIndices, NeighborCellListOffsets, NeighborCellListIndices, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
                                       Position = SimParticles.Position,
@@ -46,7 +46,8 @@ using TimerOutputs: @timeit
             CellListIndex = CellListIndices[i]
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
-            NeighborCellIndices = NeighborCellLists[CellListIndex]
+            NeighborCellStart = NeighborCellListOffsets[CellListIndex]
+            NeighborCellEnd = NeighborCellListOffsets[CellListIndex + 1] - 1
 
             @inbounds for j in SameCellStart:(i - 1)
                 dρdt_acc, acc_acc = ComputeInteractionsPerParticle!(
@@ -62,7 +63,8 @@ using TimerOutputs: @timeit
                     Velocity, ParticleType, dρdt_acc, acc_acc, i, j,
                 )
             end
-            for NeighborIdx in NeighborCellIndices
+            for NeighborCellCursor in NeighborCellStart:NeighborCellEnd
+                NeighborIdx = NeighborCellListIndices[NeighborCellCursor]
                 StartIndex_ = ParticleRanges[NeighborIdx]
                 EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
                 @inbounds for j in StartIndex_:EndIndex_
@@ -85,7 +87,7 @@ using TimerOutputs: @timeit
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,NoShifting,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellListIndices, NeighborCellLists, dρdtI,
+                                      CellListIndices, NeighborCellListOffsets, NeighborCellListIndices, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
                                       Position = SimParticles.Position,
@@ -106,7 +108,8 @@ using TimerOutputs: @timeit
             CellListIndex = CellListIndices[i]
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
-            NeighborCellIndices = NeighborCellLists[CellListIndex]
+            NeighborCellStart = NeighborCellListOffsets[CellListIndex]
+            NeighborCellEnd = NeighborCellListOffsets[CellListIndex + 1] - 1
 
             @inbounds for j in SameCellStart:(i - 1)
                 dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc =
@@ -126,7 +129,8 @@ using TimerOutputs: @timeit
                         kernel_grad_acc, i, j,
                     )
             end
-            for NeighborIdx in NeighborCellIndices
+            for NeighborCellCursor in NeighborCellStart:NeighborCellEnd
+                NeighborIdx = NeighborCellListIndices[NeighborCellCursor]
                 StartIndex_ = ParticleRanges[NeighborIdx]
                 EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
                 @inbounds for j in StartIndex_:EndIndex_
@@ -153,7 +157,7 @@ using TimerOutputs: @timeit
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,NoKernelOutput,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellListIndices, NeighborCellLists, dρdtI,
+                                      CellListIndices, NeighborCellListOffsets, NeighborCellListIndices, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
                                       Position = SimParticles.Position,
@@ -172,7 +176,8 @@ using TimerOutputs: @timeit
             CellListIndex = CellListIndices[i]
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
-            NeighborCellIndices = NeighborCellLists[CellListIndex]
+            NeighborCellStart = NeighborCellListOffsets[CellListIndex]
+            NeighborCellEnd = NeighborCellListOffsets[CellListIndex + 1] - 1
 
             @inbounds for j in SameCellStart:(i - 1)
                 dρdt_acc, acc_acc, shift_c_acc, shift_r_acc =
@@ -192,7 +197,8 @@ using TimerOutputs: @timeit
                         shift_r_acc, i, j,
                     )
             end
-            for NeighborIdx in NeighborCellIndices
+            for NeighborCellCursor in NeighborCellStart:NeighborCellEnd
+                NeighborIdx = NeighborCellListIndices[NeighborCellCursor]
                 StartIndex_ = ParticleRanges[NeighborIdx]
                 EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
                 @inbounds for j in StartIndex_:EndIndex_
@@ -219,7 +225,7 @@ using TimerOutputs: @timeit
     function NeighborLoopPerParticle!(SimDensityDiffusion::SDD, SimViscosity::SV, SimKernel,
                                       SimMetaData::SimulationMetaData{D,T,S,K,B,L},
                                       SimConstants, SimParticles, ParticleRanges,
-                                      CellListIndices, NeighborCellLists, dρdtI,
+                                      CellListIndices, NeighborCellListOffsets, NeighborCellListIndices, dρdtI,
                                       Acceleration, ∇Cᵢ,
                                       ∇◌rᵢ, AccelerationMax;
                                       Position = SimParticles.Position,
@@ -243,7 +249,8 @@ using TimerOutputs: @timeit
             CellListIndex = CellListIndices[i]
             SameCellStart = ParticleRanges[CellListIndex]
             SameCellEnd = ParticleRanges[CellListIndex + 1] - 1
-            NeighborCellIndices = NeighborCellLists[CellListIndex]
+            NeighborCellStart = NeighborCellListOffsets[CellListIndex]
+            NeighborCellEnd = NeighborCellListOffsets[CellListIndex + 1] - 1
 
             @inbounds for j in SameCellStart:(i - 1)
                 dρdt_acc, acc_acc, kernel_acc, kernel_grad_acc, shift_c_acc,
@@ -263,7 +270,8 @@ using TimerOutputs: @timeit
                     kernel_grad_acc, shift_c_acc, shift_r_acc, i, j,
                 )
             end
-            for NeighborIdx in NeighborCellIndices
+            for NeighborCellCursor in NeighborCellStart:NeighborCellEnd
+                NeighborIdx = NeighborCellListIndices[NeighborCellCursor]
                 StartIndex_ = ParticleRanges[NeighborIdx]
                 EndIndex_ = ParticleRanges[NeighborIdx + 1] - 1
                 @inbounds for j in StartIndex_:EndIndex_
@@ -691,7 +699,7 @@ using TimerOutputs: @timeit
                                       SimConstants, SimParticles, FullStencil,
                                       ParticleRanges, UniqueCells, CellListIndices,
                                       SortingScratchSpace,
-                                      NeighborCellLists, NeighborCellIndexMap, dρdtI, Velocityₙ⁺,
+                                      NeighborCellListOffsets, NeighborCellListIndices, NeighborCellIndexMap, dρdtI, Velocityₙ⁺,
                                       Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
                                       MotionDefinition::Union{
                                           Nothing,
@@ -723,7 +731,7 @@ using TimerOutputs: @timeit
 
             SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace, ParticleRanges, UniqueCells, CellListIndices)
             UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-            BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, NeighborCellIndexMap)
+            BuildNeighborCellLists!(NeighborCellListOffsets, NeighborCellListIndices, FullStencil, UniqueCellsView, ParticleRanges, NeighborCellIndexMap)
 
             if TimeSteppingMode isa SingleNeighborTimeStepping
                 @timeit SimMetaData.HourGlass "00 Init Pressure"                          Pressure!(SimParticles.Pressure, SimParticles.Density, SimConstants)
@@ -731,7 +739,7 @@ using TimerOutputs: @timeit
                 @timeit SimMetaData.HourGlass "00b Init NeighborLoop" NeighborLoopPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, ParticleRanges, CellListIndices,
-                    NeighborCellLists, dρdtI, SimParticles.Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
+                    NeighborCellListOffsets, NeighborCellListIndices, dρdtI, SimParticles.Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
                 )
             end
 
@@ -754,7 +762,7 @@ using TimerOutputs: @timeit
                         @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellListIndices)
                         SimMetaData.Δx    = zero(eltype(dρdtI))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
-                        BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, NeighborCellIndexMap)
+                        BuildNeighborCellLists!(NeighborCellListOffsets, NeighborCellListIndices, FullStencil, UniqueCellsView, ParticleRanges, NeighborCellIndexMap)
                     end
                 end
 
@@ -767,7 +775,7 @@ using TimerOutputs: @timeit
                     @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, ParticleRanges, CellListIndices,
-                        NeighborCellLists, dρdtI, SimParticles.Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
+                        NeighborCellListOffsets, NeighborCellListIndices, dρdtI, SimParticles.Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
                     )
 
                     @timeit SimMetaData.HourGlass "05 Update To Half TimeStep"               HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
@@ -780,7 +788,7 @@ using TimerOutputs: @timeit
                     @timeit SimMetaData.HourGlass "08 Second NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, ParticleRanges, CellListIndices,
-                        NeighborCellLists, dρdtI, SimParticles.Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
+                        NeighborCellListOffsets, NeighborCellListIndices, dρdtI, SimParticles.Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
                         Position = Positionₙ⁺,
                         Density = ρₙ⁺,
                         Velocity = Velocityₙ⁺,
@@ -798,7 +806,7 @@ using TimerOutputs: @timeit
                     @timeit SimMetaData.HourGlass "06 NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                         SimConstants, SimParticles, ParticleRanges, CellListIndices,
-                        NeighborCellLists, dρdtI, SimParticles.Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
+                        NeighborCellListOffsets, NeighborCellListIndices, dρdtI, SimParticles.Acceleration, ∇Cᵢ, ∇◌rᵢ, AccelerationMax,
                         Position = Positionₙ⁺,
                         Density = ρₙ⁺,
                         Velocity = Velocityₙ⁺,
@@ -906,7 +914,8 @@ using TimerOutputs: @timeit
         UniqueCells            = zeros(CartesianIndex{Dimensions}, NumberOfPoints)
         CellListIndices        = zeros(Int, NumberOfPoints)
         FullStencil            = ConstructStencil(Val(Dimensions))
-        NeighborCellLists      = [Int[] for _ in 1:length(UniqueCells)]
+        NeighborCellListOffsets = zeros(Int, length(UniqueCells) + 1)
+        NeighborCellListIndices = Int[]
         NeighborCellIndexMap   = Dict{CartesianIndex{Dimensions}, Int}()
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
 
@@ -926,7 +935,8 @@ using TimerOutputs: @timeit
                 )
                 cell_neighbor_counts = ComputeCellNeighborCounts(
                     ParticleRanges,
-                    NeighborCellLists,
+                    NeighborCellListOffsets,
+                    NeighborCellListIndices,
                     SimMetaData.IndexCounter,
                 )
             end
@@ -948,7 +958,7 @@ using TimerOutputs: @timeit
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, FullStencil, ParticleRanges,
                     UniqueCells, CellListIndices, SortingScratchSpace,
-                    NeighborCellLists, NeighborCellIndexMap, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
+                    NeighborCellListOffsets, NeighborCellListIndices, NeighborCellIndexMap, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
                     ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
                 )
                 push!(SimMetaData.TimeSteps, SimMetaData.CurrentTimeStep)
@@ -967,7 +977,8 @@ using TimerOutputs: @timeit
                     )
                     cell_neighbor_counts = ComputeCellNeighborCounts(
                         ParticleRanges,
-                        NeighborCellLists,
+                        NeighborCellListOffsets,
+                        NeighborCellListIndices,
                         length(UniqueCellsView),
                     )
                 end

--- a/src/SPHCellList.jl
+++ b/src/SPHCellList.jl
@@ -15,7 +15,7 @@ using ..OpenExternalPrograms
 using ..SPHKernels
 using ..SPHViscosityModels
 using ..SPHDensityDiffusionModels
-using ..SPHNeighborList: BuildNeighborCellLists!, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, FindCellIndex, MapFloor, UpdateNeighbors!, UpdateΔx!
+using ..SPHNeighborList: BuildNeighborCellLists!, ComputeCellNeighborCounts, ComputeCellParticleCounts, ConstructStencil, ExtractCells!, MapFloor, UpdateNeighbors!, UpdateΔx!
 
 using Base.Threads: @threads
 using Bumper: @alloc, @no_escape
@@ -289,16 +289,14 @@ using TimerOutputs: @timeit
         return nothing
     end
 
-    f(SimKernel, GhostPoint) = CartesianIndex(map(x -> MapFloor(x, SimKernel.H⁻¹), Tuple(GhostPoint)))
+    @inline GhostCellIndex(SimKernel, GhostPoint) = CartesianIndex(map(x -> MapFloor(x, SimKernel.H⁻¹), Tuple(GhostPoint)))
     function NeighborLoopMDBC!(SimKernel,
                                SimMetaData::SimulationMetaData{Dimensions, FloatType, SMode, KMode, BMode, LMode},
-                               SimConstants, ParticleRanges, UniqueCellsView,
-                               SimParticles, bᵧ, Aᵧ) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}
+                               SimConstants, FullStencil, ParticleRanges,
+                               CellIndexMap, SimParticles, bᵧ, Aᵧ) where {Dimensions, FloatType, SMode, KMode, BMode, LMode}
 
-        @unpack Position, Density, GhostPoints, GhostNormals = SimParticles
+        @unpack Position, Density, GhostPoints = SimParticles
         ParticleType = SimParticles.Type                       
-
-        FullStencil = ConstructStencil(Val(Dimensions))
 
         @inbounds @threads for iter in eachindex(GhostPoints)
             GhostPoint = GhostPoints[iter]
@@ -309,14 +307,12 @@ using TimerOutputs: @timeit
                 A_acc = zero(Aᵧ[iter])            # an SMatrix{D+1,D+1,FloatType}
             
                 # compute and accumulate into the locals
-                GhostCellIndex = f(SimKernel, GhostPoints[iter])
-                @inbounds for offset ∈ FullStencil
-                    SCellIndex = GhostCellIndex + offset
-
-                    # Returns a range, x>:x for exact match and x=:x for no match
-                    # utilizes that it is a sorted array and requires no isequal constructor,
-                    # so I prefer this for now
-                    NeighborIdx = FindCellIndex(UniqueCellsView, SCellIndex)
+                CellIndex = GhostCellIndex(SimKernel, GhostPoint)
+                @inbounds for Offset ∈ FullStencil
+                    NeighborIdx = get(CellIndexMap, CellIndex + Offset, 0)
+                    if iszero(NeighborIdx)
+                        continue
+                    end
 
                     StartIndex_       = ParticleRanges[NeighborIdx] 
                     EndIndex_         = ParticleRanges[NeighborIdx + 1] - 1
@@ -628,14 +624,13 @@ using TimerOutputs: @timeit
 
     function ApplyMDBCBeforeHalf!(SimMetaData::SimulationMetaData{D,T,S,K,SimpleMDBC,L},
                                   SimKernel, SimConstants, SimParticles,
-                                  ParticleRanges, UniqueCells
+                                  FullStencil, ParticleRanges, CellIndexMap
                                  ) where {D,T,S<:ShiftingMode,K<:KernelOutputMode,L<:LogMode}
         @no_escape begin
             DimensionsPlus = D + 1
             bᵧ = @alloc(SVector{DimensionsPlus, T}, length(SimParticles.Position))
             Aᵧ = @alloc(SMatrix{DimensionsPlus, DimensionsPlus, T, DimensionsPlus*DimensionsPlus}, length(SimParticles.Position))
-            UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-            NeighborLoopMDBC!(SimKernel, SimMetaData, SimConstants, ParticleRanges, UniqueCellsView, SimParticles, bᵧ, Aᵧ)
+            NeighborLoopMDBC!(SimKernel, SimMetaData, SimConstants, FullStencil, ParticleRanges, CellIndexMap, SimParticles, bᵧ, Aᵧ)
             ApplyMDBCCorrection(SimConstants, SimParticles, bᵧ, Aᵧ)
         end
 
@@ -696,7 +691,7 @@ using TimerOutputs: @timeit
                                       SimConstants, SimParticles, FullStencil,
                                       ParticleRanges, UniqueCells, CellListIndices,
                                       SortingScratchSpace,
-                                      NeighborCellLists, dρdtI, Velocityₙ⁺,
+                                      NeighborCellLists, NeighborCellIndexMap, dρdtI, Velocityₙ⁺,
                                       Positionₙ⁺, ρₙ⁺, ∇Cᵢ, ∇◌rᵢ,
                                       MotionDefinition::Union{
                                           Nothing,
@@ -728,11 +723,11 @@ using TimerOutputs: @timeit
 
             SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace, ParticleRanges, UniqueCells, CellListIndices)
             UniqueCellsView = view(UniqueCells, 1:SimMetaData.IndexCounter)
-            BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
+            BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, NeighborCellIndexMap)
 
             if TimeSteppingMode isa SingleNeighborTimeStepping
                 @timeit SimMetaData.HourGlass "00 Init Pressure"                          Pressure!(SimParticles.Pressure, SimParticles.Density, SimConstants)
-                @timeit SimMetaData.HourGlass "00a Init MDBC"                             ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, UniqueCells)
+                @timeit SimMetaData.HourGlass "00a Init MDBC"                             ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, FullStencil, ParticleRanges, NeighborCellIndexMap)
                 @timeit SimMetaData.HourGlass "00b Init NeighborLoop" NeighborLoopPerParticle!(
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, ParticleRanges, CellListIndices,
@@ -759,7 +754,7 @@ using TimerOutputs: @timeit
                         @timeit SimMetaData.HourGlass "01a Actual Calculate IndexCounter" SimMetaData.IndexCounter = UpdateNeighbors!(SimParticles, SimKernel.H⁻¹, SortingScratchSpace,  ParticleRanges, UniqueCells, CellListIndices)
                         SimMetaData.Δx    = zero(eltype(dρdtI))
                         UniqueCellsView   = view(UniqueCells, 1:SimMetaData.IndexCounter)
-                        BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
+                        BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, NeighborCellIndexMap)
                     end
                 end
 
@@ -767,7 +762,7 @@ using TimerOutputs: @timeit
 
                 if TimeSteppingMode isa SymplecticTimeStepping
                     @timeit SimMetaData.HourGlass "02 Pressure"                              Pressure!(SimParticles.Pressure, SimParticles.Density, SimConstants)
-                    @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, UniqueCells)
+                    @timeit SimMetaData.HourGlass "03 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, FullStencil, ParticleRanges, NeighborCellIndexMap)
 
                     @timeit SimMetaData.HourGlass "04 First NeighborLoop" NeighborLoopPerParticle!(
                         SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
@@ -791,7 +786,7 @@ using TimerOutputs: @timeit
                         Velocity = Velocityₙ⁺,
                     )
                 else
-                    @timeit SimMetaData.HourGlass "02 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, ParticleRanges, UniqueCells)
+                    @timeit SimMetaData.HourGlass "02 Apply MDBC before Half TimeStep"       ApplyMDBCBeforeHalf!(SimMetaData, SimKernel, SimConstants, SimParticles, FullStencil, ParticleRanges, NeighborCellIndexMap)
 
                     @timeit SimMetaData.HourGlass "03 Update To Half TimeStep"               HalfTimeStep(SimMetaData, SimConstants, SimParticles, Positionₙ⁺, Velocityₙ⁺, ρₙ⁺, dρdtI, dt₂)
 
@@ -912,6 +907,7 @@ using TimerOutputs: @timeit
         CellListIndices        = zeros(Int, NumberOfPoints)
         FullStencil            = ConstructStencil(Val(Dimensions))
         NeighborCellLists      = [Int[] for _ in 1:length(UniqueCells)]
+        NeighborCellIndexMap   = Dict{CartesianIndex{Dimensions}, Int}()
         _, SortingScratchSpace = Base.Sort.make_scratch(nothing, eltype(SimParticles), NumberOfPoints)
 
         output = SetupVTKOutput(SimMetaData, SimParticles, SimKernel, Dimensions)
@@ -952,7 +948,7 @@ using TimerOutputs: @timeit
                     SimDensityDiffusion, SimViscosity, SimKernel, SimMetaData,
                     SimConstants, SimParticles, FullStencil, ParticleRanges,
                     UniqueCells, CellListIndices, SortingScratchSpace,
-                    NeighborCellLists, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
+                    NeighborCellLists, NeighborCellIndexMap, dρdtI, Velocityₙ⁺, Positionₙ⁺, ρₙ⁺,
                     ∇Cᵢ, ∇◌rᵢ, MotionDefinition,
                 )
                 push!(SimMetaData.TimeSteps, SimMetaData.CurrentTimeStep)

--- a/src/SPHNeighborList.jl
+++ b/src/SPHNeighborList.jl
@@ -66,6 +66,41 @@ function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView
     return nothing
 end
 
+function BuildNeighborCellLists!(NeighborCellListOffsets, NeighborCellListIndices,
+                                 FullStencil, UniqueCellsView, ParticleRanges,
+                                 CellIndexMap::Dict{CellType, Int}) where {CellType}
+    TargetLen = length(UniqueCellsView)
+    resize!(NeighborCellListOffsets, TargetLen + 1)
+    MaxNeighborCount = max(length(FullStencil) - 1, 0)
+
+    empty!(CellIndexMap)
+    sizehint!(CellIndexMap, TargetLen)
+    @inbounds for CellIndex in eachindex(UniqueCellsView)
+        if ParticleRanges[CellIndex] < ParticleRanges[CellIndex + 1]
+            CellIndexMap[UniqueCellsView[CellIndex]] = CellIndex
+        end
+    end
+
+    empty!(NeighborCellListIndices)
+    sizehint!(NeighborCellListIndices, TargetLen * MaxNeighborCount)
+    NeighborCellListOffsets[1] = 1
+    @inbounds for CellIndex in eachindex(UniqueCellsView)
+        NeighborCellListOffsets[CellIndex] = length(NeighborCellListIndices) + 1
+        if ParticleRanges[CellIndex] < ParticleRanges[CellIndex + 1]
+            Cell = UniqueCellsView[CellIndex]
+            for Offset in FullStencil
+                NeighborIndex = get(CellIndexMap, Cell + Offset, 0)
+                if !iszero(NeighborIndex) && NeighborIndex != CellIndex
+                    push!(NeighborCellListIndices, NeighborIndex)
+                end
+            end
+        end
+    end
+    NeighborCellListOffsets[TargetLen + 1] = length(NeighborCellListIndices) + 1
+
+    return nothing
+end
+
 """
 Extracts the cells for each particle based on their positions and the inverse cutoff value.
 
@@ -146,6 +181,19 @@ function ComputeCellNeighborCounts(ParticleRanges, NeighborCellLists, CellCount)
         NeighborTotal = 0
         for NeighborIndex in NeighborCellLists[Index]
             NeighborTotal += Counts[NeighborIndex]
+        end
+        Neighbors[Index] = max(Counts[Index] - 1, 0) + NeighborTotal
+    end
+    return Neighbors
+end
+
+function ComputeCellNeighborCounts(ParticleRanges, NeighborCellListOffsets, NeighborCellListIndices, CellCount)
+    Counts = ComputeCellParticleCounts(ParticleRanges, CellCount)
+    Neighbors = Vector{Int}(undef, CellCount)
+    @inbounds for Index in 1:CellCount
+        NeighborTotal = 0
+        for Cursor in NeighborCellListOffsets[Index]:(NeighborCellListOffsets[Index + 1] - 1)
+            NeighborTotal += Counts[NeighborCellListIndices[Cursor]]
         end
         Neighbors[Index] = max(Counts[Index] - 1, 0) + NeighborTotal
     end

--- a/src/SPHNeighborList.jl
+++ b/src/SPHNeighborList.jl
@@ -21,26 +21,43 @@ end
 end
 
 function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges)
+    CellIndexMap = Dict{eltype(UniqueCellsView), Int}()
+    return BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges, CellIndexMap)
+end
+
+function BuildNeighborCellLists!(NeighborCellLists, FullStencil, UniqueCellsView, ParticleRanges,
+                                 CellIndexMap::Dict{CellType, Int}) where {CellType}
     TargetLen   = length(UniqueCellsView)
     OriginalLen = length(NeighborCellLists)
     resize!(NeighborCellLists, TargetLen)
+    MaxNeighborCount = max(length(FullStencil) - 1, 0)
 
     if TargetLen > OriginalLen
         @inbounds for Index in (OriginalLen + 1):TargetLen
             NeighborCellLists[Index] = Int[]
+            sizehint!(NeighborCellLists[Index], MaxNeighborCount)
+        end
+    end
+
+    empty!(CellIndexMap)
+    sizehint!(CellIndexMap, TargetLen)
+    @inbounds for CellIndex in eachindex(UniqueCellsView)
+        if ParticleRanges[CellIndex] < ParticleRanges[CellIndex + 1]
+            CellIndexMap[UniqueCellsView[CellIndex]] = CellIndex
         end
     end
 
     @inbounds for CellIndex in eachindex(UniqueCellsView)
         Neighbors = NeighborCellLists[CellIndex]
         empty!(Neighbors)
+        if ParticleRanges[CellIndex] >= ParticleRanges[CellIndex + 1]
+            continue
+        end
         Cell = UniqueCellsView[CellIndex]
         for Offset in FullStencil
             NeighborCell = Cell + Offset
-            NeighborIndex = FindCellIndex(UniqueCellsView, NeighborCell)
-            StartIndex = ParticleRanges[NeighborIndex]
-            EndIndex = ParticleRanges[NeighborIndex + 1] - 1
-            if StartIndex <= EndIndex && NeighborIndex != CellIndex
+            NeighborIndex = get(CellIndexMap, NeighborCell, 0)
+            if !iszero(NeighborIndex) && NeighborIndex != CellIndex
                 push!(Neighbors, NeighborIndex)
             end
         end


### PR DESCRIPTION
### Motivation

- Replace expensive search-based neighbor lookups with a direct map to speed up neighbor cell discovery and reduce allocations.
- Simplify and harden the MDBC ghost-point neighbor accumulation by avoiding repeated searches and early-skipping empty cells.
- Improve reuse and sizing of neighbor containers to reduce allocation churn during neighbor-list rebuilds.

### Description

- Add a `CellIndexMap` / `NeighborCellIndexMap` (`Dict{CartesianIndex,Int}`) to map cell coordinates to their index and thread it through `BuildNeighborCellLists!`, `NeighborLoopMDBC!`, `ApplyMDBCBeforeHalf!`, and `SimulationLoop`.
- Overload `BuildNeighborCellLists!` to populate and size-hint the `CellIndexMap` and `NeighborCellLists`, and switch neighbor lookups to `get(CellIndexMap, cell, 0)` to avoid `searchsortedfirst` in hot loops.
- Modify `NeighborLoopMDBC!` to use an inlined `GhostCellIndex` helper instead of the previous `f`, iterate `FullStencil`, and skip missing neighbors early; return per-ghost contributions using `ComputeInteractionsMDBC!` as before.
- Update `ApplyMDBCBeforeHalf!`, `SimulationLoop`, and the top-level run logic to create and pass `NeighborCellIndexMap` and to call the new `BuildNeighborCellLists!` signatures; remove unused `GhostNormals` unpack and other small cleanups.

### Testing

- Ran the package unit test suite with `] test` against the modified code and observed all tests pass.
- Executed a short smoke simulation run (example input) to validate neighbor-list rebuilds and MDBC corrections, and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a540abfa3148323a9569cd02d8380f8)